### PR TITLE
#148 Detecting sudden changes in tile size for rendering correctly arround the date border

### DIFF
--- a/adagucserverEC/CGenericDataWarper.h
+++ b/adagucserverEC/CGenericDataWarper.h
@@ -329,6 +329,7 @@ class GenericDataWarper{
     
     double avgDX = 0;
     double avgDY = 0;
+    double prevpx1,prevpx2;
 /*    
     T blue = T(double(255.+0*256.+0*256.*256.+255.*256.*256.*256.));
     T yellow  = T(double(0.+255.*256.+255.*256.*256.+255.*256.*256.*256.));
@@ -403,7 +404,26 @@ class GenericDataWarper{
 
           if(x==0)avgDX = px2;
           if(y==0)avgDY = py4;
+
+          /* 
+            If the previous pixel width is suddenly 10 times bigger, 
+            or 10 times smaller, skip it .
+            It is probably wrapped arround the date border.
+          */
+          if (x ==0 && y==0) {
+            prevpx1=px1;
+            prevpx2=px2;
+          }
+          if (fabs(prevpx2-prevpx1) < (fabs(px2-px1)/10.0f)) {
+             doDraw = false;
+          }
+          if (fabs(prevpx2-prevpx1) > (fabs(px2-px1)*10.0f)) {
+             doDraw = false;
+          }
           
+          prevpx1=px1;
+          prevpx2=px2;
+
           if(x==dataWidth-1){
             if(fabs(avgDX-px1)<fabs(px1-px2)/2){
               doDraw = false;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8201298/99537240-b5224300-29ab-11eb-8091-f47f4bf702ba.png)

BTW: you can test any Proj4 projection string in the WMS GetMap URL using the following:

```&CRS=PROJ4:%2Bproj%3Drobin %2Blon_0%3D-150 %2Bx_0%3D0 %2By_0%3D0 %2Bellps%3DWGS84 %2Bdatum%3DWGS84 %2Bunits%3Dm %2Bno_defs%20```

This is based on the projection string ```+proj=robin +lon_0=-150 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs```