### PR TITLE
 ADAGUCVector can now subset time correctly

### DIFF
--- a/Docker/adaguc-server-createtiles.sh
+++ b/Docker/adaguc-server-createtiles.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+export ADAGUC_PATH=/adaguc/adaguc-server-master/
+export ADAGUC_TMP=/tmp
+
+if [[ $1 ]]; then
+
+  # Update a specific dataset
+  for configfile in /data/adaguc-datasets/$1.xml ;do
+    filename=/data/adaguc-datasets/"${configfile##*/}" 
+    echo "Starting update for ${filename}" 
+    /adaguc/adaguc-server-master/bin/adagucserver --updatedb --config /adaguc/adaguc-server-config.xml,${filename}
+    /adaguc/adaguc-server-master/bin/adagucserver --createtiles --config /adaguc/adaguc-server-config.xml,${filename}
+  done
+
+else
+  echo "Please specify a dataset"
+fi

--- a/Docker/adaguc-services-config.xml
+++ b/Docker/adaguc-services-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <adaguc-services>
-  <external-home-url>${ENV.EXTERNALADDRESS}</external-home-url>
+  <external-home-url>{ENV.EXTERNALADDRESS}/adaguc-services/</external-home-url>
   <userworkspace>/adaguc/userworkspace</userworkspace>
   <basedir>/adaguc/basedir</basedir>
   <server>
@@ -17,4 +17,9 @@
     <export>ADAGUC_FONT=/adaguc/adaguc-server-master/data/fonts/FreeSans.ttf</export>
     <export>ADAGUC_ONLINERESOURCE={ENV.EXTERNALADDRESS}/adaguc-services/adagucserver?</export>
   </adaguc-server>
+  <autowms>
+    <enabled>true</enabled>
+    <autowmspath>/data/adaguc-autowms/</autowmspath>
+    <datasetpath>/data/adaguc-datasets/</datasetpath>
+  </autowms>
 </adaguc-services>

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -8,7 +8,8 @@ services:
             - "8091:80"
         environment:
             - "LOCAL_ADAGUCSERVER_ADDR=http://localhost:8090/" # Should be same as adaguc-server's EXTERNALADDRESS
-            - "REMOTE_ADAGUCSERVER_ADDR=http://adaguc-server:8080/"
+            - "REMOTE_ADAGUCSERVER_ADDR=http://adaguc-server:8080/" # Do not change this within the docker-compose environment
+            - "ADAGUCSERVICES_AUTOWMS=http://localhost:8090/adaguc-services/autowms?" 
     adaguc-server:
         image: openearth/adaguc-server
         container_name: adaguc-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN yum update -y && yum install -y \
     sqlite-devel \
     tomcat \
     udunits2 \
-    udunits2-devel
+    udunits2-devel 
     
 RUN mkdir /adaguc
 
@@ -54,7 +54,7 @@ COPY ./Docker/adaguc-server-config.xml /adaguc/adaguc-server-config.xml
 COPY ./Docker/adaguc-services-config.xml /adaguc/adaguc-services-config.xml
 COPY ./Docker/start.sh /adaguc/
 COPY ./Docker/adaguc-server-logrotate /etc/logrotate.d/adaguc
-COPY ./Docker/adaguc-server-updatedatasets.sh /adaguc/
+COPY ./Docker/adaguc-server-*.sh /adaguc/
 COPY ./Docker/baselayers.xml /data/adaguc-datasets-internal/baselayers.xml
 RUN  chmod +x /adaguc/adaguc-server-updatedatasets.sh && chmod +x /adaguc/start.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ COPY ./Docker/start.sh /adaguc/
 COPY ./Docker/adaguc-server-logrotate /etc/logrotate.d/adaguc
 COPY ./Docker/adaguc-server-*.sh /adaguc/
 COPY ./Docker/baselayers.xml /data/adaguc-datasets-internal/baselayers.xml
-RUN  chmod +x /adaguc/adaguc-server-updatedatasets.sh && chmod +x /adaguc/start.sh
+RUN  chmod +x /adaguc/adaguc-server-*.sh && chmod +x /adaguc/start.sh
 
 # Set adaguc-services configuration file
 ENV ADAGUC_SERVICES_CONFIG=/adaguc/adaguc-services-config.xml 

--- a/README.md
+++ b/README.md
@@ -5,17 +5,22 @@ See https://dev.knmi.nl/projects/adagucserver/wiki for details
 
 # Docker for adaguc-server:
 
-A docker image for adaguc-server is available from dockerhub. This image allows you to start with adaguc-server, as everything is pre-installed. You can mount your own directories from your workstation to the docker container, allowing you to serve and configure your own data.
+A docker image for adaguc-server is available from dockerhub. This image enables you to start quickly with adaguc-server, everything is pre-installed. You can mount your own directories from your workstation inside the docker container, allowing you to serve and configure your own data. This docker image can be used in production environments as well.
 
