### PR TITLE
Change brotli quality for Redis cache to 4

### DIFF
--- a/python/lib/adaguc/runAdaguc.py
+++ b/python/lib/adaguc/runAdaguc.py
@@ -307,7 +307,7 @@ async def response_to_cache(redis_pool, key, headers: str, data):
             entrytime
             + f"{len(cacheable_headers_json):06d}".encode("utf-8")
             + cacheable_headers_json
-            + brotli.compress(data.getvalue()),
+            + brotli.compress(data.getvalue(), quality=4),
             ex=ttl,
         )
         await redis_client.aclose()

--- a/python/python_fastapi_server/routers/caching_middleware.py
+++ b/python/python_fastapi_server/routers/caching_middleware.py
@@ -51,7 +51,7 @@ async def response_to_cache(redis_pool, request, headers, data, ex: int):
     entrytime = f"{calendar.timegm(datetime.utcnow().utctimetuple()):10d}".encode(
         "utf-8"
     )
-    compressed_data = brotli.compress(data)
+    compressed_data = brotli.compress(data, quality=4)
     if len(compressed_data) < MAX_SIZE_FOR_CACHING:
         redis_client = redis.Redis(connection_pool=redis_pool)
         await redis_client.set(
@@ -59,7 +59,7 @@ async def response_to_cache(redis_pool, request, headers, data, ex: int):
             entrytime
             + f"{len(headers_json):06d}".encode("utf-8")
             + headers_json
-            + brotli.compress(data),
+            + compressed_data,
             ex=ex,
         )
         await redis_client.aclose()


### PR DESCRIPTION
Change brotli quality for Redis cache to 4, as the default quality of 11 is extremely slow.