### PR TITLE
171 disable adaguc server logging

### DIFF
--- a/Docker/adaguc-services-config.xml
+++ b/Docker/adaguc-services-config.xml
@@ -38,7 +38,7 @@
     <export>ADAGUC_AUTOWMS_DIR={ENV.ADAGUC_AUTOWMS_DIR}</export>
     <export>ADAGUC_CONFIG=/adaguc/adaguc-server-config.xml</export>
     <export>ADAGUC_DATARESTRICTION=FALSE</export>
-    <export>ADAGUC_ENABLELOGBUFFER=FALSE</export>
+    <export>ADAGUC_ENABLELOGBUFFER=DISABLELOGGING</export>
     <export>ADAGUC_FONT=/adaguc/adaguc-server-master/data/fonts/FreeSans.ttf</export>
     <export>ADAGUC_DB={ENV.ADAGUC_DB}</export>
  </adaguc-server>

--- a/Docker/adaguc-services-config.xml
+++ b/Docker/adaguc-services-config.xml
@@ -38,7 +38,7 @@
     <export>ADAGUC_AUTOWMS_DIR={ENV.ADAGUC_AUTOWMS_DIR}</export>
     <export>ADAGUC_CONFIG=/adaguc/adaguc-server-config.xml</export>
     <export>ADAGUC_DATARESTRICTION=FALSE</export>
-    <export>ADAGUC_ENABLELOGBUFFER=DISABLELOGGING</export>
+    <export>ADAGUC_ENABLELOGBUFFER=FALSE</export>
     <export>ADAGUC_FONT=/adaguc/adaguc-server-master/data/fonts/FreeSans.ttf</export>
     <export>ADAGUC_DB={ENV.ADAGUC_DB}</export>
  </adaguc-server>

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ COPY --from=0 /adaguc/adaguc-server-master/tests /adaguc/adaguc-server-master/te
 COPY --from=0 /adaguc/adaguc-server-master/runtests.sh /adaguc/adaguc-server-master/runtests.sh
 
 # Install adaguc-services (spring boot application for running adaguc-server)
-RUN curl -L https://jitpack.io/com/github/KNMI/adaguc-services/1.2.11/adaguc-services-1.2.11.jar -o /adaguc/adaguc-services.jar
+RUN curl -L https://jitpack.io/com/github/KNMI/adaguc-services/1.2.12/adaguc-services-1.2.12.jar -o /adaguc/adaguc-services.jar
 
 # Run adaguc-server functional and regression tests
 RUN  bash runtests.sh 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ USER root
 LABEL maintainer="adaguc@knmi.nl"
 
 # Version should be same as in Definitions.h
-LABEL version="2.5.12" 
+LABEL version="2.5.13" 
 
 ######### First stage (build) ############
 

--- a/Dockerfile-minimal
+++ b/Dockerfile-minimal
@@ -27,7 +27,7 @@ COPY --from=openearth/adaguc-server /adaguc/adaguc-server-master/bin /adaguc/ada
 COPY --from=openearth/adaguc-server /adaguc/adaguc-server-master/data /adaguc/adaguc-server-master/data
 
 # Install adaguc-services (spring boot application for running adaguc-server)
-RUN curl -L https://jitpack.io/com/github/KNMI/adaguc-services/1.2.11/adaguc-services-1.2.11.jar -o /adaguc/adaguc-services.jar && \
+RUN curl -L https://jitpack.io/com/github/KNMI/adaguc-services/1.2.12/adaguc-services-1.2.12.jar -o /adaguc/adaguc-services.jar && \
     # Set same uid as vivid
     useradd -m adaguc -u 1000 && \
     # Setup directories

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+Version 2.5.13 2021-07-22
+    - Extended logging options:
+        - ADAGUC_ENABLELOGBUFFER=FALSE: buffered logging
+        - ADAGUC_ENABLELOGBUFFER=TRUE: unbuffered output, gives realtime logging. Unbuffered output can cause a slower service
+        - ADAGUC_ENABLELOGBUFFER=DISABLELOGGING: no logging at all
+
 Version 2.5.11 2021-05-12
     - Correct rendering of IPCC data on North and South pole projections
 

