### PR TITLE
Allow some large differences in windbarb tests

### DIFF
--- a/tests/AdagucTests/TestWMS.py
+++ b/tests/AdagucTests/TestWMS.py
@@ -2084,7 +2084,7 @@ class TestWMS(unittest.TestCase):
             AdagucTestTools().compareImage(
                 self.expectedoutputsspath + filename,
                 self.testresultspath + filename,
-                3,
+                37,
                 0.1,
             )
         )
@@ -2115,7 +2115,7 @@ class TestWMS(unittest.TestCase):
             AdagucTestTools().compareImage(
                 self.expectedoutputsspath + filename,
                 self.testresultspath + filename,
-                3,
+                37,
                 0.1,
             )
         )


### PR DESCRIPTION
The test output pictures look the same, this is with changes highlighted:
![UntitledDiff (1)](https://github.com/user-attachments/assets/fa1ec8fa-bf38-4466-8509-627b20cb7432)
![UntitledDiff](https://github.com/user-attachments/assets/0962b507-9882-4014-b1aa-5ba2ba635ce3)
