### PR TITLE
 Allow "radian" as a possible value for the X/Y dimension units. #122 

### DIFF
--- a/CCDFDataModel/CProj4ToCF.cpp
+++ b/CCDFDataModel/CProj4ToCF.cpp
@@ -49,7 +49,7 @@ int CProj4ToCF::getProjectionUnits(const CDF::Variable *const projectionVariable
                   return CPROJ4TOCF_UNITS_KILOMETER;
                 }else if(units.equals("m")){
                   return CPROJ4TOCF_UNITS_METER;
-                }else if(units.equals("rad")){
+                }else if(units.equals("rad") || units.equals("radian")){
                   return CPROJ4TOCF_UNITS_RADIANS;
                 }
               }


### PR DESCRIPTION
I didn't check if this is the only change that has to be done to solve this issue.
I'm sending you a testing netcdf dataset for you to test if it works.
[LSA_MTG_RAD-IR105_MTG-Disk_201704101200.zip](https://github.com/KNMI/adaguc-server/files/3988402/LSA_MTG_RAD-IR105_MTG-Disk_201704101200.zip)

Regards,
João