### PR TITLE
Fix echotops units

### DIFF
--- a/adagucserverEC/CConvertKNMIH5EchoToppen.cpp
+++ b/adagucserverEC/CConvertKNMIH5EchoToppen.cpp
@@ -137,7 +137,7 @@ int CConvertKNMIH5EchoToppen::convertKNMIH5EchoToppenHeader(CDFObject *cdfObject
     echoToppenVar->dimensionlinks.push_back(dimX);
     echoToppenVar->setType(CDF_FLOAT);
     echoToppenVar->name = CConvertKNMIH5EchoToppen_EchoToppenVar;
-    echoToppenVar->addAttribute(new CDF::Attribute("units", "FL (ft*100)"));
+    echoToppenVar->addAttribute(new CDF::Attribute("units", "FL"));
     echoToppenVar->setAttributeText("grid_mapping", "projection");
   }
   return 0;

--- a/tests/expectedoutputs/TestWMSTimeSeries/test_WMSGetFeatureInfo_KNMIHDF5_echotops_RAD_NL25_ETH_NA_TOPS.json
+++ b/tests/expectedoutputs/TestWMSTimeSeries/test_WMSGetFeatureInfo_KNMIHDF5_echotops_RAD_NL25_ETH_NA_TOPS.json
@@ -1,1 +1,1 @@
-[{"name":"echotops","standard_name":"echotops","feature_name":"echotops_0","units":"FL (ft*100)","point":{"SRS":"EPSG:4326","coords":"5.680000,50.890000"},"dims":"time","data":{"2020-04-30T13:15:00Z":"160.000000"}}]
+[{"name":"echotops","standard_name":"echotops","feature_name":"echotops_0","units":"FL","point":{"SRS":"EPSG:4326","coords":"5.680000,50.890000"},"dims":"time","data":{"2020-04-30T13:15:00Z":"160.000000"}}]


### PR DESCRIPTION
The unit description is wrong or at least confusing (why not `FL (ft/100)`, but even that is not correct).
Remove the explanation, and just leave `FL`.