### PR TITLE
Remove basetype.

### DIFF
--- a/hclasses/CTBaseType.h
+++ b/hclasses/CTBaseType.h
@@ -62,36 +62,6 @@ namespace CT {
     StackList &operator=(const StackList &) = default;
     StackList &operator=(StackList &&) = default;
   };
-
-  /**
-   * Basetype object
-   */
-  class basetype {
-  public:
-    virtual void init() = 0;
-    virtual ~basetype() {}
-    int id;
-    size_t count;
-    basetype *next, *prev, *start, *end; /* For linked list */
-  };
-
-  /**
-   * Create a linked list of objects of type basetype
-   * @param the object array to linke
-   * @param nr the length of the array
-   */
-  template <class T> void CTlink(T *object, int nr) {
-    for (int j = 0; j < nr; j++) {
-      object[j].next = &object[j + 1];
-      object[j + 1].prev = &object[j];
-      object[j].start = &object[0];
-      object[j].end = &object[nr];
-    }
-    object[0].prev = NULL;
-    object[nr].next = NULL;
-    object[nr].start = &object[0];
-    object[nr].end = &object[nr];
-  }
 }; /* namespace CT */
 
 #endif

--- a/hclasses/CTString.cpp
+++ b/hclasses/CTString.cpp
@@ -139,7 +139,6 @@ namespace CT {
       strings[j].count = n;
       delete token;
     }
-    CTlink(strings, n);
     return strings;
   };
 

--- a/hclasses/CTString.h
+++ b/hclasses/CTString.h
@@ -34,7 +34,9 @@
 #define CT_MAX_NUM_CHARACTERS_FOR_NUMERIC 39
 namespace CT {
 
-  class string : public basetype {
+  class string {
+  public:
+    size_t count;
   private:
     char stackValue[CTSTRINGSTACKLENGTH + 1];
     int allocated;

--- a/hclasses/CTStringRef.cpp
+++ b/hclasses/CTStringRef.cpp
@@ -19,7 +19,7 @@ namespace CT {
     assign(data, length);
   }
 
-  CT::stringref::stringref(CT::stringref const &f) : basetype(f) {
+  CT::stringref::stringref(CT::stringref const &f) {
     init();
     _length = f._length;
     constdata = f.constdata;

--- a/hclasses/CTStringRef.h
+++ b/hclasses/CTStringRef.h
@@ -33,7 +33,7 @@ namespace CT {
   /**
    * Read only class of string
    */
-  class stringref : public basetype {
+  class stringref {
   private:
     void init();
 


### PR DESCRIPTION
Removed `basetype` from `CT::string`. Kept `count` for now.