### PR TITLE
Fixed incorrect time range

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ USER root
 LABEL maintainer="adaguc@knmi.nl"
 
 # Version should be same as in Definitions.h
-LABEL version="3.0.3"
+LABEL version="3.0.4"
 
 # Try to update image packages
 RUN apt-get -q -y update \

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+**Version 3.0.4. 2025-06-03**
+
+- Fixed the (slightly) incorrect formatting of the model data time range for EDR.
+Test is adapted.
+- A print statement was removed.
+
 **Version 3.0.3. 2025-05-14**
 
 - Fixed bug where a multidimensional dataset with a configured `DataBaseTable` could not get queried

--- a/adagucserverEC/Definitions.h
+++ b/adagucserverEC/Definitions.h
@@ -28,7 +28,7 @@
 #ifndef Definitions_H
 #define Definitions_H
 
-#define ADAGUCSERVER_VERSION "3.0.3" // Please also update in the Dockerfile to the same version
+#define ADAGUCSERVER_VERSION "3.0.4" // Please also update in the Dockerfile to the same version
 
 // CConfigReaderLayerType
 #define CConfigReaderLayerTypeUnknown 0

--- a/python/python_fastapi_server/routers/edr_position.py
+++ b/python/python_fastapi_server/routers/edr_position.py
@@ -139,7 +139,6 @@ async def get_point_value(
     custom_dims: list[str] = None,
 ):
     """Returns information in EDR format for a given collection and position"""
-    print("instance %s", instance)
     custom_dims = [] if custom_dims is None else custom_dims
     urlrequest = "&".join(
         [

--- a/python/python_fastapi_server/routers/utils/edr_utils.py
+++ b/python/python_fastapi_server/routers/utils/edr_utils.py
@@ -702,7 +702,7 @@ def get_time_values_for_range(rng: str) -> list[str]:
     if not tstep:
         tstep = 3600
     nsteps = int(timediff / tstep) + 1
-    return [f"R{nsteps}/{iso_start.strftime('%Y-%m-%dT%H:%MZ')}/{step}"]
+    return [f"R{nsteps}/{iso_start.strftime('%Y-%m-%dT%H:%M:%SZ')}/{step}"]
 
 
 VOCAB_ENDPOINT_URL = "https://vocab.nerc.ac.uk/standard_name/"

--- a/python/python_fastapi_server/test_ogc_api_edr.py
+++ b/python/python_fastapi_server/test_ogc_api_edr.py
@@ -84,7 +84,7 @@ def test_collections(client: TestClient):
         "vertical",
         "custom",
     ]
-    assert coll_5d["extent"]["temporal"]["values"][0] == "R6/2017-01-01T00:00Z/PT5M"
+    assert coll_5d["extent"]["temporal"]["values"][0] == "R6/2017-01-01T00:00:00Z/PT5M"
 
     assert "position" in coll_5d["data_queries"]
 


### PR DESCRIPTION
This PR fixes the (slightly) incorrect formatting of the model data time range for EDR.
Test is adapted.
A print statement was removed.