### PR TITLE
Run tests against PostgreSQL by default

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,18 @@ jobs:
             runner: ubuntu-24.04
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
+
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: adaguc
+          POSTGRES_PASSWORD: adaguc
+          POSTGRES_DB: adaguc
+        ports:
+        - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
       - name: Prepare
         run: |
@@ -59,6 +71,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ env.REGISTRY_IMAGE }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          network: ${{ job.container.network }}
 
       - name: Run Trivy vulnerability scanner
         if: matrix.platform == 'linux/amd64'  # Run trivy only once

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,7 +31,7 @@ jobs:
           POSTGRES_PASSWORD: adaguc
           POSTGRES_DB: adaguc
         ports:
-        - 5432:5432
+        - 54321:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
@@ -75,6 +75,8 @@ jobs:
           tags: ${{ env.REGISTRY_IMAGE }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           network: host
+          build-args: |
+            TEST_IN_CONTAINER=github_build
 
       - name: Run Trivy vulnerability scanner
         if: matrix.platform == 'linux/amd64'  # Run trivy only once

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,6 +45,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            network=host
 
       - name: Log in to Docker Hub
         if: github.repository == 'KNMI/adaguc-server'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -74,7 +74,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ env.REGISTRY_IMAGE }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-          network: ${{ job.container.network }}
+          network: host
 
       - name: Run Trivy vulnerability scanner
         if: matrix.platform == 'linux/amd64'  # Run trivy only once

--- a/Docker/docker-compose-test.yml
+++ b/Docker/docker-compose-test.yml
@@ -1,0 +1,17 @@
+services:
+  adaguc-test-db:
+    image: postgres:13
+    container_name: adaguc-test-db
+    hostname: adaguc-test-db
+    environment:
+      - "POSTGRES_USER=adaguc"
+      - "POSTGRES_PASSWORD=adaguc"
+      - "POSTGRES_DB=adaguc"
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200k"
+        max-file: "10"
+    ports:
+      - 54321:5432

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,8 +87,6 @@ COPY python /adaguc/adaguc-server-master/python
 ######### Third stage, test ############
 FROM base AS test
 
-ARG TEST_IN_CONTAINER
-ENV TEST_IN_CONTAINER=${TEST_IN_CONTAINER:-local_build}
 
 COPY requirements-dev.txt /adaguc/adaguc-server-master/requirements-dev.txt
 RUN pip install --no-cache-dir -r requirements-dev.txt
@@ -96,6 +94,10 @@ RUN pip install --no-cache-dir -r requirements-dev.txt
 COPY tests /adaguc/adaguc-server-master/tests
 COPY runtests.sh /adaguc/adaguc-server-master/runtests.sh
 COPY runtests_psql.sh /adaguc/adaguc-server-master/runtests_psql.sh
+
+# Determine if we're building in github actions or via a local docker build
+ARG TEST_IN_CONTAINER
+ENV TEST_IN_CONTAINER=${TEST_IN_CONTAINER:-local_build}
 
 # Run adaguc-server functional and regression tests. See also `./doc/developing/testing.md`
 RUN bash runtests_psql.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,8 +98,7 @@ COPY runtests.sh /adaguc/adaguc-server-master/runtests.sh
 COPY runtests_psql.sh /adaguc/adaguc-server-master/runtests_psql.sh
 
 # Run adaguc-server functional and regression tests. See also `./doc/developing/testing.md`
-RUN bash runtests.sh
-# RUN bash runtests_psql.sh
+RUN bash runtests_psql.sh
 
 # Create a file indicating that the test succeeded. This file is used in the final stage
 RUN echo "TESTSDONE" >  /adaguc/adaguc-server-master/testsdone.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,8 @@ COPY python /adaguc/adaguc-server-master/python
 ######### Third stage, test ############
 FROM base AS test
 
-ENV TEST_IN_CONTAINER=local_build
+ARG TEST_IN_CONTAINER
+ENV TEST_IN_CONTAINER=${TEST_IN_CONTAINER:-local_build}
 
 COPY requirements-dev.txt /adaguc/adaguc-server-master/requirements-dev.txt
 RUN pip install --no-cache-dir -r requirements-dev.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,10 +85,9 @@ COPY data /adaguc/adaguc-server-master/data
 COPY python /adaguc/adaguc-server-master/python
 
 ######### Third stage, test ############
-# To run the tests against a postgres db, see docs/test_postgesql.md
 FROM base AS test
 
-ENV TEST_IN_CONTAINER=1
+ENV TEST_IN_CONTAINER=local_build
 
 COPY requirements-dev.txt /adaguc/adaguc-server-master/requirements-dev.txt
 RUN pip install --no-cache-dir -r requirements-dev.txt

--- a/tests/starttests_psql.sh
+++ b/tests/starttests_psql.sh
@@ -44,7 +44,7 @@ fi
 
 psql "$ADAGUC_DB" -c "DROP DATABASE IF EXISTS adaguc_test;"
 psql "$ADAGUC_DB" -c "CREATE DATABASE adaguc_test;"
-export ADAGUC_DB="user=adaguc password=adaguc host=${db_host} dbname=adaguc_test"
+export ADAGUC_DB="user=adaguc password=adaguc host=${db_host} dbname=adaguc_test port=54321"
 
 ulimit -c unlimited
 

--- a/tests/starttests_psql.sh
+++ b/tests/starttests_psql.sh
@@ -23,7 +23,10 @@ export ADAGUC_AUTOWMS_DIR=${ADAGUC_PATH}/data/datasets/
 # This assumes you can reach psql on port 5432
 # Tests will use a separate `adaguc_test` database
 # You cannot drop the database you are currently logged in as
