### PR TITLE
323 wcs cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ USER root
 LABEL maintainer="adaguc@knmi.nl"
 
 # Version should be same as in Definitions.h
-LABEL version="2.14.1"
+LABEL version="2.14.2"
 
 # Try to update image packages
 RUN apt-get -q -y update \

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+**Version 2.14.2 2024-01-15**
+- Fix issue where the wrong dimension was forced to a value
+- Add Cache-Control header to WCS requests (DescribeCoverage and GetCoverage)
+- Fix Cache-control when dimensions are forced to a value
+- Make AAIGRID comparison looser (ignore whitespace)
+- Add unit test for Cache-Control headers for WCS AAIGRID format
+
 **Version 2.14.1 2023-12-08**
 - Set keep-alive (to support running behind proxy/load balancer)
 

--- a/adagucserverEC/CGDALDataWriter.cpp
+++ b/adagucserverEC/CGDALDataWriter.cpp
@@ -655,7 +655,7 @@ int CGDALDataWriter::end() {
     printf("Content-Description: File Transfer\r\n");
     printf("Content-Transfer-Encoding: binary\r\n");
     printf("Content-Length: %zu\r\n", endPos);
-    printf("%s\r\n\n", mimeType.c_str());
+    printf("%s%s\r\n\n", mimeType.c_str(), srvParam->getCacheControlHeader(srvParam->getCacheControlOption()).c_str());
     for (size_t j = 0; j < endPos; j++) putchar(getc(fp));
     fclose(fp);
     fclose(stdout);

--- a/adagucserverEC/CNetCDFDataWriter.cpp
+++ b/adagucserverEC/CNetCDFDataWriter.cpp
@@ -1094,7 +1094,7 @@ int CNetCDFDataWriter::end() {
     printf("Content-Description: File Transfer\r\n");
     printf("Content-Transfer-Encoding: binary\r\n");
     printf("Content-Length: %zu\r\n", endPos);
-    printf("%s\r\n\n", "Content-Type:application/netcdf");
+    printf("%s%s\r\n\n", "Content-Type:application/netcdf", srvParam->getCacheControlHeader(srvParam->getCacheControlOption()).c_str());
     for (size_t j = 0; j < endPos; j++) putchar(getc(fp));
     fclose(fp);
     fclose(stdout);

--- a/adagucserverEC/COGCDims.h
+++ b/adagucserverEC/COGCDims.h
@@ -30,7 +30,7 @@
 #include "CDebugger.h"
 class COGCDims {
 public:
-  COGCDims() { isATimeDimension = false; }
+  COGCDims() { isATimeDimension = false; hasFixedValue = false; }
   /**
    * OGC name
    */
@@ -60,6 +60,8 @@ public:
   void addValue(const char *value);
 
   bool isATimeDimension;
+
+  bool hasFixedValue;
 };
 
 class CCDFDims {

--- a/adagucserverEC/CRequest.cpp
+++ b/adagucserverEC/CRequest.cpp
@@ -1155,10 +1155,11 @@ int CRequest::fillDimValuesForDataSource(CDataSource *dataSource, CServerParams 
         CT::string dimName(dataSource->cfgLayer->Dimension[i]->value.c_str());
         CT::string forceValue = dataSource->cfgLayer->Dimension[i]->attr.fixvalue;
         dimName.toLowerCaseSelf();
-        for (size_t l = 0; l < dataSource->requiredDims.size(); l++) {
-          if (dataSource->requiredDims[l]->name.equals(&dimName)) {
-            CDBDebug("Forcing dimension %s from %s to %s", dimName.c_str(), dataSource->requiredDims[i]->value.c_str(), forceValue.c_str());
-            dataSource->requiredDims[i]->value = forceValue;
+        for (auto & requiredDim : dataSource->requiredDims) {
+          if (requiredDim->name.equals(&dimName)) {
+            CDBDebug("Forcing dimension %s from %s to %s", dimName.c_str(), requiredDim->value.c_str(), forceValue.c_str());
+            requiredDim->value = forceValue;
+            requiredDim->hasFixedValue = true;
             break;
           }
         }
@@ -1187,17 +1188,16 @@ int CRequest::fillDimValuesForDataSource(CDataSource *dataSource, CServerParams 
   }
   CDBDebug("### [</fillDimValuesForDataSource>]");
 #endif
-  bool allDimensionsAreAsRequestedInQueryString = true;
-  for (size_t j = 0; j < dataSource->requiredDims.size(); j++) {
-    auto *requiredDim = dataSource->requiredDims[j];
-    CDBDebug("%s: [%s] === [%s]", requiredDim->name.c_str(), requiredDim->value.c_str(), requiredDim->queryValue.c_str());
-    if (!requiredDim->value.equals(requiredDim->queryValue)) {
-      allDimensionsAreAsRequestedInQueryString = false;
+  bool allNonFixedDimensionsAreAsRequestedInQueryString = true;
+  for (auto requiredDim : dataSource->requiredDims) {
+    CDBDebug("%s: [%s] === [%s], fixed:%d", requiredDim->name.c_str(), requiredDim->value.c_str(), requiredDim->queryValue.c_str(), requiredDim->hasFixedValue);
+    if (!requiredDim->hasFixedValue && !requiredDim->value.equals(requiredDim->queryValue)) {
+      allNonFixedDimensionsAreAsRequestedInQueryString = false;
     }
   }
 
-  CDBDebug("allDimensionsAreAsRequestedInQueryString %d", allDimensionsAreAsRequestedInQueryString);
-  if (allDimensionsAreAsRequestedInQueryString) {
+  CDBDebug("allNonFixedDimensionsAreAsRequestedInQueryString %d", allNonFixedDimensionsAreAsRequestedInQueryString);
+  if (allNonFixedDimensionsAreAsRequestedInQueryString) {
     srvParam->setCacheControlOption(CSERVERPARAMS_CACHE_CONTROL_OPTION_FULLYCACHEABLE);
   } else {
     srvParam->setCacheControlOption(CSERVERPARAMS_CACHE_CONTROL_OPTION_SHORTCACHE);

--- a/adagucserverEC/CRequest.cpp
+++ b/adagucserverEC/CRequest.cpp
@@ -1153,12 +1153,12 @@ int CRequest::fillDimValuesForDataSource(CDataSource *dataSource, CServerParams 
     for (size_t i = 0; i < dataSource->cfgLayer->Dimension.size(); i++) {
       if (!dataSource->cfgLayer->Dimension[i]->attr.fixvalue.empty()) {
         CT::string dimName(dataSource->cfgLayer->Dimension[i]->value.c_str());
-        CT::string forceValue = dataSource->cfgLayer->Dimension[i]->attr.fixvalue;
+        CT::string fixedValue = dataSource->cfgLayer->Dimension[i]->attr.fixvalue;
         dimName.toLowerCaseSelf();
         for (auto & requiredDim : dataSource->requiredDims) {
           if (requiredDim->name.equals(&dimName)) {
-            CDBDebug("Forcing dimension %s from %s to %s", dimName.c_str(), requiredDim->value.c_str(), forceValue.c_str());
-            requiredDim->value = forceValue;
+            CDBDebug("Forcing dimension %s from %s to %s", dimName.c_str(), requiredDim->value.c_str(), fixedValue.c_str());
+            requiredDim->value = fixedValue;
             requiredDim->hasFixedValue = true;
             break;
           }

--- a/adagucserverEC/CRequest.cpp
+++ b/adagucserverEC/CRequest.cpp
@@ -1715,7 +1715,7 @@ int CRequest::process_all_layers() {
       if (pszADAGUCWriteToFile != NULL) {
         CReadFile::write(pszADAGUCWriteToFile, XMLDocument.c_str(), XMLDocument.length());
       } else {
-        printf("%s%c%c\n", "Content-Type:text/xml", 13, 10);
+        printf("%s%s%c%c\n", "Content-Type:text/xml", srvParam->getCacheControlHeader(CSERVERPARAMS_CACHE_CONTROL_OPTION_SHORTCACHE).c_str(), 13, 10);
         printf("%s", XMLDocument.c_str());
       }
       return 0;

--- a/adagucserverEC/CServerParams.cpp
+++ b/adagucserverEC/CServerParams.cpp
@@ -652,7 +652,6 @@ int CServerParams::parseConfigFile(CT::string &pszConfigFile, std::vector<CServe
 
 CT::string CServerParams::getCacheControlHeader(int mode) {
   if (cfg != nullptr && cfg->Settings.size() == 1) {
-    int cacheAge = 0;
     CT::string cacheString = "\r\nCache-Control:max-age=";
     if (mode == CSERVERPARAMS_CACHE_CONTROL_OPTION_SHORTCACHE) {
       if (!cfg->Settings[0]->attr.cache_age_volatileresources.empty()) {

--- a/adagucserverEC/Definitions.h
+++ b/adagucserverEC/Definitions.h
@@ -28,7 +28,7 @@
 #ifndef Definitions_H
 #define Definitions_H
 
-#define ADAGUCSERVER_VERSION "2.14.1" // Please also update in the Dockerfile to the same version
+#define ADAGUCSERVER_VERSION "2.14.2" // Please also update in the Dockerfile to the same version
 
 // CConfigReaderLayerType
 #define CConfigReaderLayerTypeUnknown 0

--- a/data/config/datasets/adaguc.tests.cacheheader.xml
+++ b/data/config/datasets/adaguc.tests.cacheheader.xml
@@ -30,9 +30,19 @@
     <FilePath filter="^nc_5D_.*\.nc$">{ADAGUC_PATH}/data/datasets/netcdf_5dims/</FilePath>
     <Variable>data</Variable>
     <Styles>testdata</Styles>
-    
   </Layer>
 
-  
+  <Layer type="database">
+    <Name>data_with_fixed</Name>
+    <FilePath filter="^nc_5D_.*\.nc$">{ADAGUC_PATH}/data/datasets/netcdf_5dims/</FilePath>
+    <Dimension name="time">time</Dimension>
+    <Dimension name="member" hidden="true" fixvalue="member4">member</Dimension>
+    <Dimension name="height">elevation</Dimension>
+    <Variable>data</Variable>
+    <Styles>testdata</Styles>
+  </Layer>
+
+
+
   <!-- End of configuration /-->
 </Configuration>

--- a/data/config/datasets/adaguc.tests.cacheheader.xml
+++ b/data/config/datasets/adaguc.tests.cacheheader.xml
@@ -27,6 +27,7 @@
   </Style>
   
   <Layer type="database">
+    <Name>data</Name>
     <FilePath filter="^nc_5D_.*\.nc$">{ADAGUC_PATH}/data/datasets/netcdf_5dims/</FilePath>
     <Variable>data</Variable>
     <Styles>testdata</Styles>

--- a/tests/AdagucTests/TestWCS.py
+++ b/tests/AdagucTests/TestWCS.py
@@ -302,3 +302,21 @@ class TestWCS(unittest.TestCase):
     self.assertEqual(status, 0)
     self.assertTrue("Content-Type:application/netcdf" in headers)
     self.assertTrue("Cache-Control:max-age=60" in headers)
+
+    # Test AAIgrid response format
+    status, data, headers = AdagucTestTools().runADAGUCServer(
+      "SERVICE=WCS&request=GetCoverage&coverage=data&crs=EPSG%3A4326&format=aaigrid&bbox=0,50,10,60&width=100&height=100",
+      {"ADAGUC_CONFIG": config}
+    )
+    self.assertEqual(status, 0)
+    self.assertTrue("Content-Type:text/plain" in headers)
+    self.assertTrue("Cache-Control:max-age=60" in headers)
+
+    # Test AAIgrid response format
+    status, data, headers = AdagucTestTools().runADAGUCServer(
+      "SERVICE=WCS&request=GetCoverage&coverage=data&crs=EPSG%3A4326&format=aaigrid&bbox=0,50,10,60&width=100&height=100&time=2017-01-01T00:05:00Z&DIM_member=member3&elevation=5000",
+      {"ADAGUC_CONFIG": config}
+    )
+    self.assertEqual(status, 0)
+    self.assertTrue("Content-Type:text/plain" in headers)
+    self.assertTrue("Cache-Control:max-age=7200" in headers)

--- a/tests/AdagucTests/TestWCS.py
+++ b/tests/AdagucTests/TestWCS.py
@@ -64,8 +64,14 @@ class TestWCS(unittest.TestCase):
                                                               env=self.env, args=["--report"])
     AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
     self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue(), AdagucTestTools(
-    ).readfromfile(self.expectedoutputsspath + filename))
+    # Different gdal versions give different spaces in the output.
+    # Compare in a way where any sequence of whitespace characters is equivalent
+    # This means that newlines (which are important?) are not compared
+    test_output = data.getvalue()
+    expected_output = AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
+    test_output = ' '.join(test_output.decode("utf-8").split())
+    expected_output = ' '.join(expected_output.decode("utf-8").split())
+    self.assertEqual(test_output, expected_output)
 
   def test_WCSGetCoverageNetCDF3_testdatanc(self):
     """

--- a/tests/AdagucTests/TestWMS.py
+++ b/tests/AdagucTests/TestWMS.py
@@ -2400,3 +2400,41 @@ class TestWMS(unittest.TestCase):
         self.assertEqual(
             headers, ["Content-Type:image/png", "Cache-Control:max-age=60"]
         )
+
+        #### From here, dimension 'member' is fixed to 'member4'
+        # If we query member with same value as what it is fixed to, we get long cache
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data_with_fixed&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=2017-01-01T00:05:00Z&DIM_member=member4&elevation=5000",
+            {"ADAGUC_CONFIG": config},
+        )
+        self.assertEqual(
+            headers, ["Content-Type:image/png", "Cache-Control:max-age=7200"]
+        )
+
+        # If we query member with different value as what it is fixed to, we get long cache. Fixed values wins from queried value.
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data_with_fixed&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=2017-01-01T00:05:00Z&DIM_member=member2&elevation=5000",
+            {"ADAGUC_CONFIG": config},
+        )
+        self.assertEqual(
+            headers, ["Content-Type:image/png", "Cache-Control:max-age=7200"]
+        )
+
+        # If we don't provide query at all for member, we should get long cache
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data_with_fixed&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=2017-01-01T00:05:00Z&elevation=5000",
+            {"ADAGUC_CONFIG": config},
+        )
+        self.assertEqual(
+            headers, ["Content-Type:image/png", "Cache-Control:max-age=7200"]
+        )
+
+        # Unfixed, unprovided dimension should still result in short cache
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data_with_fixed&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=2017-01-01T00:05:00Z",
+            {"ADAGUC_CONFIG": config},
+        )
+        self.assertEqual(
+            headers, ["Content-Type:image/png", "Cache-Control:max-age=60"]
+        )
+        AdagucTestTools().writetofile("test1.png", data.getvalue())


### PR DESCRIPTION
- Fix issue where the wrong dimension was forced to a value
- Add Cache-Control header to WCS requests (DescribeCoverage and GetCoverage)
- Fix Cache-control when dimensions are forced to a value
- Make AAIGRID comparison looser (ignore whitespace)
- Add unit test for Cache-Control headers for WCS AAIGRID format