### PR TITLE
Allows setting a mask for updatedb script.

### DIFF
--- a/Docker/adaguc-server-updatedatasets.sh
+++ b/Docker/adaguc-server-updatedatasets.sh
@@ -31,6 +31,12 @@ else
   for configfile in /data/adaguc-datasets/*xml ;do
     filename=/data/adaguc-datasets/"${configfile##*/}" 
     filebasename=${filename##*/}
+    if [[ "${ADAGUC_DATASET_MASK}" && `echo ${filebasename} | grep -E ${ADAGUC_DATASET_MASK}` != ${filebasename} ]] ; then
+        if [[ "${ADAGUC_DATASET_MASK}" ]] ; then
+            echo "${filebasename} doesn't match ${ADAGUC_DATASET_MASK}"
+        fi
+        continue
+    fi
     echo ""
     echo "Starting update for ${filename}" 
     /adaguc/adaguc-server-master/bin/adagucserver --updatedb --config /adaguc/adaguc-server-config.xml,${filename}

--- a/Docker/adaguc-server-updatedatasets.sh
+++ b/Docker/adaguc-server-updatedatasets.sh
@@ -25,8 +25,10 @@ if [[ $1 ]]; then
   done
 
 else
-  # remove all old service status files such that only active services are monitored
-  rm -f /servicehealth/*
+  if [[ ! "${ADAGUC_DATASET_MASK}" ]] ; then
+      # remove all old service status files such that only active services are monitored
+      rm -f /servicehealth/*
+  fi
   # Update all datasets
   for configfile in /data/adaguc-datasets/*xml ;do
     filename=/data/adaguc-datasets/"${configfile##*/}" 

--- a/Docker/adaguc-server-updatedatasets.sh
+++ b/Docker/adaguc-server-updatedatasets.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+# TODO: https://github.com/KNMI/adaguc-server/issues/71
+
 export ADAGUC_PATH=/adaguc/adaguc-server-master/
 export ADAGUC_TMP=/tmp
 export ADAGUC_ONLINERESOURCE=""


### PR DESCRIPTION
Pass along an environment variable in the docker exec command to update
certain datasets.

For example:
```
MASK='^eprofile_L0_[0-9]{5}-[A-Z]\.xml$'
docker exec --env ADAGUC_DATASET_MASK=${MASK} -i -t adagucserver
/adaguc/adaguc-server-updatedatasets.sh
```
where adagucserver is the name of the docker container you wish to run
the command in.