-db_host=$([[ "${TEST_IN_CONTAINER}" == 1  ]] && echo "host.docker.internal" || echo "localhost")
+
+# db_host=$([[ "${TEST_IN_CONTAINER}" == 1  ]] && echo "host.docker.internal" || echo "localhost")
+db_host="postgres"
+
 export ADAGUC_DB="user=adaguc password=adaguc host=${db_host} dbname=postgres"
 psql "$ADAGUC_DB" -c "DROP DATABASE IF EXISTS adaguc_test;"
 psql "$ADAGUC_DB" -c "CREATE DATABASE adaguc_test;"

--- a/tests/starttests_psql.sh
+++ b/tests/starttests_psql.sh
@@ -25,7 +25,7 @@ export ADAGUC_AUTOWMS_DIR=${ADAGUC_PATH}/data/datasets/
 # You cannot drop the database you are currently logged in as
 
 # db_host=$([[ "${TEST_IN_CONTAINER}" == 1  ]] && echo "host.docker.internal" || echo "localhost")
-db_host="postgres"
+db_host="localhost"
 
 export ADAGUC_DB="user=adaguc password=adaguc host=${db_host} dbname=postgres"
 psql "$ADAGUC_DB" -c "DROP DATABASE IF EXISTS adaguc_test;"

--- a/tests/starttests_psql.sh
+++ b/tests/starttests_psql.sh
@@ -20,17 +20,28 @@ export ADAGUC_DATASET_DIR=${ADAGUC_PATH}/data/config/datasets/
 export ADAGUC_DATA_DIR=${ADAGUC_PATH}/data/datasets/
 export ADAGUC_AUTOWMS_DIR=${ADAGUC_PATH}/data/datasets/
 
-if [[ $CI == "true" ]]; then
-    # When running in CI, psql will be available on localhost
-    db_host="localhost";
+
+if [[ "${TEST_IN_CONTAINER}" == "github_build" ]]; then
+    db_host="localhost"
+elif [[ "${TEST_IN_CONTAINER}" == "local_build" ]]; then
+    db_host="host.docker.internal"
 else
-    db_host=$([[ "${TEST_IN_CONTAINER}" == 1  ]] && echo "host.docker.internal" || echo "localhost")
+    db_host="localhost"
 fi
 
 # This assumes you can reach psql on port 5432
 # Tests will use a separate `adaguc_test` database
 # You cannot drop the database you are currently logged in as
-export ADAGUC_DB="user=adaguc password=adaguc host=${db_host} dbname=postgres"
+export ADAGUC_DB="user=adaguc password=adaguc host=${db_host} dbname=postgres port=54321"
+
+psql "${ADAGUC_DB}" -c "SELECT 1";
+if [[ $? -ne 0 ]]; then
+    echo ""
+    echo -e "No Adaguc test database available. Please run:\n"
+    echo -e "\tdocker compose -f Docker/docker-compose-test.yml up -Vd"
+    exit 1
+fi
+
 psql "$ADAGUC_DB" -c "DROP DATABASE IF EXISTS adaguc_test;"
 psql "$ADAGUC_DB" -c "CREATE DATABASE adaguc_test;"
 export ADAGUC_DB="user=adaguc password=adaguc host=${db_host} dbname=adaguc_test"

--- a/tests/starttests_psql.sh
+++ b/tests/starttests_psql.sh
@@ -20,13 +20,16 @@ export ADAGUC_DATASET_DIR=${ADAGUC_PATH}/data/config/datasets/
 export ADAGUC_DATA_DIR=${ADAGUC_PATH}/data/datasets/
 export ADAGUC_AUTOWMS_DIR=${ADAGUC_PATH}/data/datasets/
 
+if [[ $CI == "true" ]]; then
+    # When running in CI, psql will be available on localhost
+    db_host="localhost";
+else
+    db_host=$([[ "${TEST_IN_CONTAINER}" == 1  ]] && echo "host.docker.internal" || echo "localhost")
+fi
+
 # This assumes you can reach psql on port 5432
 # Tests will use a separate `adaguc_test` database
 # You cannot drop the database you are currently logged in as
-
-# db_host=$([[ "${TEST_IN_CONTAINER}" == 1  ]] && echo "host.docker.internal" || echo "localhost")
-db_host="localhost"
-
 export ADAGUC_DB="user=adaguc password=adaguc host=${db_host} dbname=postgres"
 psql "$ADAGUC_DB" -c "DROP DATABASE IF EXISTS adaguc_test;"
 psql "$ADAGUC_DB" -c "CREATE DATABASE adaguc_test;"


### PR DESCRIPTION
When building the Adaguc container, we also run the testsuites which need a database to work. The default is SQLite, however there are lots of tests which require PostgreSQL, these tests currently get skipped.

This MR:
- Makes the tests run against PostgreSQL by default.
- Adds an extra `docker-compose-test.yml` which includes a postgres database, to not clash with your local setup.
- The test database runs against port `54321` by default.
- Adds an "is psql running?" check in `starttests_psql.sh` and shows how to setup a local database if needed.

There are three different situations in which the tests can connect to PSQL:
- The build in github actions uses an extra `postgres` service in the CI/CD. The tests will automatically connect to psql on `localhost`, which works in github actions (with `network=host`).
- Doing `docker build ...` on your local machine, the tests will connect to psql on `host.docker.internal`. This should get tested on both linux and macOS (@lukas-phaf). It currently works for me :)
- Doing `bash runtests_psql.sh` on your local machine, the tests will connect to psql on `localhost`.

This could be a first step to deprecate SQLite in Adaguc.
This MR will close https://github.com/KNMI/adaguc-server/issues/400.