-These directories are:
-* adaguc-data: Put your NetCDF, HDF5, GeoJSON or PNG files and sequences inside this directory, these are referenced in your dataset configurations.
-* adaguc-datasets: These are your dataset configuration files, defining a service. These are small XML files, see satellite imagery example below.
-* adaguc-autowms: Put your files you want to have visualised automatically without any scanning
+## Directories and data
+
+The most important directories are:
+* adaguc-data: Put your NetCDF, HDF5, GeoJSON or PNG files inside this directory, these are referenced by your dataset configurations.
+* adaguc-datasets: These are your dataset configuration files, defining a service. These are small XML files allowing you to customize the styling and aggregation of datafiles. See satellite imagery example below. It is good practice to configure datasets to read data from the /data/adaguc-data folder, which can be mounted from your host machine. This ensures that dataset configurations will work on different environments where paths to the data can differ. Datasets are referenced in the WMS service by the dataset=<Your datasetname> keyword.
+* adaguc-autowms: Put your files here you want to have visualised automatically without any scanning.
 * adagucdb: Persistent place for the database files
-* adaguc-logs: Logfiles are placed here, inspect these if something does not work as expected.
+* adaguc-logs: Logfiles are placed here, you can inspect these if something does not work as expected.
 
+## Serve on another address and/or port
 
-To start, do:
+By default adaguc-server docker is set to run on port 8090 and to serve content locally on http://127.0.0.1:8090/, configured via settings given to the docker run command. If you need to run adaguc-server on a different address and/or port, you can configure this with the EXTERNALADDRESS and port settings. The EXTERNALADDRESS setting is used by the WMS to describe the OnlineResource element in the WMS GetCapabilities document. The viewer needs this information to point correctly to WMS getmap requests. It is good practice to set the EXTERNALADDRESS to your systems publicy accessible name and port. Inside the docker container adaguc runs on port 8080, that is why the port mapping in the docker run command is set to 8080.
+
+## To start with the docker image, do:
 ```
 docker pull openearth/adaguc-server # Or build latest docker from this repo yourself with "docker build -t adaguc-server ."
 
@@ -36,10 +41,10 @@ docker run \
   --name my-adaguc-server \
   -it openearth/adaguc-server 
 
-# If the container does not want to run because the container name is aready in use, please do:
-# docker rm my-adaguc-server
-# first.
-
+```
+If the container does not want to run because the container name is aready in use, please do:
+```
+docker rm my-adaguc-server
 ```
 
 # Visualize a NetCDF file via autowms
@@ -71,7 +76,7 @@ http://localhost:8090/adaguc-services/adagucserver?service=wms&request=getcapabi
 
 # Aggregation of hi-res satellite imagery
 
-Download a sequence of satellite data:
+First download a sequence of satellite data from opendap.knmi.nla:
 ```
 cd $HOME/adaguc-server-docker/adaguc-data/
 wget -nc -r -l2 -A.h5   -I /knmi/thredds/fileServer/,/knmi/thredds/catalog/ 'http://opendap.knmi.nl/knmi/thredds/catalog/ADAGUC/testsets/projectedgrids/meteosat/catalog.html'

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ ADAGUC is a geographical information system to visualize netCDF files via the we
 See https://dev.knmi.nl/projects/adagucserver/wiki for details
 
 # Docker for adaguc-server:
+
+A docker image for adaguc-server is available from dockerhub. This image allows you to start with adaguc-server, as everything is pre-installed. You can mount your own directories from your workstation to the docker container, allowing you to serve and configure your own data.
+
+These directories are:
+* adaguc-data: Put your NetCDF, HDF5, GeoJSON or PNG files and sequences inside this directory, these are referenced in your dataset configurations.
+* adaguc-datasets: These are your dataset configuration files, defining a service. These are small XML files, see satellite imagery example below.
+* adaguc-autowms: Put your files you want to have visualised automatically without any scanning
+* adagucdb: Persistent place for the database files
+* adaguc-logs: Logfiles are placed here, inspect these if something does not work as expected.
+
+
+To start, do:
 ```
 docker pull openearth/adaguc-server # Or build latest docker from this repo yourself with "docker build -t adaguc-server ."
 
@@ -23,6 +35,10 @@ docker run \
   -v $HOME/adaguc-server-docker/adaguc-logs:/var/log/adaguc \
   --name my-adaguc-server \
   -it openearth/adaguc-server 
