### PR TITLE
Statuscode is now kept to 200 for GetCapabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ USER root
 LABEL maintainer="adaguc@knmi.nl"
 
 # Version should be same as in Definitions.h
-LABEL version="2.23.0"
+LABEL version="2.24.0"
 
 # Try to update image packages
 RUN apt-get -q -y update \

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+**Version 2.24.0 2024-07-09**
+- Statuscode is now kept to 200 for GetCapabilities and the corresponding error message for the specific layer is embedded in the document
+
 **Version 2.23.0 2024-06-07**
 - DataPostProcessor `windspeed_knots_to_ms` was added to convert knots to meters per second, use `<DataPostProc algorithm="windspeed_knots_to_ms"/>`
 - TimeSeries fetching with GetFeatureInfo now support multimodel ensembles

--- a/adagucserverEC/CRequest.cpp
+++ b/adagucserverEC/CRequest.cpp
@@ -1700,9 +1700,19 @@ int CRequest::process_all_layers() {
           break;
         }
       }
+
+      // This layer was not found in the configuration
       if (layerNo == srvParam->cfg->Layer.size()) {
-        CDBError("Layer [%s] not found", srvParam->WMSLayers[j].c_str());
-        setStatusCode(HTTP_STATUSCODE_404_NOT_FOUND);
+
+        // Do not set status code for a missing layer to 404 when we request GetCapabilities
+        // GetCapabilities should return statuscode 200 with layers that work.
+        if (srvParam->requestType != REQUEST_WMS_GETCAPABILITIES && srvParam->requestType != REQUEST_WCS_GETCAPABILITIES && srvParam->requestType != REQUEST_WCS_DESCRIBECOVERAGE) {
+          setStatusCode(HTTP_STATUSCODE_404_NOT_FOUND);
+          CDBError("Layer [%s] not found", srvParam->WMSLayers[j].c_str());
+        } else {
+          CDBDebug("Layer [%s] not found", srvParam->WMSLayers[j].c_str());
+        }
+        // Return 1, this layer was not found in the configuration
         return 1;
       }
     }
@@ -2445,7 +2455,7 @@ int CRequest::process_querystring() {
   }
 
   queryString.decodeURLSelf();
-  // CDBDebug("QueryString: \"%s\"",queryString.c_str());
+  // CDBDebug("QueryString: \"%s\"", queryString.c_str());
   CT::string *parameters = queryString.splitToArray("&");
 
 #ifdef CREQUEST_DEBUG

--- a/adagucserverEC/Definitions.h
+++ b/adagucserverEC/Definitions.h
@@ -28,7 +28,7 @@
 #ifndef Definitions_H
 #define Definitions_H
 
-#define ADAGUCSERVER_VERSION "2.23.0" // Please also update in the Dockerfile to the same version
+#define ADAGUCSERVER_VERSION "2.24.0" // Please also update in the Dockerfile to the same version
 
 // CConfigReaderLayerType
 #define CConfigReaderLayerTypeUnknown 0

--- a/data/config/datasets/adaguc.tests.datasetwithmisconfiguredlayer.xml
+++ b/data/config/datasets/adaguc.tests.datasetwithmisconfiguredlayer.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+  <!-- Custom styles -->
+
+
+
+
+  <Layer type="database">
+    
+    <FilePath filter="">{ADAGUC_PATH}data/datasets/testdata.nc</FilePath>
+    <Variable>testdata</Variable>
+    <Styles>auto</Styles>
+    <DataPostProc algorithm="ax+b" a="600" b="-20" units="meter" />
+  </Layer>
+
+
+  <Layer type="database">
+    
+    <FilePath filter="">{ADAGUC_PATH}data/datasets/testdatamisconfigured.nc</FilePath>
+    <Variable>testdatamisconfigured</Variable>
+    <Styles>auto</Styles>
+    <DataPostProc algorithm="ax+b" a="600" b="-20" units="meter" />
+  </Layer>
+
+
+
+
+  <!-- End of configuration /-->
+</Configuration>

