### PR TITLE
File modification date advertised in GetCapabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ USER root
 LABEL maintainer="adaguc@knmi.nl"
 
 # Version should be same as in Definitions.h
-LABEL version="2.6.9" 
+LABEL version="2.7.0" 
 
 ######### First stage (build) ############
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+**Version 2.7.0 2022-04-04**
+
+- The time dimension for a layer in a GetCapabilities document can now be set based on the modification time of the file by configuring a dimension using: `<Dimension default="filetimedate">time</Dimension>`
+
 **Version 2.6.9 2022-03-17**
 
 - Support for pointstyle radiusandvalue, to display earthquakes with a disc depending on magnitude and color depending on age.

--- a/adagucserverEC/CDBFileScanner.cpp
+++ b/adagucserverEC/CDBFileScanner.cpp
@@ -109,6 +109,11 @@ int CDBFileScanner::createDBUpdateTables(CDataSource *dataSource, int &removeNon
   // Check and create all tables...
   for (size_t d = 0; d < dataSource->cfgLayer->Dimension.size(); d++) {
 
+    /* A dimension where the default value is set to filetimedate is not a required dim and should not be queried from the db */
+    if (dataSource->cfgLayer->Dimension[d]->attr.defaultV.equals("filetimedate")) {
+      continue;
+    }
+
     CT::string dimName = "";
     if (dataSource->cfgLayer->Dimension[d]->attr.name.empty() == false) {
       dimName = dataSource->cfgLayer->Dimension[d]->attr.name.c_str();
@@ -340,6 +345,13 @@ int CDBFileScanner::DBLoopFiles(CDataSource *dataSource, int removeNonExistingFi
 
       isTimeDim[d] = false;
       skipDim[d] = false;
+
+      /* A dimension where the default value is set to filetimedate is not a required dim and should not be queried from the db */
+      if (dataSource->cfgLayer->Dimension[d]->attr.defaultV.equals("filetimedate")) {
+        isTimeDim[d] = true;
+        skipDim[d] = true;
+        continue;
+      }
 
       CDataReader::DimensionType dtype = CDataReader::getDimensionType(cdfObjectOfFirstFile, dimNames[d].c_str());
 

--- a/adagucserverEC/CRequest.cpp
+++ b/adagucserverEC/CRequest.cpp
@@ -891,6 +891,11 @@ int CRequest::fillDimValuesForDataSource(CDataSource *dataSource, CServerParams 
       // Check if this dim is not already added
       bool alreadyAdded = false;
 
+      /* A dimension where the default value is set to filetimedate is not a required dim and should not be queried from the db */
+      if (dataSource->cfgLayer->Dimension[i]->attr.defaultV.equals("filetimedate")) {
+        alreadyAdded = true;
+      }
+
       for (size_t l = 0; l < dataSource->requiredDims.size(); l++) {
         if (dataSource->requiredDims[l]->name.equals(&dimName)) {
           alreadyAdded = true;
@@ -1039,6 +1044,11 @@ int CRequest::fillDimValuesForDataSource(CDataSource *dataSource, CServerParams 
       if (alreadyAdded == false) {
         CT::string netCDFDimName(dataSource->cfgLayer->Dimension[i]->attr.name.c_str());
         if (netCDFDimName.equals("none")) {
+          continue;
+        }
+
+        /* A dimension where the default value is set to filetimedate should not be queried from the db */
+        if (dataSource->cfgLayer->Dimension[i]->attr.defaultV.equals("filetimedate")) {
           continue;
         }
         CT::string tableName;

--- a/adagucserverEC/Definitions.h
+++ b/adagucserverEC/Definitions.h
@@ -28,7 +28,7 @@
 #ifndef Definitions_H
 #define Definitions_H
 
-#define ADAGUCSERVER_VERSION "2.6.9" // Please also update in the Dockerfile to the same version
+#define ADAGUCSERVER_VERSION "2.7.0" // Please also update in the Dockerfile to the same version
 
 // CConfigReaderLayerType
 #define CConfigReaderLayerTypeUnknown 0

--- a/data/config/datasets/adaguc.testKMDS_PointNetCDF_filetimedate.xml
+++ b/data/config/datasets/adaguc.testKMDS_PointNetCDF_filetimedate.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+  <Configuration>
+  
+    <Layer type="database">
+      <FilePath filter=".*\.nc$">{ADAGUC_PATH}/data/datasets/test/netcdfpointtimeseries/Actuele10mindataKNMIstations_20201220123000.nc</FilePath>
+      <Name>stationname</Name>
+      <Title>stationsnaam</Title>
+      <Variable>stationname</Variable>
+      <Abstract>stationnaam</Abstract>
+      <Styles>auto</Styles>
+      <Dimension default="filetimedate">time</Dimension> 
+    </Layer>
+
+  </Configuration>


### PR DESCRIPTION
- The time dimension for a layer in a GetCapabilities document can now be set based on the modification time of the file by configuring a dimension using: `<Dimension default="filetimedate">time</Dimension>`