--- a/adagucserverEC/Definitions.h
+++ b/adagucserverEC/Definitions.h
@@ -28,7 +28,7 @@
 #ifndef Definitions_H
 #define Definitions_H
 
-#define ADAGUCSERVER_VERSION "2.5.12" // Please also update in the Dockerfile to the same version
+#define ADAGUCSERVER_VERSION "2.5.13" // Please also update in the Dockerfile to the same version
 
 //CConfigReaderLayerType
 #define CConfigReaderLayerTypeUnknown 0

--- a/adagucserverEC/adagucserver.cpp
+++ b/adagucserverEC/adagucserver.cpp
@@ -34,13 +34,13 @@ extern Tracer NewTrace;
 DEF_ERRORMAIN();
 
 FILE * pLogDebugFile = NULL;
-enum LogBufferMode { TRUE, FALSE, DISABLELOGGING };
-LogBufferMode logMode = FALSE;
+enum LogBufferMode { LogBufferMode_TRUE, LogBufferMode_FALSE, LogBufferMode_DISABLELOGGING };
+LogBufferMode logMode = LogBufferMode::LogBufferMode_FALSE;
 
 void writeLogFile(const char * msg){
-  if (logMode == DISABLELOGGING) return;
+  if (logMode == LogBufferMode_DISABLELOGGING) return;
   if(pLogDebugFile != NULL){
-    if (logMode == FALSE) {
+    if (logMode == LogBufferMode_FALSE) {
       setvbuf(pLogDebugFile, NULL, _IONBF, 0);
     }
     fputs  (msg, pLogDebugFile );
@@ -325,10 +325,10 @@ int main(int argc, char **argv, char **envp){
   if(ADAGUC_ENABLELOGBUFFER!=NULL){
     CT::string check = ADAGUC_ENABLELOGBUFFER;
     if(check.equalsIgnoreCase("true")){
-      logMode = TRUE;
+      logMode = LogBufferMode::LogBufferMode_TRUE;
     } 
     if(check.equalsIgnoreCase("DISABLELOGGING")){
-      logMode = DISABLELOGGING;
+      logMode = LogBufferMode::LogBufferMode_DISABLELOGGING;
     } 
   }
 

--- a/adagucserverEC/adagucserver.cpp
+++ b/adagucserverEC/adagucserver.cpp
@@ -34,11 +34,13 @@ extern Tracer NewTrace;
 DEF_ERRORMAIN();
 
 FILE * pLogDebugFile = NULL;
-bool useLogBuffer = false;
+enum LogBufferMode { TRUE, FALSE, DISABLELOGGING };
+LogBufferMode logMode = FALSE;
 
 void writeLogFile(const char * msg){
+  if (logMode == DISABLELOGGING) return;
   if(pLogDebugFile != NULL){
-    if (useLogBuffer == false) {
+    if (logMode == FALSE) {
       setvbuf(pLogDebugFile, NULL, _IONBF, 0);
     }
     fputs  (msg, pLogDebugFile );
@@ -314,12 +316,19 @@ int main(int argc, char **argv, char **envp){
     }
   }
 
-  /* Check if we enable logbuffer, true means unbuffered output with live logging but means a slower service */
+  /* Check if we enable logbuffer:
+    - true means unbuffered output with live logging but means a slower service 
+    - false means buffered logging
+    - nologging means no logging at all
+  */
   const char * ADAGUC_ENABLELOGBUFFER=getenv("ADAGUC_ENABLELOGBUFFER");
   if(ADAGUC_ENABLELOGBUFFER!=NULL){
     CT::string check = ADAGUC_ENABLELOGBUFFER;
     if(check.equalsIgnoreCase("true")){
-      useLogBuffer = true;
+      logMode = TRUE;
+    } 
+    if(check.equalsIgnoreCase("DISABLELOGGING")){
+      logMode = DISABLELOGGING;
     } 
   }
 


### PR DESCRIPTION
Version 2.5.13 2021-07-22
    - Extended logging options:
        - ADAGUC_ENABLELOGBUFFER=FALSE: buffered logging
        - ADAGUC_ENABLELOGBUFFER=TRUE: unbuffered output, gives realtime logging. Unbuffered output can cause a slower service
        - ADAGUC_ENABLELOGBUFFER=DISABLELOGGING: no logging at all