### PR TITLE
Only clean psql db when using psql

### DIFF
--- a/python/lib/adaguc/AdagucTestTools.py
+++ b/python/lib/adaguc/AdagucTestTools.py
@@ -149,7 +149,8 @@ class AdagucTestTools:
         Some tests fail when using postgres if there is already data present in the database.
         Running the test separately works."""
 
-        if adaguc_db := os.getenv("ADAGUC_DB", None):
+        adaguc_db = os.getenv("ADAGUC_DB", None)
+        if adaguc_db and not adaguc_db.endswith(".db"):
             subprocess.run(
                 [
                     "psql",


### PR DESCRIPTION
The environment variable `ADAGUC_DB` contains either `/path/to/sqlite.db` or `connection string for psql`. If `ADAGUC_DB` ends with `.db`, we assume it's sqlite. See https://github.com/KNMI/adaguc-server/blob/master/adagucserverEC/CDBFactory.cpp#L39.

I've now added this check in the testing code to decide if we need to run psql cleaning.