--- a/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDBPathFileWithNonMatchingPathGetCapabilities.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDBPathFileWithNonMatchingPathGetCapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 2.13.1, of Sep 26 2023 11:14:12 </Keyword>
+            <Keyword>ADAGUCServer version 2.23.0, of Jul  9 2024 12:13:41 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testScanPathSubfolderSuffix&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -60,6 +60,8 @@
         <UserDefinedSymbolization SupportSLD="1" />
 <Layer>
 <Title>WMS of  adaguc.testScanPathSubfolderSuffix</Title>
+
+<!-- Note: Error: Layer [RAD_NL25_PCP_CM] is misconfigured -->
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_KMDS_PointNetCDF_pointstylepoint.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_KMDS_PointNetCDF_pointstylepoint.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 2.14.0, of Nov 30 2023 10:09:29 </Keyword>
+            <Keyword>ADAGUCServer version 2.23.0, of Jul  9 2024 12:13:41 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -94,6 +94,10 @@
 <BoundingBox CRS="EPSG:40000" minx="-9555333.229813" miny="-10285561.445145" maxx="1280134.942825" maxy="-1473840.584239" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
+
+<!-- Note: Error: Layer [stationname] is misconfigured -->
+
+<!-- Note: Error: Layer [height] is misconfigured -->
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>dd</Name>
 <Title>windrichting [graden]</Title>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_multidimnc_autostyle.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_multidimnc_autostyle.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 2.13.7, of Nov  1 2023 11:45:57 </Keyword>
+            <Keyword>ADAGUCServer version 2.23.0, of Jul  9 2024 12:13:41 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -96,6 +96,10 @@
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:4326" minx="89.511108" miny="-180.494446" maxx="-90.488892" maxy="179.505554" />
+
+<!-- Note: Error: Layer [geojsonbaselayer] is misconfigured -->
+
+<!-- Note: Error: Layer [geojsonoverlay] is misconfigured -->
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>data</Name>
 <Title>data</Title>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_no_error_on_existing_dataset_misconfigured_layer.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_no_error_on_existing_dataset_misconfigured_layer.xml
@@ -10,14 +10,14 @@
      >
     <Service>
         <Name>WMS</Name>
-        <Title>AutoResource testdata.nc</Title>
+        <Title>adaguc.tests.datasetwithmisconfiguredlayer</Title>
         <Abstract>This service demonstrates how the ADAGUC server can be used to create OGC services.</Abstract>
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
             <Keyword>ADAGUCServer version 2.23.0, of Jul  9 2024 12:13:41 </Keyword>
         </KeywordList>
-        <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;"/>
+        <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datasetwithmisconfiguredlayer&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
           
         </ContactInformation>
@@ -30,7 +30,7 @@
         <Request>
             <GetCapabilities>
                 <Format>text/xml</Format>
-                <DCPType><HTTP><Get><OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;"/></Get></HTTP></DCPType>
+                <DCPType><HTTP><Get><OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datasetwithmisconfiguredlayer&amp;SERVICE=WMS&amp;"/></Get></HTTP></DCPType>
             </GetCapabilities>
             <GetMap>
                 <Format>image/png</Format>
@@ -41,7 +41,7 @@
                 <Format>image/gif</Format>
                 <Format>image/jpeg</Format>
                 <!--<Format>image/webp</Format>-->
-                <DCPType><HTTP><Get><OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;"/></Get></HTTP></DCPType>
+                <DCPType><HTTP><Get><OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datasetwithmisconfiguredlayer&amp;SERVICE=WMS&amp;"/></Get></HTTP></DCPType>
             </GetMap>
             <GetFeatureInfo>
                 <Format>image/png</Format>
@@ -49,7 +49,7 @@
                 <Format>text/html</Format>
                 <Format>text/xml</Format>
                 <Format>application/json</Format>
-                <DCPType><HTTP><Get><OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;"/></Get></HTTP></DCPType>
+                <DCPType><HTTP><Get><OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datasetwithmisconfiguredlayer&amp;SERVICE=WMS&amp;"/></Get></HTTP></DCPType>
             </GetFeatureInfo>
         </Request>
         <Exception>
