### PR TITLE
Retention limit can be configured and substituted via environment vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ USER root
 LABEL maintainer="adaguc@knmi.nl"
 
 # Version should be same as in Definitions.h
-LABEL version="2.8.5"
+LABEL version="2.8.6"
 
 ######### First stage (build) ############
 
@@ -71,7 +71,7 @@ WORKDIR /adaguc/adaguc-server-master
 # Upgrade pip and install python requirements.txt
 COPY --from=0 /adaguc/adaguc-server-master/requirements.txt /adaguc/adaguc-server-master/requirements.txt
 RUN pip3 install --no-cache-dir --upgrade pip \
-   && pip3 install --no-cache-dir -r requirements.txt
+    && pip3 install --no-cache-dir -r requirements.txt
 
 # Install compiled adaguc binaries from stage one
 COPY --from=0 /adaguc/adaguc-server-master/bin /adaguc/adaguc-server-master/bin
@@ -85,7 +85,7 @@ COPY --from=0 /adaguc/adaguc-server-master/runtests.sh /adaguc/adaguc-server-mas
 
 RUN bash runtests.sh
 
-    # Set same uid as vivid
+# Set same uid as vivid
 RUN useradd -m adaguc -u 1000 && \
     # Setup directories
     mkdir -p /data/adaguc-autowms && \

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+**Version 2.8.6 2023-03-23**
+- Added a configuration option to limit the number of deletions done at once, configurable with `cleanupsystemlimit="5"`  in [Settings](doc/configuration/Settings.md).
+- Added a configuration option to start a dryrun of cleanup, explaining which files would be deleted (but not actually deleting them), configurable with `enablecleanupsystem="dryrun"` in [Settings](doc/configuration/Settings.md)
+- Added the option to replace custom variables in the dataset configuration using the [Environment](doc/configuration/Environment.md) keyword. These will get the value from the environment. This has been added to make it possible to let dev branches have a shorter retentionperiod and the main branch a longer retentionperiod. 
+- See complete dataset example in [data/config/datasets/adaguc.tests.cleandb-step2.xml](data/config/datasets/adaguc.tests.cleandb-step2.xml)
+
+
 **Version 2.8.5 2023-03-15**
 - Add parameter Unit of Measurement to DescribeCoverage output 
 

--- a/adagucserverEC/CAutoConfigure.cpp
+++ b/adagucserverEC/CAutoConfigure.cpp
@@ -6,7 +6,7 @@
 #include "CRequest.h"
 const char *CAutoConfigure::className = "CAutoConfigure";
 
