### PR TITLE
2.11.3 Do not skip cleanup when file to scan does not exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ USER root
 LABEL maintainer="adaguc@knmi.nl"
 
 # Version should be same as in Definitions.h
-LABEL version="2.11.3"
+LABEL version="2.11.4"
 
 ######### First stage (build) ############
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,13 @@
+**Version 2.11.4 2023-09-04**
+
+- Also cleanup FS and DB when the file to scan was not found (When an error occured)
+
 **Version 2.11.3 2023-09-04**
 
 - Reduced logging during dataset scanning for better traceability
 - Stop scanning at early stage when a variable does not exist in a NetCDF file.
 
-**Version 2.11.3 2023-08-21**
+**Version 2.11.2 2023-08-21**
 
 - Hot fix: Accidently removed necessary python dependencies in Docker build
 

--- a/adagucserverEC/CDBFileScanner.cpp
+++ b/adagucserverEC/CDBFileScanner.cpp
@@ -1010,6 +1010,9 @@ int CDBFileScanner::updatedb(CDataSource *dataSource, CT::string *_tailPath, CT:
     if (removeNonExistingFiles == 1) status = DB->query("COMMIT");
 #endif
 
+    // Clean up if needed
+    cleanFiles(dataSource, scanFlags);
+
     return 1;
   }
 

--- a/adagucserverEC/Definitions.h
+++ b/adagucserverEC/Definitions.h
@@ -28,7 +28,7 @@
 #ifndef Definitions_H
 #define Definitions_H
 
-#define ADAGUCSERVER_VERSION "2.11.3" // Please also update in the Dockerfile to the same version
+#define ADAGUCSERVER_VERSION "2.11.4" // Please also update in the Dockerfile to the same version
 
 // CConfigReaderLayerType
 #define CConfigReaderLayerTypeUnknown 0


### PR DESCRIPTION
Cleanup was not called when an error occured.