@@ -59,7 +59,7 @@
         </Exception>
         <UserDefinedSymbolization SupportSLD="1" />
 <Layer>
-<Title>WMS of  AutoResource testdata.nc</Title>
+<Title>WMS of  adaguc.tests.datasetwithmisconfiguredlayer</Title>
 <CRS>EPSG:3411</CRS>
 <CRS>EPSG:3412</CRS>
 <CRS>EPSG:3575</CRS>
@@ -96,10 +96,6 @@
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
 <BoundingBox CRS="EPSG:3067" minx="-3107150.509005" miny="4216726.250381" maxx="783036.427152" maxy="8092286.994278" />
 <BoundingBox CRS="EPSG:28992" minx="-1500000.013393" miny="1999999.970833" maxx="1500000.013393" maxy="-999999.970833" />
-
-<!-- Note: Error: Layer [geojsonbaselayer] is misconfigured -->
-
-<!-- Note: Error: Layer [geojsonoverlay] is misconfigured -->
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>testdata</Name>
 <Title>Testdata (testdata)</Title>
@@ -126,7 +122,9 @@
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
 <BoundingBox CRS="EPSG:3067" minx="-3107150.509005" miny="4216726.250381" maxx="783036.427152" maxy="8092286.994278" />
 <BoundingBox CRS="EPSG:28992" minx="-1500000.013393" miny="1999999.970833" maxx="1500000.013393" maxy="-999999.970833" />
-   <Style>    <Name>testdata_style_1/nearest</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_1/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_1/bilinear</Name>    <Title>Rainbow colors, bilinear</Title>    <Abstract>Drawing with rainbow colors, bilinear interpolation</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_1/bilinear"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_1/nearestcontour</Name>    <Title>Rainbow colors, contours</Title>    <Abstract>Drawing with rainbow colors, contours</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_1/nearestcontour"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_1/shadedcontour</Name>    <Title>Rainbow colors, shading and contours</Title>    <Abstract>Drawing with rainbow colors, shading and contours</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_1/shadedcontour"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_2/nearest</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_2/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_2/bilinear</Name>    <Title>Rainbow colors, bilinear</Title>    <Abstract>Drawing with rainbow colors, bilinear interpolation</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_2/bilinear"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_2/nearestcontour</Name>    <Title>Rainbow colors, contours</Title>    <Abstract>Drawing with rainbow colors, contours</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_2/nearestcontour"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_2/shadedcontour</Name>    <Title>Rainbow colors, shading and contours</Title>    <Abstract>Drawing with rainbow colors, shading and contours</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_2/shadedcontour"/>    </LegendURL>  </Style>   <Style>    <Name>auto/nearest</Name>    <Title>auto/nearest</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>auto/bilinear</Name>    <Title>auto/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/bilinear"/>    </LegendURL>  </Style>   <Style>    <Name>auto/point</Name>    <Title>auto/point</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/point"/>    </LegendURL>  </Style>   <Style>    <Name>auto/barb</Name>    <Title>auto/barb</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/barb"/>    </LegendURL>  </Style></Layer>
+   <Style>    <Name>auto/nearest</Name>    <Title>auto/nearest</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datasetwithmisconfiguredlayer&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>auto/bilinear</Name>    <Title>auto/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datasetwithmisconfiguredlayer&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/bilinear"/>    </LegendURL>  </Style>   <Style>    <Name>auto/point</Name>    <Title>auto/point</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datasetwithmisconfiguredlayer&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/point"/>    </LegendURL>  </Style>   <Style>    <Name>auto/barb</Name>    <Title>auto/barb</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datasetwithmisconfiguredlayer&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/barb"/>    </LegendURL>  </Style></Layer>
+
+<!-- Note: Error: Layer [testdatamisconfigured] is misconfigured -->
     </Layer>
   </Capability>
 </WMS_Capabilities>


### PR DESCRIPTION
- Statuscode is now kept to 200 for GetCapabilities, also when a layer is misconfigured or has missing data.
- If a Layer is misconfigured, a comment is placed inside the XML with the layer name


See test results for details

Closes https://github.com/KNMI/adaguc-server/issues/388