-//#define CAUTOCONFIGURE_DEBUG
+// #define CAUTOCONFIGURE_DEBUG
 
 int CAutoConfigure::checkCascadedDimensions(const CDataSource *dataSource) {
   if (dataSource != NULL && dataSource->dLayerType == CConfigReaderLayerTypeCascaded) {

--- a/adagucserverEC/CAutoResource.cpp
+++ b/adagucserverEC/CAutoResource.cpp
@@ -81,8 +81,16 @@ int CAutoResource::configureDataset(CServerParams *srvParam, bool) {
 
     CDBDebug("Found dataset %s", datasetConfigFile.c_str());
 
+    // Find variables to substitute
+    CServerParams tempServerParam;
+    tempServerParam.parseConfigFile(datasetConfigFile, nullptr);
+    std::vector<CServerConfig::XMLE_Environment *> *extraEnvironment = nullptr;
+    if (tempServerParam.configObj != nullptr && tempServerParam.configObj->Configuration.size() > 0 && tempServerParam.configObj->Configuration[0]->Environment.size() > 0) {
+      extraEnvironment = &tempServerParam.configObj->Configuration[0]->Environment;
+    }
+
     // Add the dataset file to the current configuration
-    int status = srvParam->parseConfigFile(datasetConfigFile);
+    int status = srvParam->parseConfigFile(datasetConfigFile, extraEnvironment);
     if (status != 0) {
       CDBError("Invalid dataset configuration file.");
       return 1;

--- a/adagucserverEC/CDBFileScanner.cpp
+++ b/adagucserverEC/CDBFileScanner.cpp
@@ -33,7 +33,7 @@
 #include <set>
 const char *CDBFileScanner::className = "CDBFileScanner";
 std::vector<CT::string> CDBFileScanner::tableNamesDone;
-//#define CDBFILESCANNER_DEBUG
+// #define CDBFILESCANNER_DEBUG
 #define ISO8601TIME_LEN 32
 
 #define CDBFILESCANNER_TILECREATIONFAILED -100
@@ -610,10 +610,10 @@ int CDBFileScanner::DBLoopFiles(CDataSource *dataSource, int removeNonExistingFi
                       status = dimVar->readData(CDF_STRING);
                     }
                   }
-                  //#ifdef CDBFILESCANNER_DEBUG
-                  //                   CDBDebug("Reading dimension %s of length
-                  //                   %d",dimVar->name.c_str(),dimDim->getSize());
-                  //#endif
+                  // #ifdef CDBFILESCANNER_DEBUG
+                  //                    CDBDebug("Reading dimension %s of length
+                  //                    %d",dimVar->name.c_str(),dimDim->getSize());
+                  // #endif
                   if (status != 0) {
                     CREPORT_ERROR_NODOC(CT::string("Unable to read variable data for ") + dimVar->name, CReportMessage::Categories::GENERAL);
                     throw(__LINE__);

--- a/adagucserverEC/CDBFileScanner.h
+++ b/adagucserverEC/CDBFileScanner.h
@@ -44,6 +44,7 @@
 #define CDBFILESCANNER_DONOTTILE 128
 
 #define CDBFILESCANNER_RETENTIONTYPE_DATATIME "datatime"
+#define CDBFILESCANNER_CLEANUP_DEFAULT_LIMIT 10
 
 /**
  * Class which scans files and updates the database.

--- a/adagucserverEC/CDBFileScannerCleanFiles.cpp
+++ b/adagucserverEC/CDBFileScannerCleanFiles.cpp
@@ -34,7 +34,7 @@ int CDBFileScanner::cleanFiles(CDataSource *dataSource, int) {
   }
   CT::string enableCleanupSystem = dataSource->cfg->Settings.size() == 1 ? dataSource->cfg->Settings[0]->attr.enablecleanupsystem : "false";
   bool enableCleanupIsTrue = enableCleanupSystem.equals("true");
-  bool enableCleanupIsInform = enableCleanupSystem.equals("inform");
+  bool enableCleanupIsInform = enableCleanupSystem.equals("dryrun");
   int cleanupSystemLimit = dataSource->cfg->Settings.size() == 1 && !dataSource->cfg->Settings[0]->attr.cleanupsystemlimit.empty() ? dataSource->cfg->Settings[0]->attr.cleanupsystemlimit.toInt()
                                                                                                                                    : CDBFILESCANNER_CLEANUP_DEFAULT_LIMIT;
   if (!enableCleanupIsTrue && !enableCleanupIsInform) {
@@ -47,7 +47,7 @@ int CDBFileScanner::cleanFiles(CDataSource *dataSource, int) {
   CDBDebug("Start Cleanfiles with retentiontype [%s] and retentionperiod [%s], limit %d", retentiontype.c_str(), retentionperiod.c_str(), cleanupSystemLimit);
 
   if (enableCleanupIsInform) {
-    CDBDebug("Note that mode is set to inform only, no actual deleting");
+    CDBDebug("Note that mode is set to dryrun only, no actual deleting");
   }
   CDBAdapter *dbAdapter = CDBFactory::getDBAdapter(dataSource->srvParams->cfg);
   if (dataSource->cfgLayer->Dimension.size() == 0) {

--- a/adagucserverEC/CDBFileScannerCleanFiles.cpp
+++ b/adagucserverEC/CDBFileScannerCleanFiles.cpp
@@ -24,17 +24,31 @@ void CDBFileScanner::_removeFileFromTables(CT::string fileNamestr, CDataSource *
 }
 
 int CDBFileScanner::cleanFiles(CDataSource *dataSource, int) {
-  if (!dataSource->cfgLayer->FilePath[0]->attr.retentiontype.equals(CDBFILESCANNER_RETENTIONTYPE_DATATIME) || dataSource->cfgLayer->FilePath[0]->attr.retentionperiod.empty()) {
+  if (dataSource->cfgLayer->FilePath[0]->attr.retentiontype.empty() || dataSource->cfgLayer->FilePath[0]->attr.retentionperiod.empty()) {
     return 0;
   }
-  if (!(dataSource->cfg->Settings.size() == 1 && dataSource->cfg->Settings[0]->attr.enablecleanupsystem.equals("true"))) {
+
+  if (!dataSource->cfgLayer->FilePath[0]->attr.retentiontype.equals(CDBFILESCANNER_RETENTIONTYPE_DATATIME)) {
+    CDBDebug("retentiontype is not set to \"%s\" but  to \"%s\", ignoring", CDBFILESCANNER_RETENTIONTYPE_DATATIME, dataSource->cfgLayer->FilePath[0]->attr.retentiontype.c_str());
+    return 0;
+  }
+  CT::string enableCleanupSystem = dataSource->cfg->Settings.size() == 1 ? dataSource->cfg->Settings[0]->attr.enablecleanupsystem : "false";
+  bool enableCleanupIsTrue = enableCleanupSystem.equals("true");
+  bool enableCleanupIsInform = enableCleanupSystem.equals("inform");
+  int cleanupSystemLimit = dataSource->cfg->Settings.size() == 1 && !dataSource->cfg->Settings[0]->attr.cleanupsystemlimit.empty() ? dataSource->cfg->Settings[0]->attr.cleanupsystemlimit.toInt()
+                                                                                                                                   : CDBFILESCANNER_CLEANUP_DEFAULT_LIMIT;
+  if (!enableCleanupIsTrue && !enableCleanupIsInform) {
     CDBWarning("Layer wants to autocleanup, but attribute enablecleanupsystem in Settings is not set to true");
     return 1;
   }
+
   CT::string retentiontype = dataSource->cfgLayer->FilePath[0]->attr.retentiontype;
   CT::string retentionperiod = dataSource->cfgLayer->FilePath[0]->attr.retentionperiod;
-  CDBDebug("Start Cleanfiles with retentiontype [%s] and retentionperiod [%s]", retentiontype.c_str(), retentionperiod.c_str());
+  CDBDebug("Start Cleanfiles with retentiontype [%s] and retentionperiod [%s], limit %d", retentiontype.c_str(), retentionperiod.c_str(), cleanupSystemLimit);
 
+  if (enableCleanupIsInform) {
+    CDBDebug("Note that mode is set to inform only, no actual deleting");
+  }
   CDBAdapter *dbAdapter = CDBFactory::getDBAdapter(dataSource->srvParams->cfg);
   if (dataSource->cfgLayer->Dimension.size() == 0) {
     if (CAutoConfigure::autoConfigureDimensions(dataSource) != 0) {
@@ -66,28 +80,36 @@ int CDBFileScanner::cleanFiles(CDataSource *dataSource, int) {
   CT::string currentTime = CTime::currentDateTime();
   CTime::Date date = ctime.freeDateStringToDate(currentTime.c_str());
 
-  CDBDebug("currentDate\t\t\t%s", ctime.dateToISOString(date).c_str());
+  // CDBDebug("currentDate\t\t\t%s", ctime.dateToISOString(date).c_str());
 
   CT::string dateMinusRetentionPeriod = ctime.dateToISOString(ctime.subtractPeriodFromDate(date, retentionperiod.c_str()));
 
-  CDBDebug("dateMinusRetentionPeriod\t%s", dateMinusRetentionPeriod.c_str());
+  // CDBDebug("dateMinusRetentionPeriod\t%s", dateMinusRetentionPeriod.c_str());
 
-  CDBStore::Store *store = dbAdapter->getBetween("0000-01-01T00:00:00Z", dateMinusRetentionPeriod.c_str(), colName.c_str(), tableNameForTimeDimension.c_str(), 10000);
+  CDBStore::Store *store = dbAdapter->getBetween("0000-01-01T00:00:00Z", dateMinusRetentionPeriod.c_str(), colName.c_str(), tableNameForTimeDimension.c_str(), cleanupSystemLimit);
 
   if (store != NULL && store->getSize() > 0) {
+    CDBDebug("Found (at least) %d files which are too old.", store->getSize());
     for (size_t j = 0; j < store->getSize(); j++) {
       std::string fileNamestr = store->getRecord(j)->get(0)->c_str();
-      _removeFileFromTables(fileNamestr.c_str(), dataSource);
-      /* Don't delete files which where already deleted */
-      if (filesDeletedFromFS.find(fileNamestr) == filesDeletedFromFS.end()) {
-        int status = remove(fileNamestr.c_str());
-        if (status != 0) {
-          CDBError("Unable to remove file from FS: [%s]", fileNamestr.c_str());
-        } else {
-          filesDeletedFromFS.insert(fileNamestr);
+      if (enableCleanupIsInform) {
+        CDBDebug("[INFO] Would clean: [%s]", fileNamestr.c_str());
+      }
+      if (enableCleanupIsTrue) {
+        _removeFileFromTables(fileNamestr.c_str(), dataSource);
+        /* Don't delete files which where already deleted */
+        if (filesDeletedFromFS.find(fileNamestr) == filesDeletedFromFS.end()) {
+          int status = remove(fileNamestr.c_str());
+          if (status != 0) {
+            CDBError("Unable to remove file from FS: [%s]", fileNamestr.c_str());
+          } else {
+            filesDeletedFromFS.insert(fileNamestr);
+          }
         }
       }
     }
+  } else {
+    CDBDebug("Nothing to clean.");
   }
   delete store;
   return 0;

--- a/adagucserverEC/CDBFileScannerCleanFiles.cpp
+++ b/adagucserverEC/CDBFileScannerCleanFiles.cpp
@@ -38,7 +38,7 @@ int CDBFileScanner::cleanFiles(CDataSource *dataSource, int) {
   int cleanupSystemLimit = dataSource->cfg->Settings.size() == 1 && !dataSource->cfg->Settings[0]->attr.cleanupsystemlimit.empty() ? dataSource->cfg->Settings[0]->attr.cleanupsystemlimit.toInt()
                                                                                                                                    : CDBFILESCANNER_CLEANUP_DEFAULT_LIMIT;
   if (!enableCleanupIsTrue && !enableCleanupIsInform) {
-    CDBWarning("Layer wants to autocleanup, but attribute enablecleanupsystem in Settings is not set to true");
+    CDBWarning("Layer wants to autocleanup, but attribute enablecleanupsystem in Settings is not set to true or dryrun but to %s", enableCleanupSystem.c_str());
     return 1;
   }
 

--- a/adagucserverEC/CRequest.cpp
+++ b/adagucserverEC/CRequest.cpp
@@ -84,7 +84,7 @@ int CRequest::setConfigFile(const char *pszConfigFile) {
   CT::StackList<CT::string> configFileList = configFile.splitToStack(",");
 
   // Parse the main configuration file
-  int status = srvParam->parseConfigFile(configFileList[0]);
+  int status = srvParam->parseConfigFile(configFileList[0], nullptr);
 
   if (status == 0 && srvParam->configObj->Configuration.size() == 1) {
 
@@ -95,7 +95,7 @@ int CRequest::setConfigFile(const char *pszConfigFile) {
     if (configFileList.size() > 1) {
       for (size_t j = 1; j < configFileList.size() - 1; j++) {
         // CDBDebug("Include '%s'",configFileList[j].c_str());
-        status = srvParam->parseConfigFile(configFileList[j]);
+        status = srvParam->parseConfigFile(configFileList[j], nullptr);
         if (status != 0) {
           CDBError("There is an error with include '%s'", configFileList[j].c_str());
           return 1;
@@ -175,7 +175,7 @@ int CRequest::setConfigFile(const char *pszConfigFile) {
 #ifdef CREQUEST_DEBUG
         CDBDebug("Include '%s'", srvParam->cfg->Include[index]->attr.location.c_str());
 #endif
-        status = srvParam->parseConfigFile(srvParam->cfg->Include[index]->attr.location);
+        status = srvParam->parseConfigFile(srvParam->cfg->Include[index]->attr.location, nullptr);
         if (status != 0) {
           CDBError("There is an error with include '%s'", srvParam->cfg->Include[index]->attr.location.c_str());
           return 1;

--- a/adagucserverEC/CServerConfig_CPPXSD.h
+++ b/adagucserverEC/CServerConfig_CPPXSD.h
@@ -986,7 +986,9 @@ public:
       CXMLSerializerInterface *base = (CXMLSerializerInterface *)baseClass;
       base->currentNode = (CXMLObjectInterface *)this;
       if (rc == 0)
-        if (value != NULL) this->value.copy(CDirReader::makeCleanPath(value));
+        if (value != NULL) {
+          this->value.copy(CDirReader::makeCleanPath(value));
+        }
       if (pt2Class != NULL) pt2Class->addElement(baseClass, rc - pt2Class->level, name, value);
     }
 
@@ -1197,15 +1199,34 @@ public:
     }
   };
 
+  class XMLE_Environment : public CXMLObjectInterface {
+  public:
+    class Cattr {
+    public:
+      CT::string name, defaultVal;
+    } attr;
+    void addAttribute(const char *name, const char *value) {
+      if (equals("name", 4, name)) {
+        attr.name.copy(value);
+        return;
+      } else if (equals("default", 7, name)) {
+        attr.defaultVal.copy(value);
+        return;
+      }
+    }
+  };
   class XMLE_Settings : public CXMLObjectInterface {
   public:
     class Cattr {
     public:
-      CT::string enablecleanupsystem;
+      CT::string enablecleanupsystem, cleanupsystemlimit;
     } attr;
     void addAttribute(const char *attrname, const char *attrvalue) {
       if (equals("enablecleanupsystem", 19, attrname)) {
         attr.enablecleanupsystem.copy(attrvalue);
+        return;
+      } else if (equals("cleanupsystemlimit", 18, attrname)) {
+        attr.cleanupsystemlimit.copy(attrvalue);
         return;
       }
     }
@@ -1841,6 +1862,7 @@ public:
     std::vector<XMLE_Logging *> Logging;
     std::vector<XMLE_Symbol *> Symbol;
     std::vector<XMLE_Settings *> Settings;
+    std::vector<XMLE_Environment *> Environment;
 
     ~XMLE_Configuration() {
       XMLE_DELOBJ(Legend);
@@ -1861,6 +1883,7 @@ public:
       XMLE_DELOBJ(Logging);
       XMLE_DELOBJ(Symbol);
       XMLE_DELOBJ(Settings);
+      XMLE_DELOBJ(Environment);
     }
     void addElement(CXMLObjectInterface *baseClass, int rc, const char *name, const char *value) {
       CXMLSerializerInterface *base = (CXMLSerializerInterface *)baseClass;
@@ -1905,6 +1928,8 @@ public:
           XMLE_ADDOBJ(Symbol);
         } else if (equals("Settings", 8, name)) {
           XMLE_ADDOBJ(Settings);
+        } else if (equals("Environment", 11, name)) {
+          XMLE_ADDOBJ(Environment);
         }
       }
       if (pt2Class != NULL) pt2Class->addElement(baseClass, rc - pt2Class->level, name, value);

--- a/adagucserverEC/CServerParams.h
+++ b/adagucserverEC/CServerParams.h
@@ -38,7 +38,7 @@
 #include <map>
 #include <string>
 
-//#define MAX_DIMS 10
+// #define MAX_DIMS 10
 
 /**
  * See http://www.resc.rdg.ac.uk/trac/ncWMS/wiki/WmsExtensions
@@ -307,7 +307,7 @@ public:
    * @param pszConfigFile The config file to parse
    * returns zero on success       *
    */
-  int parseConfigFile(CT::string &pszConfigFile);
+  int parseConfigFile(CT::string &pszConfigFile, std::vector<CServerConfig::XMLE_Environment *> *extraEnvironment);
 };
 
 #endif

--- a/adagucserverEC/CServerParams.h
+++ b/adagucserverEC/CServerParams.h
@@ -40,6 +40,8 @@
 
 // #define MAX_DIMS 10
 
+#define CSERVERPARAMS_ADAGUCENV_PREFIX "ADAGUCENV_"
+
 /**
  * See http://www.resc.rdg.ac.uk/trac/ncWMS/wiki/WmsExtensions
  */

--- a/adagucserverEC/Definitions.h
+++ b/adagucserverEC/Definitions.h
@@ -28,7 +28,7 @@
 #ifndef Definitions_H
 #define Definitions_H
 
-#define ADAGUCSERVER_VERSION "2.8.5" // Please also update in the Dockerfile to the same version
+#define ADAGUCSERVER_VERSION "2.8.6" // Please also update in the Dockerfile to the same version
 
 // CConfigReaderLayerType
 #define CConfigReaderLayerTypeUnknown 0
@@ -124,12 +124,12 @@
 #define ADAGUC_USE_CAIRO
 
 // #define CImgWarpBilinear_DEBUG
-//#define CImgWarpBilinear_TIME
+// #define CImgWarpBilinear_TIME
 // #define MEASURETIME
 
-//#define CDATAREADER_DEBUG
-//#define CCDFNETCDFIO_DEBUG
-// Debug settings:
+// #define CDATAREADER_DEBUG
+// #define CCDFNETCDFIO_DEBUG
+//  Debug settings:
 /*
 #define CIMAGEDATAWRITER_DEBUG
 #define CDATAREADER_DEBUG
@@ -153,9 +153,9 @@
 #define MEASURETIME
 */
 
-//#define MEASURETIME
-//#define ADAGUC_TILESTITCHER_DEBUG
-//#define DEBUGON
+// #define MEASURETIME
+// #define ADAGUC_TILESTITCHER_DEBUG
+// #define DEBUGON
 #ifdef DEBUGON
 #define CDATASOURCE_DEBUG
 #define CREQUEST_DEBUG
@@ -169,21 +169,21 @@
 #define CDFOBJECTSTORE_DEBUG
 #define ADAGUC_TILESTITCHER_DEBUG
 #endif
-//#define MEASURETIME
-//#define CCDFNETCDFIO_DEBUG
-//#define CXMLGEN_DEBUG
-//#define CDATAREADER_DEBUG
-//#define CCDFNETCDFIO_DEBUG
-//#define CCDFNETCDFIO_DEBUG_OPEN
-//#define CDATAREADER_DEBUG
+// #define MEASURETIME
+// #define CCDFNETCDFIO_DEBUG
+// #define CXMLGEN_DEBUG
+// #define CDATAREADER_DEBUG
+// #define CCDFNETCDFIO_DEBUG
+// #define CCDFNETCDFIO_DEBUG_OPEN
+// #define CDATAREADER_DEBUG
 
-//#define MEASURETIME
-//#define CDATAREADER_DEBUG
-//#define CIMAGEDATAWRITER_DEBUG
-//#define CDATASOURCE_DEBUG
+// #define MEASURETIME
+// #define CDATAREADER_DEBUG
+// #define CIMAGEDATAWRITER_DEBUG
+// #define CDATASOURCE_DEBUG
 #define CSLD_DEBUG
 
-//#define ENABLE_CURL in Makefile
+// #define ENABLE_CURL in Makefile
 
-//#define ADAGUC_USE_GDAL
+// #define ADAGUC_USE_GDAL
 #endif

--- a/data/config/datasets/adaguc.tests.cleandb-step2.xml
+++ b/data/config/datasets/adaguc.tests.cleandb-step2.xml
@@ -1,11 +1,14 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
-  
-  <Settings enablecleanupsystem="true"/>
-  
+  <Environment name="ADAGUCENV_RETENTIONPERIOD" default="P7D" />
+  <Environment name="ADAGUCENV_ENABLECLEANUP" default="true" />
+  <Settings enablecleanupsystem="{ADAGUCENV_ENABLECLEANUP}" />
+
   <!-- Layers -->
   <Layer type="database">
-    <FilePath filter="^.*\.csv$" retentionperiod="P7D" retentiontype="datatime">{ADAGUC_TMP}/cleandb/</FilePath>
+    <FilePath filter="^.*\.csv$" retentionperiod="{ADAGUCENV_RETENTIONPERIOD}"
+      retentiontype="datatime">
+      {ADAGUC_TMP}/cleandb/</FilePath>
     <Name>test</Name>
     <Title>test</Title>
     <Variable>test</Variable>

--- a/doc/configuration/Configuration.md
+++ b/doc/configuration/Configuration.md
@@ -28,6 +28,7 @@ Configuration
     files to the service
 -   [Logging](Logging.md) - (debug) - Configure the type of logging
 -   [Settings](Settings.md) - (enablecleanupsystem) - Configure global settings of the server / Dataset
+-   [Environment](Environment.md) - (name, default) - For within dataset configuration, specify which values should be substituted
 
 <!-- -->
 

--- a/doc/configuration/Environment.md
+++ b/doc/configuration/Environment.md
@@ -18,7 +18,7 @@ It can for example be used in the following dataset configuration snippet:
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
   <Environment name="ADAGUCENV_RETENTIONPERIOD" default="PT10M" />
-  <Environment name="ADAGUCENV_ENABLECLEANUP" default="inform" />
+  <Environment name="ADAGUCENV_ENABLECLEANUP" default="dryrun" />
   <Settings enablecleanupsystem="{ADAGUCENV_ENABLECLEANUP}" cleanupsystemlimit="5" />
   <Layer type="database">
     <FilePath filter=".*\.nc$" retentionperiod="{ADAGUCENV_RETENTIONPERIOD}"
@@ -33,7 +33,7 @@ It can for example be used in the following dataset configuration snippet:
 </Configuration>
 ```
 
-By default it will not enable the cleanup, but only inform. But by setting the following environment:
+By default it will not enable the cleanup, but only inform what would be deleted. But by setting the following environment:
 
 ```
 export ADAGUCENV_RETENTIONPERIOD="P7D"

--- a/doc/configuration/Environment.md
+++ b/doc/configuration/Environment.md
@@ -1,0 +1,43 @@
+Environment (name, default)
+===============
+
+Back to [Configuration](./Configuration.md)
+
+Available since: 2.8.6
+
+Allows to substitute environment variables in a dataset configuration.
+
+- name The environment variable and the name inside the dataset configuration. Note that these should be prefixed with `ADAGUCENV`
+- default The default value if no environment variable is set.
+
+
+It can for example be used in the following dataset configuration snippet:
+
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+  <Environment name="ADAGUCENV_RETENTIONPERIOD" default="PT10M" />
+  <Environment name="ADAGUCENV_ENABLECLEANUP" default="inform" />
+  <Settings enablecleanupsystem="{ADAGUCENV_ENABLECLEANUP}" cleanupsystemlimit="5" />
+  <Layer type="database">
+    <FilePath filter=".*\.nc$" retentionperiod="{ADAGUCENV_RETENTIONPERIOD}"
+      retentiontype="datatime">
+      /data/adaguc-data/livetimestream/</FilePath>
+
+    <Variable>data</Variable>
+    <Dimension name="time" interval="PT1M" quantizeperiod="PT1M" quantizemethod="low">time</Dimension>
+    <RenderMethod>rgba</RenderMethod>
+  </Layer>
+
+</Configuration>
+```
+
+By default it will not enable the cleanup, but only inform. But by setting the following environment:
+
+```
+export ADAGUCENV_RETENTIONPERIOD="P7D"
+export ADAGUCENV_ENABLECLEANUP=true
+```
+
+Cleanup will be enabled and retentionperiod will be set to 7 days

--- a/doc/configuration/Settings.md
+++ b/doc/configuration/Settings.md
@@ -5,18 +5,18 @@ Back to [Configuration](./Configuration.md)
 
 Available since: 2.8.6
 
-- enablecleanupsystem (false | true | inform): Enables the auto cleanup system. See [FilePath](./FilePath.md) and retentionperiod for details
+- enablecleanupsystem (false | true | dryrun): Enables the auto cleanup system. See [FilePath](./FilePath.md) and retentionperiod for details
 - cleanupsystemlimit (number): Configures how many files will be deleted at once, defaults to 10 (CDBFILESCANNER_CLEANUP_DEFAULT_LIMIT).
 
 Allowed values for enablecleanupsystem are:
 - false (or nothing)
 - true - Enables the cleanup, deletes files from the filesystem and from the database
-- inform - Informs which files would be removed, like a dry run.
+- dryrun - Informs which files would be removed, like a dry run.
 
 
 
 ```xml
-<Settings enablecleanupsystem="true"/>
+<Settings enablecleanupsystem="true" cleanupsystemlimit="10"/>
 ```
 
 This can be configured in the main Configuration section or a dataset

--- a/doc/configuration/Settings.md
+++ b/doc/configuration/Settings.md
@@ -3,9 +3,17 @@ Settings (enablecleanupsystem)
 
 Back to [Configuration](./Configuration.md)
 
-Available since: 2.7.12
+Available since: 2.8.6
 
-- enablecleanupsystem: Enables the auto cleanup system. See [FilePath](./FilePath.md) and retentionperiod for details
+- enablecleanupsystem (false | true | inform): Enables the auto cleanup system. See [FilePath](./FilePath.md) and retentionperiod for details
+- cleanupsystemlimit (number): Configures how many files will be deleted at once, defaults to 10 (CDBFILESCANNER_CLEANUP_DEFAULT_LIMIT).
+
+Allowed values for enablecleanupsystem are:
+- false (or nothing)
+- true - Enables the cleanup, deletes files from the filesystem and from the database
+- inform - Informs which files would be removed, like a dry run.
+
+
 
 ```xml
 <Settings enablecleanupsystem="true"/>

--- a/hclasses/CDirReader.cpp
+++ b/hclasses/CDirReader.cpp
@@ -130,6 +130,8 @@ CT::string CDirReader::makeCleanPath(const char *_path) {
   if (_path == NULL) return path;
   path = _path;
   if (path.length() == 0) return path;
+  path.replaceSelf("\n", "");
+  path.trimSelf();
   CT::StackList<CT::string> parts = path.splitToStack("/");
 
   int startAtIndex = 0;

--- a/python/lib/adaguc/runAdaguc.py
+++ b/python/lib/adaguc/runAdaguc.py
@@ -1,4 +1,4 @@
-
+from ast import Dict
 import subprocess
 import os
 from os.path import expanduser
@@ -14,6 +14,7 @@ from adaguc.CGIRunner import CGIRunner
 
 
 class runAdaguc:
+
     def __init__(self):
         """ ADAGUC_LOGFILE is the location where logfiles are stored. 
           In current config file adaguc.autoresource.xml, the DB is written to this temporary directory. 
@@ -22,13 +23,13 @@ class runAdaguc:
         self.ADAGUC_LOGFILE = "/tmp/adaguc-server-" + \
             self.get_random_string(10) + ".log"
         self.ADAGUC_PATH = os.getenv('ADAGUC_PATH', "./")
-        self.ADAGUC_CONFIG = self.ADAGUC_PATH+"/data/config/adaguc.autoresource.xml"
-        self.ADAGUC_DATA_DIR = os.getenv(
-            'ADAGUC_DATA_DIR', "/data/adaguc-data")
-        self.ADAGUC_AUTOWMS_DIR = os.getenv(
-            'ADAGUC_AUTOWMS_DIR', "/data/adaguc-autowms")
-        self.ADAGUC_DATASET_DIR = os.getenv(
-            'ADAGUC_DATASET_DIR', "/data/adaguc-datasets")
+        self.ADAGUC_CONFIG = self.ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"
+        self.ADAGUC_DATA_DIR = os.getenv('ADAGUC_DATA_DIR',
+                                         "/data/adaguc-data")
+        self.ADAGUC_AUTOWMS_DIR = os.getenv('ADAGUC_AUTOWMS_DIR',
+                                            "/data/adaguc-autowms")
+        self.ADAGUC_DATASET_DIR = os.getenv('ADAGUC_DATASET_DIR',
+                                            "/data/adaguc-datasets")
         self.ADAGUC_TMP = os.getenv('ADAGUC_TMP', "/tmp")
         self.ADAGUC_FONT = os.getenv(
             'ADAGUC_FONT', self.ADAGUC_PATH + "./data/fonts/Roboto-Medium.ttf")
@@ -62,7 +63,6 @@ class runAdaguc:
         config = self.ADAGUC_CONFIG + "," + datasetName
         """ Setup a new environment """
         adagucenv = {}
-
         """ Set required environment variables """
         adagucenv['ADAGUC_CONFIG'] = self.ADAGUC_CONFIG
         adagucenv['ADAGUC_LOGFILE'] = self.ADAGUC_LOGFILE
@@ -74,13 +74,14 @@ class runAdaguc:
         adagucenv['ADAGUC_FONT'] = self.ADAGUC_FONT
 
         status, data, headers = self.runADAGUCServer(
-            args=['--updatedb', '--config', config], env=adagucenv, isCGI=False)
+            args=['--updatedb', '--config', config],
+            env=adagucenv,
+            isCGI=False)
 
         return (data.getvalue().decode())
 
     def runGetMapUrl(self, url):
         adagucenv = {}
-
         """ Set required environment variables """
         adagucenv['ADAGUC_CONFIG'] = self.ADAGUC_CONFIG
         adagucenv['ADAGUC_LOGFILE'] = self.ADAGUC_LOGFILE
@@ -90,8 +91,9 @@ class runAdaguc:
         adagucenv['ADAGUC_DATASET_DIR'] = self.ADAGUC_DATASET_DIR
         adagucenv['ADAGUC_TMP'] = self.ADAGUC_TMP
         adagucenv['ADAGUC_FONT'] = self.ADAGUC_FONT
-        status, data, headers = self.runADAGUCServer(
-            url, env=adagucenv,  showLogOnError=False)
+        status, data, headers = self.runADAGUCServer(url,
+                                                     env=adagucenv,
+                                                     showLogOnError=False)
         logfile = self.getLogFile()
         self.removeLogFile()
         if data is not None:
@@ -112,7 +114,7 @@ class runAdaguc:
 
     def getLogFile(self):
         try:
-            f = open(self.ADAGUC_LOGFILE,  encoding="utf8", errors='ignore')
+            f = open(self.ADAGUC_LOGFILE, encoding="utf8", errors='ignore')
             data = f.read()
             f.close()
             return data
@@ -126,7 +128,14 @@ class runAdaguc:
         print(self.getLogFile())
         print("=== END ADAGUC LOGS ===")
 
-    def runADAGUCServer(self, url=None, env=[], path=None, args=None, isCGI=True, showLogOnError=True, showLog=False):
+    def runADAGUCServer(self,
+                        url=None,
+                        env=[],
+                        path=None,
+                        args=None,
+                        isCGI=True,
+                        showLogOnError=True,
+                        showLog=False):
 
         # adagucenv=os.environ.copy()
         # adagucenv.update(env)
@@ -144,6 +153,15 @@ class runAdaguc:
         adagucenv['ADAGUC_DATASET_DIR'] = self.ADAGUC_DATASET_DIR
         adagucenv['ADAGUC_TMP'] = self.ADAGUC_TMP
         adagucenv['ADAGUC_FONT'] = self.ADAGUC_FONT
+        ld_library_path = os.getenv("LD_LIBRARY_PATH")
+        if ld_library_path:
+            adagucenv['LD_LIBRARY_PATH'] = ld_library_path
+
+        # Forward all environment variables starting with ADAGUCENV_
+        prefix: str = "ADAGUCENV_"
+        for key, value in os.environ.items():
+            if key[:len(prefix)] == prefix:
+                adagucenv[key] = value
 
         ADAGUC_PATH = adagucenv['ADAGUC_PATH']
         ADAGUC_LOGFILE = adagucenv['ADAGUC_LOGFILE']
@@ -153,7 +171,7 @@ class runAdaguc:
         except:
             pass
 
-        adagucexecutable = ADAGUC_PATH+"/bin/adagucserver"
+        adagucexecutable = ADAGUC_PATH + "/bin/adagucserver"
 
         adagucargs = [adagucexecutable]
 
@@ -161,8 +179,12 @@ class runAdaguc:
             adagucargs = adagucargs + args
 
         filetogenerate = BytesIO()
-        status, headers, processErr = CGIRunner().run(adagucargs, url=url, output=filetogenerate,
-                                          env=adagucenv, path=path, isCGI=isCGI)
+        status, headers, processErr = CGIRunner().run(adagucargs,
+                                                      url=url,
+                                                      output=filetogenerate,
+                                                      env=adagucenv,
+                                                      path=path,
+                                                      isCGI=isCGI)
 
         if (status != 0 and showLogOnError == True) or showLog == True:
             print("\n\n--- START ADAGUC DEBUG INFO ---")


### PR DESCRIPTION
This is an update for the cleanup system, after receiving feedback from GeoWeb.

**Version 2.8.6 2023-03-23**
- Added a configuration option to limit the number of deletions done at once, configurable with `cleanupsystemlimit="5"`  in [Settings](doc/configuration/Settings.md).
- Added a configuration option to start a dryrun of cleanup, explaining which files would be deleted (but not actually deleting them), configurable with `enablecleanupsystem="dryrun"` in [Settings](doc/configuration/Settings.md)
- Added the option to replace custom variables in the dataset configuration using the [Environment](doc/configuration/Environment.md) keyword. These will get the value from the environment. This has been added to make it possible to let dev branches have a shorter retentionperiod and the main branch a longer retentionperiod. 
- See complete dataset example in [data/config/datasets/adaguc.tests.cleandb-step2.xml](data/config/datasets/adaguc.tests.cleandb-step2.xml)

The following dataset configuration demonstrates it:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<Configuration>
  <Environment name="ADAGUCENV_RETENTIONPERIOD" default="PT10M" />
  <Environment name="ADAGUCENV_ENABLECLEANUP" default="inform" />
  <Settings enablecleanupsystem="{ADAGUCENV_ENABLECLEANUP}" cleanupsystemlimit="5" />
  <Layer type="database">
    <FilePath filter=".*\.nc$" retentionperiod="{ADAGUCENV_RETENTIONPERIOD}"
      retentiontype="datatime">
      /data/adaguc-data/livetimestream/</FilePath>

    <Variable>data</Variable>
    <Dimension name="time" interval="PT1M" quantizeperiod="PT1M" quantizemethod="low">time</Dimension>
    <RenderMethod>rgba</RenderMethod>
  </Layer>

</Configuration>
```