### PR TITLE
Added support for azimuthal_equidistant projection

### DIFF
--- a/CCDFDataModel/CProj4ToCF.h
+++ b/CCDFDataModel/CProj4ToCF.h
@@ -65,6 +65,7 @@ private:
   void initTransverseMercator(CDF::Variable *projectionVariable, std::vector<CProj4ToCF::KVP *> projKVPList);
   void initLAEAPerspective(CDF::Variable *projectionVariable, std::vector<KVP *> projKVPList);
   void initGeosPerspective(CDF::Variable *projectionVariable, std::vector<KVP *> projKVPList);
+  void initAEQDPerspective(CDF::Variable *projectionVariable, std::vector<KVP *> projKVPList);
 
   int convertBackAndFort(const char *projString, CDF::Variable *projectionVariable);
 
@@ -87,10 +88,9 @@ public:
   /**
    * Converts a CF projection variable to a proj4 stringtring to CF mappings
    * @param projectionVariable The variable with CF projection attributes to convert to the proj4 string
-   * @param proj4String The proj4 string which will contain the new proj string after conversion is finished
-   * @return Zero on succes and nonzero on failure
+   * @return The proj4 string which will contain the new proj string after conversion is finished or empty if an error occured
    */
-  int convertCFToProj(CDF::Variable *projectionVariable, CT::string *proj4String);
+  CT::string convertCFToProj(CDF::Variable *projectionVariable);
 
   int __checkProjString(const char *name, const char *string);
   /**

--- a/adagucserverEC/CDataReader.cpp
+++ b/adagucserverEC/CDataReader.cpp
@@ -320,10 +320,9 @@ bool CDataReader::copyCRSFromCFProjectionVariable(CDataSource *dataSource, CDF::
 
   CProj4ToCF proj4ToCF;
   proj4ToCF.debug = true;
-  CT::string projString;
-  int status = proj4ToCF.convertCFToProj(projVar, &projString);
+  CT::string projString = proj4ToCF.convertCFToProj(projVar);
 
-  if (status != 0) {
+  if (projString.empty()) {
     CREPORT_WARN_NODOC(CT::string("Unknown CF conventions projection."), CReportMessage::Categories::GENERAL);
     return false;
   }

--- a/adagucserverEC/CImageWarper.cpp
+++ b/adagucserverEC/CImageWarper.cpp
@@ -568,11 +568,8 @@ std::tuple<CT::string, double> CImageWarper::fixProjection(CT::string projection
         majorAttribute->setData<float>(CDF_FLOAT, semi_major_axis * scaling);
         minorAttribute->setData<float>(CDF_FLOAT, semi_minor_axis * scaling);
 
-        CT::string newProjectionString;
-        int status2 = trans.convertCFToProj(&var, &newProjectionString);
-        //        printf("%s\n", projectionString.c_str());
-        //        printf("%s\n\n", newProjectionString.c_str());
-        if (status2 == 0) return std::make_tuple(newProjectionString, scaling);
+        CT::string newProjectionString = trans.convertCFToProj(&var);
+        if (!newProjectionString.empty()) return std::make_tuple(newProjectionString, scaling);
       }
     }
   }

--- a/adagucserverEC/testadagucserver.cpp
+++ b/adagucserverEC/testadagucserver.cpp
@@ -273,3 +273,25 @@ TEST(CImgRenderFieldVectors, jacobianTransformUWCWDiniMultiplePoints) {
   DOUBLES_EQUAL(resultD.u, -2.288372, 0.001);
   DOUBLES_EQUAL(resultD.v, 7.171310, 0.001);
 }
+
+TEST(CProj4ToCF, azimuthal_equidistant) {
+  CProj4ToCF proj4ToCF;
+  CDF::Variable var;
+  var.setName("azimuthal_equidistant");
+  var.setAttributeText("grid_mapping_name", "azimuthal_equidistant");
+  double longitude_of_projection_origin = 174.7;
+  double latitude_of_projection_origin = -41.2;
+  double earth_radius = 6370997.0;
+  double false_easting = 0.;
+  double false_northing = 0.;
+  var.setAttribute("longitude_of_projection_origin", CDF_DOUBLE, &longitude_of_projection_origin, 1);
+  var.setAttribute("latitude_of_projection_origin", CDF_DOUBLE, &latitude_of_projection_origin, 1);
+  var.setAttribute("earth_radius", CDF_DOUBLE, &earth_radius, 1);
+  var.setAttribute("false_easting", CDF_DOUBLE, &false_easting, 1);
+  var.setAttribute("false_northing", CDF_DOUBLE, &false_northing, 1);
+  CT::string projString = proj4ToCF.convertCFToProj(&var);
+  CDBDebug("projString [%s]", projString.c_str());
+
+  CT::string expected = "+proj=aeqd +lat_0=-41.200000 +lon_0=174.700000 +k_0=1.0 +x_0=0.000000 +y_0=0.000000 +a=6378140.000000 +b=6378140.000000 ";
+  CHECK(projString == expected);
+}


### PR DESCRIPTION
A file for the DESTINE Floodmind project did not work with adaguc-server. It seemed azimuthal_equidistant  was not supported.

Added it, including a test. Refactored the method a little bit.

A netcdf file with the following metadata is now supported:
```
	long azimuthal_equidistant ;
		azimuthal_equidistant:grid_mapping_name = "azimuthal_equidistant" ;
		azimuthal_equidistant:longitude_of_projection_origin = 174.700000df ;
		azimuthal_equidistant:latitude_of_projection_origin = -41.200000df ;
		azimuthal_equidistant:earth_radius = 6370997.000000df ;
		azimuthal_equidistant:false_easting = 0.000000df ;
		azimuthal_equidistant:false_northing = 0.000000df ;
		azimuthal_equidistant:autogen_proj = "+proj=aeqd +lat_0=-41.200000 +lon_0=174.700000 +k_0=1.0 +x_0=0.000000 +y_0=0.000000 +a=6378140.000000 +b=6378140.000000 " ;
```