### PR TITLE
For Docker, the owner of the adagucdb folder is now unchanged and files inside have the same owner

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -23,6 +23,7 @@ services:
             - $HOME/adaguc-server-docker/adaguc-logs:/var/log/adaguc
         environment:
             - "EXTERNALADDRESS=http://localhost:8090/"
+            - "PGUSERID=$UID"
 
 #cd ./adaguc-server/
 #docker pull openearth/adaguc-viewer
@@ -35,7 +36,7 @@ services:
 #mkdir -p $HOME/adaguc-server-docker/adagucdb && chmod 777 $HOME/adaguc-server-docker/adagucdb
 #mkdir -p $HOME/adaguc-server-docker/adaguc-logs && chmod 777 $HOME/adaguc-server-docker/adaguc-logs
 
-# docker-compose -f ./Docker/docker-compose.yml up 
+# export UID && docker-compose -f ./Docker/docker-compose.yml up 
 # Go to http://localhost:8091/adaguc-viewer/ or http://localhost:8090/adaguc-services/wms.cgi? 
 
 # CTRL+C and docker-compose down # To stop 

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -23,7 +23,6 @@ services:
             - $HOME/adaguc-server-docker/adaguc-logs:/var/log/adaguc
         environment:
             - "EXTERNALADDRESS=http://localhost:8090/"
-            - "PGUSERID=$UID"
 
 #cd ./adaguc-server/
 #docker pull openearth/adaguc-viewer
@@ -36,7 +35,7 @@ services:
 #mkdir -p $HOME/adaguc-server-docker/adagucdb && chmod 777 $HOME/adaguc-server-docker/adagucdb
 #mkdir -p $HOME/adaguc-server-docker/adaguc-logs && chmod 777 $HOME/adaguc-server-docker/adaguc-logs
 
-# export UID && docker-compose -f ./Docker/docker-compose.yml up 
+# docker-compose -f ./Docker/docker-compose.yml up 
 # Go to http://localhost:8091/adaguc-viewer/ or http://localhost:8090/adaguc-services/wms.cgi? 
 
 # CTRL+C and docker-compose down # To stop 

--- a/Docker/start.sh
+++ b/Docker/start.sh
@@ -1,29 +1,55 @@
 #!/bin/bash