+
+# If the container does not want to run because the container name is aready in use, please do:
+# docker rm my-adaguc-server
+# first.
 
 ```
 

--- a/adagucserverEC/CConvertADAGUCVector.cpp
+++ b/adagucserverEC/CConvertADAGUCVector.cpp
@@ -1,27 +1,27 @@
 /******************************************************************************
- * 
- * Project:  ADAGUC Server
- * Purpose:  ADAGUC OGC Server
- * Author:   Maarten Plieger, plieger "at" knmi.nl
- * Date:     2013-06-01
- *
- ******************************************************************************
- *
- * Copyright 2013, Royal Netherlands Meteorological Institute (KNMI)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- *      http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
- ******************************************************************************/
+* 
+* Project:  ADAGUC Server
+* Purpose:  ADAGUC OGC Server
+* Author:   Maarten Plieger, plieger "at" knmi.nl
+* Date:     2013-06-01
+*
+******************************************************************************
+*
+* Copyright 2013, Royal Netherlands Meteorological Institute (KNMI)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* 
+*      http://www.apache.org/licenses/LICENSE-2.0
+* 
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+* 
+******************************************************************************/
 
 #include "CConvertADAGUCVector.h"
 #include "CFillTriangle.h"
@@ -30,8 +30,8 @@
 const char *CConvertADAGUCVector::className="CConvertADAGUCVector";
 
 /**
- * This function adjusts the cdfObject by creating virtual 2D variables
- */
+* This function adjusts the cdfObject by creating virtual 2D variables
+*/
 int CConvertADAGUCVector::convertADAGUCVectorHeader( CDFObject *cdfObject ){
   //Check whether this is really an adaguc file
   try{
@@ -41,16 +41,16 @@ int CConvertADAGUCVector::convertADAGUCVectorHeader( CDFObject *cdfObject ){
   }catch(int e){
     return 1;
   }
-
- CDBDebug("Using CConvertADAGUCVector.h");
-
+  
+  CDBDebug("Using CConvertADAGUCVector.h");
+  
   bool hasTimeData = false;
   
   //Is there a time variable
   CDF::Variable *origT = cdfObject->getVariableNE("time");
   if(origT!=NULL){
     hasTimeData=true;
-
+    
     //Create a new time dimension for the new 2D fields.
     CDF::Dimension *dimT=new CDF::Dimension();
     dimT->name="time2D";
@@ -70,16 +70,16 @@ int CConvertADAGUCVector::convertADAGUCVectorHeader( CDFObject *cdfObject ){
     //Detect time from the netcdf data and copy the same units from the original time variable
     if(origT!=NULL){
       try{
-#ifdef CCONVERTADAGUCVECTOR_DEBUG
- CDBDebug("Start reading time dim");
-#endif 
+        #ifdef CCONVERTADAGUCVECTOR_DEBUG
+        CDBDebug("Start reading time dim");
+        #endif 
         varT->setAttributeText("units",origT->getAttribute("units")->toString().c_str());
         if(origT->readData(CDF_DOUBLE)!=0){
           CDBError("Unable to read time variable");
         }else{
-#ifdef CCONVERTADAGUCVECTOR_DEBUG
- CDBDebug("Done reading time dim");
-#endif 
+          #ifdef CCONVERTADAGUCVECTOR_DEBUG
+          CDBDebug("Done reading time dim");
+          #endif 
           
           //Loop through the time variable and detect the earliest time
           double tfill;
@@ -107,7 +107,7 @@ int CConvertADAGUCVector::convertADAGUCVectorHeader( CDFObject *cdfObject ){
       }catch(int e){}
     }
   }
-
+  
   //Standard bounding box of adaguc data is worldwide
   double dfBBOX[]={-180,-90,180,90};
   
@@ -139,7 +139,7 @@ int CConvertADAGUCVector::convertADAGUCVectorHeader( CDFObject *cdfObject ){
     varX->dimensionlinks.push_back(dimX);
     cdfObject->addVariable(varX);
     CDF::allocateData(CDF_DOUBLE,&varX->data,dimX->length);
-
+    
     //For y 
     dimY=new CDF::Dimension();
     dimY->name="y";
@@ -230,7 +230,7 @@ int CConvertADAGUCVector::convertADAGUCVectorHeader( CDFObject *cdfObject ){
     
     new2DVar->setType(CDF_FLOAT);
   }
- 
+  
   return 0;
 }
 
@@ -238,8 +238,8 @@ int CConvertADAGUCVector::convertADAGUCVectorHeader( CDFObject *cdfObject ){
 
 
 /**
- * This function draws the virtual 2D variable into a new 2D field
- */
+* This function draws the virtual 2D variable into a new 2D field
+*/
 int CConvertADAGUCVector::convertADAGUCVectorData(CDataSource *dataSource,int mode){
   #ifdef CCONVERTADAGUCVECTOR_DEBUG
   CDBDebug("convertADAGUCVectorData");
@@ -271,7 +271,7 @@ int CConvertADAGUCVector::convertADAGUCVectorData(CDataSource *dataSource,int mo
   }
   CDF::Variable *swathLon;
   CDF::Variable *swathLat;
- 
+  
   try{
     swathLon = cdfObject->getVariable("lon_bnds");
     swathLat = cdfObject->getVariable("lat_bnds");
@@ -279,12 +279,12 @@ int CConvertADAGUCVector::convertADAGUCVectorData(CDataSource *dataSource,int mo
     CDBError("lat or lon variables not found");
     return 1;
   }
-
+  
   //Read original data first 
   swathVar->readData(CDF_FLOAT,true);
   swathLon->readData(CDF_FLOAT,true);
   swathLat->readData(CDF_FLOAT,true);
- 
+  
   CDF::Attribute *fillValue = swathVar->getAttributeNE("_FillValue");
   if(fillValue!=NULL){
     dataObjects[0]->hasNodataValue=true;
@@ -351,16 +351,16 @@ int CConvertADAGUCVector::convertADAGUCVectorData(CDataSource *dataSource,int mo
   double cellSizeY=(dataSource->srvParams->Geo->dfBBOX[3]-dataSource->srvParams->Geo->dfBBOX[1])/double(dataSource->dHeight);
   double offsetX=dataSource->srvParams->Geo->dfBBOX[0];
   double offsetY=dataSource->srvParams->Geo->dfBBOX[1];
- 
- 
-  
-
   
   
   
-
+  
+  
+  
+  
+  
   if(mode==CNETCDFREADER_MODE_OPEN_ALL){
-   
+    
     
     #ifdef CCONVERTADAGUCVECTOR_DEBUG
     CDBDebug("Drawing %s",new2DVar->name.c_str());
@@ -370,7 +370,7 @@ int CConvertADAGUCVector::convertADAGUCVectorData(CDataSource *dataSource,int mo
     CDF::Dimension *dimY;
     CDF::Variable *varX ;
     CDF::Variable *varY;
-  
+    
     //Create new dimensions and variables (X,Y,T)
     dimX=cdfObject->getDimension("x");
     dimX->setSize(dataSource->dWidth);
@@ -421,8 +421,8 @@ int CConvertADAGUCVector::convertADAGUCVectorData(CDataSource *dataSource,int mo
     #endif
     
     
-
-  
+    
+    
     CImageWarper imageWarper;
     bool projectionRequired=false;
     if(dataSource->srvParams->Geo->CRS.length()>0){
@@ -458,9 +458,10 @@ int CConvertADAGUCVector::convertADAGUCVectorData(CDataSource *dataSource,int mo
         return 1;
       }
     }
-  
-    float *swathData = (float*)swathVar->data;
     
+    float *swathData = (float*)swathVar->data;
+    float fillValueLat = fill;
+    float fillValueLon = fill;
     for(int timeNr=0;timeNr<numTimes;timeNr++){ 
       int pSwath = timeNr;
       
@@ -484,57 +485,51 @@ int CConvertADAGUCVector::convertADAGUCVectorData(CDataSource *dataSource,int mo
       
       bool tileHasNoData = false;
       
-      bool tileIsTooLarge=false;
-      bool moveTile=false;
-      
+      float lonMin,lonMax,lonMiddle=0;
       for(int j=0;j<4;j++){
-        if(lons[j]==fill){tileIsTooLarge=true;break;}
-        if(lons[j]>185)moveTile=true;
-      }
-
+        float lon = lons[j];
+        if(j==0){lonMin=lon;lonMax=lon;}else{
+          if(lon<lonMin)lonMin=lon;
+          if(lon>lonMax)lonMax=lon;
+        }
+        lonMiddle+=lon;
+        float lat = lats[j];
+        float val = vals[j];
+        if(val==fill||val==INFINITY||val==NAN||val==-INFINITY||!(val==val)){tileHasNoData=true;break;}
+        if(lat==fillValueLat||lat==INFINITY||lat==-INFINITY||!(lat==lat)){tileHasNoData=true;break;}
+        if(lon==fillValueLon||lon==INFINITY||lon==-INFINITY||!(lon==lon)){tileHasNoData=true;break;}
         
-//       float lon0 ;
-//       float lat0;
-     
-      if(tileIsTooLarge==false){
-        for(int j=0;j<4;j++){
-          if(moveTile==true)lons[j]-=360;
-          if(lons[j]<-280)lons[j]+=360;
-//           if(j==0){
-//             lon0 =lons[0];
-//             lat0 =lats[0];
-//           }else{
-//             if(fabs(lon0-lons[j])>1)tileIsTooLarge=true;
-//             if(fabs(lat0-lats[j])>1)tileIsTooLarge=true;
-//           }
-       
-          if(vals[j]==fill)tileHasNoData=true;
+      }
+      lonMiddle/=4;
+      if(lonMax-lonMin>=350){
+        if(lonMiddle>0){
+          for(int j=0;j<4;j++)if(lons[j]<lonMiddle)lons[j]+=360;
+        }else{
+          for(int j=0;j<4;j++)if(lons[j]>lonMiddle)lons[j]-=360;
         }
       }
-      //vals[0]=10;
+      
       vals[1]=vals[0];
       vals[2]=vals[0];
       vals[3]=vals[0];
       int dlons[4],dlats[4];
       bool projectionIsOk = true;
       if(tileHasNoData==false){
-        if(tileIsTooLarge==false){
-          for(int j=0;j<4;j++){
-            if(projectionRequired){
-              if(imageWarper.reprojfromLatLon(lons[j],lats[j])!=0)projectionIsOk = false;
-            }
-            dlons[j]=int((lons[j]-offsetX)/cellSizeX);
-            dlats[j]=int((lats[j]-offsetY)/cellSizeY);
+        for(int j=0;j<4;j++){
+          if(projectionRequired){
+            if(imageWarper.reprojfromLatLon(lons[j],lats[j])!=0)projectionIsOk = false;
           }
-          if(projectionIsOk){
-            fillQuadGouraud(sdata, vals, dataSource->dWidth,dataSource->dHeight, dlons,dlats);
-          }
+          dlons[j]=int((lons[j]-offsetX)/cellSizeX);
+          dlats[j]=int((lats[j]-offsetY)/cellSizeY);
+        }
+        if(projectionIsOk){
+          fillQuadGouraud(sdata, vals, dataSource->dWidth,dataSource->dHeight, dlons,dlats);
         }
       }
     }
-   
+    
     imageWarper.closereproj();
-   
+    
   }
   #ifdef CCONVERTADAGUCVECTOR_DEBUG
   CDBDebug("/convertADAGUCVectorData");

--- a/adagucserverEC/CConvertADAGUCVector.cpp
+++ b/adagucserverEC/CConvertADAGUCVector.cpp
@@ -515,15 +515,29 @@ int CConvertADAGUCVector::convertADAGUCVectorData(CDataSource *dataSource,int mo
       int dlons[4],dlats[4];
       bool projectionIsOk = true;
       if(tileHasNoData==false){
+         int dlonMin,dlonMax,dlatMin,dlatMax;
+        
         for(int j=0;j<4;j++){
           if(projectionRequired){
             if(imageWarper.reprojfromLatLon(lons[j],lats[j])!=0)projectionIsOk = false;
           }
           dlons[j]=int((lons[j]-offsetX)/cellSizeX);
           dlats[j]=int((lats[j]-offsetY)/cellSizeY);
+          int lon = dlons[j];
+          int lat = dlats[j];
+          if(j==0){dlonMin=lon;dlonMax=lon;dlatMin=lat;dlatMax=lat;}else{
+            if(lon<dlonMin)dlonMin=lon;
+            if(lon>dlonMax)dlonMax=lon;
+            if(lat<dlatMin)dlatMin=lat;
+            if(lat>dlatMax)dlatMax=lat;
+          }
         }
+        if(dlonMax - dlonMin <256 &&
+          dlatMax - dlatMin <256 )
+        {
         if(projectionIsOk){
           fillQuadGouraud(sdata, vals, dataSource->dWidth,dataSource->dHeight, dlons,dlats);
+        }
         }
       }
     }

--- a/adagucserverEC/CDBAdapterPostgreSQL.cpp
+++ b/adagucserverEC/CDBAdapterPostgreSQL.cpp
@@ -405,7 +405,18 @@ CDBStore::Store *CDBAdapterPostgreSQL::getFilesAndIndicesForDimensions(CDataSour
             if(sDims->count>=2){
               if(l==0){
                 if(!CServerParams::checkTimeFormat(sDims[l]))timeValidationError=true;
-                subQuery.printconcat("%s >= '%s' ",netCDFDimName.c_str(),sDims[l].c_str());
+                // Get closest lowest value to this requested one, or if request value is way below get earliest value:
+                subQuery.printconcat("%s >= (select max(%s) from %s where %s <= '%s' or %s = (select min(%s) from %s)) ",
+                                    netCDFDimName.c_str(),
+                                    netCDFDimName.c_str(),
+                                    tableName.c_str(),
+                                    netCDFDimName.c_str(),
+                                    sDims[l].c_str(),
+                                    netCDFDimName.c_str(),
+                                    netCDFDimName.c_str(),
+                                    tableName.c_str()
+                                    );
+                // subQuery.printconcat("%s >= '%s' ",netCDFDimName.c_str(),sDims[l].c_str());
               }
               if(l==1){
                 if(!CServerParams::checkTimeFormat(sDims[l]))timeValidationError=true;

--- a/adagucserverEC/CDBAdapterSQLLite.cpp
+++ b/adagucserverEC/CDBAdapterSQLLite.cpp
@@ -28,7 +28,7 @@
 #include "CDebugger.h"
 #include "CTime.h"
 
-//#define CDBAdapterSQLLite_DEBUG
+#define CDBAdapterSQLLite_DEBUG
 
 const char *CDBAdapterSQLLite::className="CDBAdapterSQLLite";
 

--- a/adagucserverEC/CDBAdapterSQLLite.cpp
+++ b/adagucserverEC/CDBAdapterSQLLite.cpp
@@ -28,7 +28,7 @@
 #include "CDebugger.h"
 #include "CTime.h"
 
-#define CDBAdapterSQLLite_DEBUG
+// #define CDBAdapterSQLLite_DEBUG
 
 const char *CDBAdapterSQLLite::className="CDBAdapterSQLLite";
 
@@ -579,7 +579,17 @@ CDBStore::Store *CDBAdapterSQLLite::getFilesAndIndicesForDimensions(CDataSource 
             if(sDims->count>=2){
               if(l==0){
                 if(!CServerParams::checkTimeFormat(sDims[l]))timeValidationError=true;
-                subQuery.printconcat("%s >= '%s' ",netCDFDimName.c_str(),sDims[l].c_str());
+                subQuery.printconcat("%s >= (select max(%s) from %s where %s <= '%s' or %s = (select min(%s) from %s)) ",
+                                  netCDFDimName.c_str(),
+                                  netCDFDimName.c_str(),
+                                  tableName.c_str(),
+                                  netCDFDimName.c_str(),
+                                  sDims[l].c_str(),
+                                  netCDFDimName.c_str(),
+                                  netCDFDimName.c_str(),
+                                  tableName.c_str()
+                                  );
+                // subQuery.printconcat("%s >= '%s' ",netCDFDimName.c_str(),sDims[l].c_str());
               }
               if(l==1){
                 if(!CServerParams::checkTimeFormat(sDims[l]))timeValidationError=true;

--- a/adagucserverEC/CDBFileScanner.cpp
+++ b/adagucserverEC/CDBFileScanner.cpp
@@ -1059,7 +1059,6 @@ std::vector<std::string> CDBFileScanner::searchFileNames(const char * path,CT::s
       CDBDebug("Reading directory %s with filter %s",filePath.c_str(),fileFilterExpr.c_str()); 
       
       CDirReader * dirReader = CCachedDirReader::getDirReader(filePath.c_str(),fileFilterExpr.c_str());
-      CDBDebug("OK, %d",dirReader);
       dirReader->listDirRecursive(filePath.c_str(),fileFilterExpr.c_str());
       std::vector<std::string> fileList;
       
@@ -1069,9 +1068,8 @@ std::vector<std::string> CDBFileScanner::searchFileNames(const char * path,CT::s
           fileList.push_back(dirReader->fileList[j].c_str());
         }
       }
-      #ifdef CDBFILESCANNER_DEBUG
-        CDBDebug("Found %d file(s)",int(dirReader->fileList.size()));
-      #endif
+        
+      CDBDebug("Found %d file(s)",int(dirReader->fileList.size()));
       return fileList;
     }catch(const char *msg){
       CDBDebug("Directory %s does not exist, silently skipping...",filePath.c_str());

--- a/adagucserverEC/CRequest.cpp
+++ b/adagucserverEC/CRequest.cpp
@@ -24,8 +24,8 @@
  * 
  ******************************************************************************/
 
- //#define CREQUEST_DEBUG
-//#define MEASURETIME
+#define CREQUEST_DEBUG
+#define MEASURETIME
 
 #include "CRequest.h"
 #include "COpenDAPHandler.h"
@@ -1109,7 +1109,7 @@ int CRequest::fillDimValuesForDataSource(CDataSource *dataSource,CServerParams *
         delete maxStore;
       }
     }        
-  
+   
     #ifdef CREQUEST_DEBUG
     CDBDebug("Fix found time values:");
     #endif
@@ -1136,6 +1136,7 @@ int CRequest::fillDimValuesForDataSource(CDataSource *dataSource,CServerParams *
     return 2;
   }
   
+
     if(dataSource->requiredDims.size()==0){
       CDBDebug("Required dims is still zero, add none now");
       COGCDims *ogcDim = new COGCDims();
@@ -1144,6 +1145,10 @@ int CRequest::fillDimValuesForDataSource(CDataSource *dataSource,CServerParams *
       ogcDim->value.copy("0");
       ogcDim->netCDFDimName.copy("none");
     }
+    
+  for(size_t j=0;j<dataSource->requiredDims.size();j++){
+    CDBDebug("dataSource->requiredDims[%d] = [%s]",j, dataSource->requiredDims[j]->value.c_str());
+  }
   return 0;
 }
 

--- a/adagucserverEC/CRequest.cpp
+++ b/adagucserverEC/CRequest.cpp
@@ -1146,9 +1146,9 @@ int CRequest::fillDimValuesForDataSource(CDataSource *dataSource,CServerParams *
       ogcDim->netCDFDimName.copy("none");
     }
     
-  for(size_t j=0;j<dataSource->requiredDims.size();j++){
-    CDBDebug("dataSource->requiredDims[%d] = [%s]",j, dataSource->requiredDims[j]->value.c_str());
-  }
+//   for(size_t j=0;j<dataSource->requiredDims.size();j++){
+//     CDBDebug("dataSource->requiredDims[%d] = [%s]",j, dataSource->requiredDims[j]->value.c_str());
+//   }
   return 0;
 }
 

--- a/adagucserverEC/CRequest.cpp
+++ b/adagucserverEC/CRequest.cpp
@@ -24,8 +24,8 @@
  * 
  ******************************************************************************/
 
-#define CREQUEST_DEBUG
-#define MEASURETIME
+// #define CREQUEST_DEBUG
+// #define MEASURETIME
 
 #include "CRequest.h"
 #include "COpenDAPHandler.h"

--- a/data/python/himawaritonetcdf.py
+++ b/data/python/himawaritonetcdf.py
@@ -1,0 +1,201 @@
+from PIL import Image
+import numpy as np
+import netCDF4
+import dateutil.parser
+from os import listdir
+from os.path import isfile, join
+import os.path
+import datetime
+import urllib
+import imghdr
+import subprocess
+#Maarten Plieger, KNMI (2018)
+
+class HimawariConverter:
+    imgextent = [-5500000,-5500000,5500000,5500000]
+    imgproj = "+proj=geos +h=35785863 +a=6378137.0 +b=6356752.3 +lon_0=140.7 +no_defs"
+    product = "full_disk_ahi_true_color"
+    directorytoscan = "/home/osm/adaguc-server-docker/adaguc-data/himawari8_rammb/jpg"
+    outputfolder = "/home/osm/adaguc-server-docker/adaguc-data/himawari8_rammb/netcdf/"
+    adagucdatasetname = "himawari"
+
+    def getDataURLFromDate(self, start_date):
+        himawaritimestring =  start_date.strftime("%Y%m%d%H%M00")    
+        datafilename = "full_disk_ahi_true_color_%s.jpg" % himawaritimestring
+        return "http://rammb.cira.colostate.edu/ramsdis/online/images/hi_res/himawari-8/full_disk_ahi_true_color/%s" % datafilename
+
+    def drange(self, start, stop, step):
+        r = start
+        if(step > 0):
+            while r < stop:
+                yield r
+                r += step
+        if(step < 0):
+            while r > stop:
+                yield r
+                r += step
+
+    def convertonc(self, inputname,mfile,imgextent,imgproj,product,outputname):
+        print("Converting file [%s]"%inputname)
+        isodate=mfile.split("_")[5].split(".")[0]
+        image = Image.open(inputname)
+
+        imgwidth = image.size[0]
+        imgheight = image.size[1]
+        rgbaimage=image.convert("RGBA")
+        print "Get data"
+        rgbArray=rgbaimage.getdata()
+        
+        #print "Setting zeroes"
+        #rgbArray = np.zeros((len(d),4), 'uint8')
+        #print "Setting data"
+        #rgbArray[:] = d
+
+        print "Writing to "+outputname
+        ncfile = netCDF4.Dataset(outputname,'w')
+            
+        ncfile.Conventions = "CF-1.4";
+
+        lat_dim = ncfile.createDimension('y', imgheight)     # latitude axis
+        lon_dim = ncfile.createDimension('x', imgwidth)     # longitude axis
+
+
+        lat = ncfile.createVariable('y', 'd', ('y'), zlib=True)
+        lat.units = 'degrees_north'
+        lat.standard_name = 'latitude'
+
+        lon = ncfile.createVariable('x', 'd', ('x'), zlib=True)
+        lon.units = 'degrees_east'
+        lon.standard_name = 'longitude'
+
+
+
+        projection = ncfile.createVariable('projection','byte')
+        projection.proj4 = imgproj
+
+        cellsizex=((imgextent[2]-imgextent[0])/float(imgwidth))
+        cellsizey=((imgextent[1]-imgextent[3])/float(imgheight))
+        print len(list(self.drange(imgextent[0]+cellsizex/2,imgextent[2],cellsizex)))
+        print len(list(self.drange(imgextent[3]+cellsizey/2,imgextent[1],cellsizey)))
+        lon[:] = list(self.drange(imgextent[0]+cellsizex/2,imgextent[2],cellsizex))
+        lat[:] = list(self.drange(imgextent[3]+cellsizey/2,imgextent[1],cellsizey))
+
+        width = len(lon);
+        height= len(lat);
+
+        
+        if len(isodate)>0:
+            print "Setting date " + isodate
+            time_dim=ncfile.createDimension('time', 1)
+            timevar =  ncfile.createVariable('time', 'd', ('time'))
+            timevar.units="seconds since 1970-01-01 00:00:00"
+            timevar.standard_name='time'
+            timevar[:] = epochtime = int(dateutil.parser.parse(isodate).strftime("%s")) ;
+            rgbdata = ncfile.createVariable(product,'u4',('time','y','x'),chunksizes=(1,100,width), zlib=True)
+        else:
+            rgbdata = ncfile.createVariable(product,'u4',('y','x'))
+        rgbdata.units = 'rgba'
+        rgbdata.standard_name = 'rgba'
+        rgbdata.long_name = product
+        rgbdata.grid_mapping= 'projection'
+        """ Convert to uint32 and assign to nc variable """
+        print "Setting data"
+        def chunks(self, l, n):
+            """Yield successive n-sized chunks from l."""
+            for i in range(0, len(l), n):
+                yield l[i:i + n]
+        
+        print "Making newdata"
+        
+        
+        print len(rgbArray);
+        
+        for y in range(0, height/100):
+            y=y*100
+            print "Line % d till %d" % (y, y+100)
+            d=rgbaimage.crop((0,y,width,y+100)).getdata()
+            rgbArray = np.zeros((len(d),4), 'uint8')
+            rgbArray[:] = d
+            rgbdata[0,y:y+100,0:width] = rgbArray.view(np.uint32)[:]
+
+        ncfile.close()
+        
+        
+        print "Ok!"
+
+
+    def start(self):
+        self.convertjpgdirtonc()
+        start_date = datetime.datetime.utcnow().replace(microsecond=0, second=0,minute=0)  - datetime.timedelta(hours=10)
+        end_date = (datetime.datetime.utcnow().replace(microsecond=0, second=0,minute=0)  - datetime.timedelta(hours=8));
+        totaldirectorylisting = listdir(self.directorytoscan)
+
+        directorylisting = [];
+        for localfilename in totaldirectorylisting:
+            datafilelocation = self.directorytoscan + "/" + localfilename
+            if imghdr.what(datafilelocation) == 'jpeg':
+                directorylisting.append(localfilename)
+        print len(directorylisting)
+        print directorylisting
+
+        while start_date < end_date:
+            start_date = start_date + datetime.timedelta(minutes=10)
+            remotedataurl = self.getDataURLFromDate(start_date);
+            
+            
+            datafilename = os.path.basename(remotedataurl)
+            if datafilename not in directorylisting:
+                datafilelocation = self.directorytoscan + "/" + datafilename
+                try:
+                    print "Start Fetching %s" % datafilename
+                    urllib.urlretrieve (remotedataurl, datafilelocation)
+                    filetype = imghdr.what(datafilelocation)
+                    if filetype == 'jpeg':
+                        print "Succeeded %s" % localfilename
+                        self.convert(datafilename)
+                    else:
+                        print remotedataurl + " not succeeded: file type is %s" % filetype
+                        if filetype is not None:
+                            os.remove(datafilelocation)
+                except Exception, e:
+                    print "Error downloading image %s because %s" % (remotedataurl,e)
+                    pass
+
+    def convert(self, mfile):
+        print "Start converting %s to netcdf" % mfile
+        inputname=self.directorytoscan+"/"+mfile
+        
+        outputname = self.outputfolder+"/"+mfile+".nc"
+        if os.path.isfile(outputname) == False:
+            try:
+                self.convertonc(inputname,mfile, self.imgextent,self.imgproj,self.product,outputname)  
+                subprocess.call(("docker exec -i -t my-adaguc-server bash /adaguc/adaguc-server-createtiles.sh " + self.adagucdatasetname).split())
+            except:
+                print "Error converting image %s" % inputname
+                os.remove(inputname)
+                pass
+
+    def convertjpgdirtonc(self):
+        #convertonc(inputname,imgextent,imgproj,product,outputname)
+        totaldirectorylisting = listdir(self.directorytoscan)
+        directorylisting = []
+        for localfilename in totaldirectorylisting:
+            datafilelocation = self.directorytoscan + "/" + localfilename
+            if imghdr.what(datafilelocation) == 'jpeg':
+                directorylisting.append(localfilename)
+        
+        print len(directorylisting)
+
+        onlyfiles = [f for f in directorylisting if isfile(join(self.directorytoscan, f))]
+        filenr=0
+        
+        filteredlist = [mfile for mfile in onlyfiles if "jpg" in mfile]    
+
+        for mfile in filteredlist:
+        
+            filenr+=1
+            print("File %d/%d/%s"%(filenr,len(filteredlist),mfile))
+                
+            self.convert(mfile);
+
+HimawariConverter().start()

--- a/hclasses/CDirReader.cpp
+++ b/hclasses/CDirReader.cpp
@@ -179,11 +179,16 @@ CT::string CDirReader::makeCleanPath(const char *_path){
 //     appendSlash = true;
 //   }
 
-  /* Check if this should start with a slash or not */
+  int startAtIndex = 0;
   if(path.c_str()[0]=='/'){
+    /* Check if this should start with a slash or not */
     path.copy("/");
-  }else path.copy("");
-  
+  } else if(path.indexOf("://")!=-1){
+    /*Check if this should start with the original prefix"*/
+    CT::string leftPart = path.splitToStack("://")[0] + "://";
+    path.copy(leftPart);
+    startAtIndex = 1;
+  } else path.copy("");
   
   std::vector<CT::string> parts2;
   for(size_t j=0;j<parts.size();j++){
@@ -192,7 +197,7 @@ CT::string CDirReader::makeCleanPath(const char *_path){
     }
   }
   
-  for(size_t j=0;j<parts2.size();j++){
+  for(size_t j=startAtIndex;j<parts2.size();j++){
     if(parts2[j].length()>0){
       path.concat(&(parts2[j]));
       if(j+1<parts2.size()){


### PR DESCRIPTION
- Vector tiles larger than 256x256 px are currently not drawn as the complete screen is blocked by these tiles
- Updated tile moving over the dateborder boundary for ADAGUC vector data
- Added tiling script to docker and added himawari tiling example file
- Fixed opendap compatibility, was broken due to makecleanpath removing double // items