### PR TITLE
Fixed quantizehigh error; adapted test

### DIFF
--- a/CCDFDataModel/CTime.cpp
+++ b/CCDFDataModel/CTime.cpp
@@ -913,9 +913,10 @@ double CTime::quantizeTimeToISO8601(double offsetOrig, CT::string period, CT::st
       date.hour = origH - restH;
       offsetLow = thisTime->dateToOffset(date);
       if (restH > 0) {
-        date.hour = date.hour + restH;
+        offsetHigh = offsetLow + H * 3600;
+      } else {
+        offsetHigh = offsetLow;
       }
-      offsetHigh = thisTime->dateToOffset(date);
     } else if (hmsPart.indexOf("M") != -1) { // 5M
       hmsPart.replaceSelf("M", "");
       int M = hmsPart.toInt();
@@ -925,9 +926,12 @@ double CTime::quantizeTimeToISO8601(double offsetOrig, CT::string period, CT::st
       date.minute = origM - restM;
       offsetLow = thisTime->dateToOffset(date);
       if (restM > 0) {
-        date.minute = date.minute + M;
+        // date.minute = date.minute + M;
+        offsetHigh = offsetLow + 60 * M;
+      } else {
+        offsetHigh = offsetLow;
       }
-      offsetHigh = thisTime->dateToOffset(date);
+      // offsetHigh = thisTime->dateToOffset(date);
     } else if (hmsPart.indexOf("S") != -1) { // 30S
       hmsPart.replaceSelf("S", "");
       int S = hmsPart.toInt();
@@ -937,8 +941,10 @@ double CTime::quantizeTimeToISO8601(double offsetOrig, CT::string period, CT::st
       offsetLow = thisTime->dateToOffset(date);
       if (restS > 0) {
         date.second = origS + restS;
+        offsetHigh = offsetLow + S;
+      } else {
+        offsetHigh = offsetLow;
       }
-      offsetHigh = thisTime->dateToOffset(date);
     }
 
   } else { // Contains YMD

--- a/CCDFDataModel/CTime.cpp
+++ b/CCDFDataModel/CTime.cpp
@@ -926,12 +926,10 @@ double CTime::quantizeTimeToISO8601(double offsetOrig, CT::string period, CT::st
       date.minute = origM - restM;
       offsetLow = thisTime->dateToOffset(date);
       if (restM > 0) {
-        // date.minute = date.minute + M;
         offsetHigh = offsetLow + 60 * M;
       } else {
         offsetHigh = offsetLow;
       }
-      // offsetHigh = thisTime->dateToOffset(date);
     } else if (hmsPart.indexOf("S") != -1) { // 30S
       hmsPart.replaceSelf("S", "");
       int S = hmsPart.toInt();

--- a/data/datasets/quantize_high/csvexample_time06.csv
+++ b/data/datasets/quantize_high/csvexample_time06.csv
@@ -1,0 +1,3 @@
+# time=2018-12-04T12:50:00Z
+lat,lon,Name,Index,ff,dd
+48.1,0.25,"Station",1,4,0

--- a/data/datasets/quantize_high/csvexample_time07.csv
+++ b/data/datasets/quantize_high/csvexample_time07.csv
@@ -1,0 +1,3 @@
+# time=2018-12-04T12:57:06Z
+lat,lon,Name,Index,ff,dd
+48.1,0.25,"Station",1,4,0

--- a/tests/AdagucTests/TestWMS.py
+++ b/tests/AdagucTests/TestWMS.py
@@ -1569,7 +1569,7 @@ class TestWMS(unittest.TestCase):
 
         filename = "testWMSGetCapabilities_quantizehigh.xml"
         status, data, headers = AdagucTestTools().runADAGUCServer(
-            "DATASET=adaguc.tests.quantizelow&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities",
+            "DATASET=adaguc.tests.quantizehigh&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities",
             env=env,
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())

--- a/tests/expectedoutputs/TestWMS/testWMSGetCapabilities_quantizehigh.xml
+++ b/tests/expectedoutputs/TestWMS/testWMSGetCapabilities_quantizehigh.xml
@@ -119,7 +119,7 @@
 <BoundingBox CRS="EPSG:40000" minx="21344.930005" miny="-4891867.568064" maxx="21344.930005" maxy="-4891865.568064" />
 <BoundingBox CRS="EPSG:900913" minx="27829.872698" miny="6123506.170632" maxx="27829.872698" maxy="6123508.170632" />
 <BoundingBox CRS="EPSG:3067" minx="-1481251.794314" miny="5683942.666186" maxx="-1481251.794314" maxy="5683944.666186" />
-<Dimension name="time" units="ISO8601" default="2018-12-04T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2018-12-04T12:10:00Z/2018-12-04T12:40:00Z/PT10M</Dimension>
+<Dimension name="time" units="ISO8601" default="2018-12-04T13:00:00Z" multipleValues="1" nearestValue="0" current="1">2018-12-04T12:10:00Z/2018-12-04T13:00:00Z/PT10M</Dimension>
    <Style>    <Name>default</Name>    <Title>default</Title>    <Abstract>default</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.quantizehigh&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=wind&amp;format=image/png&amp;STYLE=default"/>    </LegendURL>  </Style></Layer>
     </Layer>
   </Capability>


### PR DESCRIPTION
Fixes an error in quantizehigh for times, where a time that would round up to the next hour would be incorrectly calculated. Fixes NOAA GOES-16 images missing on every HH:00 except 00:00