### PR TITLE
Prevent double logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ USER root
 LABEL maintainer="adaguc@knmi.nl"
 
 # Version should be same as in Definitions.h
-LABEL version="2.11.0"
+LABEL version="2.11.1"
 
 ######### First stage (build) ############
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+**Version 2.11.1 2023-08-21**
+
+- Avoid double logging
+- Timeout to prevent endless running of processes
+
 **Version 2.11.0 2023-08-17**
 - Update Docker base image to Python 3.10 based on Debian 12 ("bookworm")
 

--- a/adagucserverEC/Definitions.h
+++ b/adagucserverEC/Definitions.h
@@ -28,7 +28,7 @@
 #ifndef Definitions_H
 #define Definitions_H
 
-#define ADAGUCSERVER_VERSION "2.11.0" // Please also update in the Dockerfile to the same version
+#define ADAGUCSERVER_VERSION "2.11.1" // Please also update in the Dockerfile to the same version
 
 // CConfigReaderLayerType
 #define CConfigReaderLayerTypeUnknown 0

--- a/python/lib/adaguc/CGIRunner.py
+++ b/python/lib/adaguc/CGIRunner.py
@@ -42,6 +42,7 @@ class CGIRunner:
             (processOutput, processError) = process.communicate(timeout=timeout)
         except TimeoutExpired:
             process.kill()
+            process.communicate()
             output.write(b'TimeOut')
             return 1, [], None
 

--- a/python/lib/adaguc/CGIRunner.py
+++ b/python/lib/adaguc/CGIRunner.py
@@ -4,7 +4,7 @@
 """
 
 import sys
-from subprocess import PIPE, Popen, STDOUT
+from subprocess import PIPE, Popen, STDOUT, TimeoutExpired
 from threading import Thread
 import os
 import io
@@ -22,7 +22,7 @@ class CGIRunner:
       Run the CGI script with specified URL and environment. Stdout is captured and put in a BytesIO object provided in output
     """
 
-    def run(self, cmds, url, output, env=[],  path=None, isCGI=True):
+    def run(self, cmds, url, output, env=[],  path=None, isCGI=True, timeout=300):
         localenv = {}
         if url != None:
             localenv['QUERY_STRING'] = url
@@ -37,8 +37,14 @@ class CGIRunner:
         # Execute adaguc-server binary
         ON_POSIX = 'posix' in sys.builtin_module_names
         process = Popen(cmds, stdout=PIPE, stderr=PIPE, env=localenv, close_fds=ON_POSIX)
-        (processOutput, processError) = process.communicate()
- 
+        
+        try:
+            (processOutput, processError) = process.communicate(timeout=timeout)
+        except TimeoutExpired:
+            process.kill()
+            output.write(b'TimeOut')
+            return 1, [], None
+
         status = process.wait()
 
         # Split headers from body using a regex

--- a/python/python_fastapi_server/configure_logging.py
+++ b/python/python_fastapi_server/configure_logging.py
@@ -2,25 +2,10 @@
 
 """Configures logging for the adaguc-server python wrapper"""
 import sys
-from functools import wraps
 
-def run_once(f):
-    """Runs a function (successfully) only once.
-    The running can be reset by setting the `has_run` attribute to False
-    """
-    @wraps(f)
-    def wrapper(*args, **kwargs):
-        if not f.has_run:
-            f.has_run = True
-            return f(*args, **kwargs)
-
-    f.has_run = False
-    return wrapper
-
-
-@run_once
 def configure_logging(logging):
     """Configures logging for the adaguc-server python wrapper"""
+    logging.getLogger().handlers.clear()
     root = logging.getLogger()
     root.setLevel(logging.DEBUG)
     handler = logging.StreamHandler(sys.stdout)

--- a/python/python_fastapi_server/configure_logging.py
+++ b/python/python_fastapi_server/configure_logging.py
@@ -2,14 +2,19 @@
 
 """Configures logging for the adaguc-server python wrapper"""
 import sys
+from functools import wraps
 
 def run_once(f):
+    """Runs a function (successfully) only once.
+    The running can be reset by setting the `has_run` attribute to False
+    """
+    @wraps(f)
     def wrapper(*args, **kwargs):
-        if not wrapper.has_run:
-            wrapper.has_run = True
+        if not f.has_run:
+            f.has_run = True
             return f(*args, **kwargs)
 
-    wrapper.has_run = False
+    f.has_run = False
     return wrapper
 
 

--- a/python/python_fastapi_server/configure_logging.py
+++ b/python/python_fastapi_server/configure_logging.py
@@ -3,7 +3,17 @@
 """Configures logging for the adaguc-server python wrapper"""
 import sys
 
+def run_once(f):
+    def wrapper(*args, **kwargs):
+        if not wrapper.has_run:
+            wrapper.has_run = True
+            return f(*args, **kwargs)
 
+    wrapper.has_run = False
+    return wrapper
+
+
+@run_once
 def configure_logging(logging):
     """Configures logging for the adaguc-server python wrapper"""
     root = logging.getLogger()

--- a/python/python_fastapi_server/routers/wmswcs.py
+++ b/python/python_fastapi_server/routers/wmswcs.py
@@ -46,6 +46,7 @@ async def handle_wms(req: Request, ):
     # Run adaguc-server
     status, data, headers = adaguc_instance.runADAGUCServer(query_string,
                                                             env=adagucenv,
+                                                            showLogOnError=False,
                                                             showLog=False)
 
     # Obtain logfile


### PR DESCRIPTION
Fixed two issues since we are using fast-api:
- Logging showed up twice
- Process had no timeout