### PR TITLE
nits: updates to tutorial and glossary

### DIFF
--- a/doc/GLOSSARY.md
+++ b/doc/GLOSSARY.md
@@ -16,8 +16,10 @@ Band Interleaved by Line.
 Band Interleaved by Pixel.
 ## BSQ       
 Band SeQuential.
-## CF        
+## CF
 Climate and Forecast.
+## EDR
+Environmental Data Retrieval
 ## ECMWF     
 European Centre for Medium-Range Weather Forecasts.
 ## EOS       
@@ -43,7 +45,7 @@ Hierarchical Data Format.
 ## IMAA      
 for Environmental Analysis.
 ## IMAU      
-Institute for Marine and Atmospheric Research.
+Institute for Marine and Atmospheric Research (Utrecht University).
 ## INSPIRE   
 Infrastructure for Spatial Information in the European Community.
 ## ISO       
@@ -123,6 +125,6 @@ World Meteorological Organization.
 ## WMS       
 Web Map Service.
 ## WUR       
-and Research Centre.
+Wageningen University and Research Centre.
 ## XML       
 eXtensible Markup Language.

--- a/doc/tutorials/Configure_EDR_service.md
+++ b/doc/tutorials/Configure_EDR_service.md
@@ -20,6 +20,7 @@ This file is available in the adaguc-server repository with location `data/datas
 
 ## Step 2: Configure a dataset for this datafile, including EDR support
 
+Create the following file at the filepath `$ADAGUC_DATASET_DIR/edr.xml`. You can also consider changing `<FilePath>` to `/data/adaguc-data/*.nc`.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>


### PR DESCRIPTION
While following the tutorials I noticed some bits of info were missing.

The Dockerfile change solves a Gtk error while importing data as described in the [Radar files tutorial](https://github.com/KNMI/adaguc-server/blob/master/doc/tutorials/Create_WMS_on_series_KNMI_HDF5_radar_files.md)