### PR TITLE
Fix warnings in Github actions.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,23 +13,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to Docker Hub
         if: github.repository == 'KNMI/adaguc-server'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: openearth/adaguc-server
 
       - name: Build and potentially push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: ${{ github.repository == 'KNMI/adaguc-server' }}

--- a/Docker/nginx-adaguc/Dockerfile
+++ b/Docker/nginx-adaguc/Dockerfile
@@ -1,9 +1,8 @@
-FROM python:3.8.0-alpine3.10
+FROM python:3.8-alpine
 
 RUN apk update && apk add --no-cache nginx certbot runit gettext openssl
 
 RUN mkdir /etc/service/nginx
-RUN mkdir /run/nginx
 RUN mkdir /acme
 
 COPY nginx.conf /nginx.conf


### PR DESCRIPTION
Several steps of the Github actions were showing the following warnings:
```Warning: The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/```

![Screenshot 2022-12-21 at 11 32 14](https://user-images.githubusercontent.com/24407794/208884502-8b38df46-652a-4c87-9521-3453a1b93c34.png)

Updating versions of the steps fixes this problem.