-chmod 777 /var/log/adaguc
+
+if [ -z ${PGUSERID+x} ]; then echo "PGUSERID is unset"; export PGUSERID=`id -u postgres`; else echo "PGUSERID is set to '$PGUSERID'"; fi
+
+echo "Starting with UID : ${PGUSERID}"
+useradd --shell /bin/bash -u ${PGUSERID} -o -c "" -m user
+export HOME=/home/user
+chmod 777 /var/run/postgresql/ && chown -R user: ${ADAGUCDB} && chmod 700 ${ADAGUCDB}
+chmod 777 /var/log/adaguc && runuser -l user -c "touch /var/log/adaguc/postgresql.log" && chmod 777 /var/log/adaguc/postgresql.log
 
 files=$(shopt -s nullglob dotglob; echo ${ADAGUCDB}/*)
 if (( ${#files} ))
 then
   echo "Re-using persistent postgresql database from ${ADAGUCDB}" && \
-  runuser -l postgres -c "pg_ctl -w -D ${ADAGUCDB} -l /var/log/adaguc/postgresql.log start"
+  runuser -l user -c "pg_ctl -w -U user -D ${ADAGUCDB} -l /var/log/adaguc/postgresql.log start"
+  if [ $? -ne 0 ]
+  then
+  exit 1
+  fi
 else 
   echo "Initializing new postgresql database"
-  mkdir -p ${ADAGUCDB} && chmod 777 ${ADAGUCDB} && chown postgres: ${ADAGUCDB} && \
-  runuser -l postgres -c "pg_ctl initdb -w -D ${ADAGUCDB}" && \
-  runuser -l postgres -c "pg_ctl -w -D ${ADAGUCDB} -l /var/log/adaguc/postgresql.log start" && \
+  #mkdir -p ${ADAGUCDB} && chmod 777 ${ADAGUCDB} && chown postgres: ${ADAGUCDB} && #TODO NOT NEEDED ANYMORE?
+  runuser -l user -c "pg_ctl initdb -U user -w -D ${ADAGUCDB}" && \
+  runuser -l user -c "pg_ctl -w -U user -D ${ADAGUCDB} -l /var/log/adaguc/postgresql.log start" && \
   echo "Configuring new postgresql database" && \
-  runuser -l postgres -c "createuser --superuser adaguc" && \
-  runuser -l postgres -c "psql postgres -c \"ALTER USER adaguc PASSWORD 'adaguc';\"" && \
-  runuser -l postgres -c "psql postgres -c \"CREATE DATABASE adaguc;\""
+  runuser -l user -c "createuser --superuser adaguc" && \
+  runuser -l user -c "psql -U user postgres -c \"ALTER USER adaguc PASSWORD 'adaguc';\"" && \
+  runuser -l user -c "psql -U user postgres -c \"CREATE DATABASE adaguc;\""
+  
+  if [ $? -ne 0 ]
+  then
+  exit 1
+  fi
 fi
+
+echo "Checking POSTGRESQL DB" &&  runuser -l user -c "psql -U user postgres -c \"show data_directory;\""
+if [ $? -ne 0 ]
+then
+  echo "Unable to connect to postgres database"
+  exit 1
+fi  
+
 
 export ADAGUC_PATH=/adaguc/adaguc-server-master/ && \
 export ADAGUC_TMP=/tmp && \
 /adaguc/adaguc-server-master/bin/adagucserver --updatedb \
-  --config /adaguc/adaguc-server-config.xml,/data/adaguc-datasets-internal/baselayers.xml
+  --config /adaguc/adaguc-server-config.xml,baselayers.xml
 
-echo "Checking POSTGRESQL DB" && \
-    runuser -l postgres -c "psql postgres -c \"show data_directory;\"" && \
-    echo "Starting adaguc-services Server" && \
-    /usr/libexec/tomcat/server start 
+if [ $? -ne 0 ]
+then
+  echo "Unable to update baselayers with adaguc-server --updatedb"
+  exit 1
+fi  
+echo "Starting adaguc-services Server" &&  /usr/libexec/tomcat/server start 
     

--- a/Docker/start.sh
+++ b/Docker/start.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
-if [ -z ${PGUSERID+x} ]; then echo "PGUSERID is unset"; export PGUSERID=`id -u postgres`; else echo "PGUSERID is set to '$PGUSERID'"; fi
+if [ -z ${PGUSERID+x} ] || [ -z ${PGUSERID} ]; then 
+  echo "PGUSERID is unset, trying to get id from directory"; 
+  PGUSERID=$(stat -c "%u" ${ADAGUCDB})
+  echo "Using ${PGUSERID} from owner of dir ${ADAGUCDB}"
+else 
+  echo "PGUSERID is set to '$PGUSERID'"; 
+fi
 
-echo "Starting with UID : ${PGUSERID}"
+echo "Using PGUSERID : ${PGUSERID}"
 useradd --shell /bin/bash -u ${PGUSERID} -o -c "" -m user
 export HOME=/home/user
 chmod 777 /var/run/postgresql/ && chown -R user: ${ADAGUCDB} && chmod 700 ${ADAGUCDB}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ mkdir -p $HOME/adaguc-server-docker/adagucdb
 mkdir -p $HOME/adaguc-server-docker/adaguc-logs
 
 docker run \
-  -e PGUSERID=${UID} \
   -e EXTERNALADDRESS="http://127.0.0.1:8090/" \
   -p 8090:8080 \
   -v $HOME/adaguc-server-docker/adaguc-data:/data/adaguc-data \
@@ -171,7 +170,7 @@ mkdir -p $HOME/adaguc-server-docker/adaguc-autowms
 mkdir -p $HOME/adaguc-server-docker/adagucdb 
 mkdir -p $HOME/adaguc-server-docker/adaguc-logs
 
-export UID && docker-compose -f ./Docker/docker-compose.yml up 
+docker-compose -f ./Docker/docker-compose.yml up 
 ```
 The following services are now available:
 * viewer at http://localhost:8091/adaguc-viewer/ 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ docker pull openearth/adaguc-server # Or build latest docker from this repo your
 mkdir -p $HOME/adaguc-server-docker/adaguc-data
 mkdir -p $HOME/adaguc-server-docker/adaguc-datasets
 mkdir -p $HOME/adaguc-server-docker/adaguc-autowms
-mkdir -p $HOME/adaguc-server-docker/adagucdb && chmod 777 $HOME/adaguc-server-docker/adagucdb
-mkdir -p $HOME/adaguc-server-docker/adaguc-logs && chmod 777 $HOME/adaguc-server-docker/adaguc-logs
+mkdir -p $HOME/adaguc-server-docker/adagucdb
+mkdir -p $HOME/adaguc-server-docker/adaguc-logs
 
 docker run \
+  -e PGUSERID=${UID} \
   -e EXTERNALADDRESS="http://127.0.0.1:8090/" \
   -p 8090:8080 \
   -v $HOME/adaguc-server-docker/adaguc-data:/data/adaguc-data \
@@ -167,10 +168,10 @@ docker pull openearth/adaguc-server
 mkdir -p $HOME/adaguc-server-docker/adaguc-data
 mkdir -p $HOME/adaguc-server-docker/adaguc-datasets
 mkdir -p $HOME/adaguc-server-docker/adaguc-autowms
-mkdir -p $HOME/adaguc-server-docker/adagucdb && chmod 777 $HOME/adaguc-server-docker/adagucdb
-mkdir -p $HOME/adaguc-server-docker/adaguc-logs && chmod 777 $HOME/adaguc-server-docker/adaguc-logs
+mkdir -p $HOME/adaguc-server-docker/adagucdb 
+mkdir -p $HOME/adaguc-server-docker/adaguc-logs
 
-docker-compose -f ./Docker/docker-compose.yml up 
+export UID && docker-compose -f ./Docker/docker-compose.yml up 
 ```
 The following services are now available:
 * viewer at http://localhost:8091/adaguc-viewer/ 


### PR DESCRIPTION
Previously the files and the folders in the adagucdb folder where automaticaly owned by user postgres. Users without the right permissions (sudo/root/etc) were unable to change or remove these folders outside the Docker container.
With this fix, the folder's userid is read and is used to run postgres. This causes that all files and folders inside adagucdb are owned by the same user who created the adagucdb folder in the first place. This fixes compatibility/permission issues with KNMI workstations.