### PR TITLE
Found and fixed memory issue in PNG reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,5 @@ hclasses/testhclasses
 *Makefile*
 *cmake_install.cmake*
 core-adagucserver*
+data/datasets/arcus_multivar/uwcw_ha43_dini_testfile_multivar_5x6_clean.nc
+tests/env_checker_report.txt

--- a/CCDFDataModel/CCDFNetCDFIO.cpp
+++ b/CCDFDataModel/CCDFNetCDFIO.cpp
@@ -484,23 +484,20 @@ int CDFNetCDFReader::readAttributes(int root_id, std::vector<CDF::Attribute *> &
 }
 
 int CDFNetCDFReader::_findNCGroupIdForCDFVariable(CT::string *varName) {
-  CT::string *paths = varName->splitToArray(CDFNetCDFGroupSeparator);
-  if (paths->count <= 1) {
-    delete[] paths;
+  auto paths = varName->splitToStack(CDFNetCDFGroupSeparator);
+  if (paths.size() <= 1) {
     return root_id;
   }
   int currentId = root_id;
-  for (size_t j = 0; j < paths->count - 1; j++) {
+  for (size_t j = 0; j < paths.size() - 1; j++) {
     int grp_ncid;
     status = nc_inq_ncid(currentId, paths[j].c_str(), &grp_ncid);
     if (status != NC_NOERR) {
       ncError(__LINE__, className, "nc_inq_ncid: ", status);
-      delete[] paths;
       return -1;
     }
     currentId = grp_ncid;
   }
-  delete[] paths;
   return currentId;
 };
 

--- a/CCDFDataModel/CCDFObject.cpp
+++ b/CCDFDataModel/CCDFObject.cpp
@@ -149,14 +149,13 @@ void ncmlHandleAttribute(xmlNode *cur_node, CT::string NCMLVarName, CDFObject *c
           } else {
             size_t attrLen = 0;
             CT::string t = pszAttributeValue;
-            CT::string *t2 = t.splitToArray(",");
-            attrLen = t2->count;
+            auto t2 = t.splitToStack(",");
+            attrLen = t2.size();
             double values[attrLen];
             for (size_t attrN = 0; attrN < attrLen; attrN++) {
               values[attrN] = atof(t2[attrN].c_str());
               // CDBDebug("%f",values[attrN]);
             }
-            delete[] t2;
             // if(attrLen==3)exit(2);
 
             // double value=atof(pszAttributeValue);

--- a/CCDFDataModel/CCDFObject.cpp
+++ b/CCDFDataModel/CCDFObject.cpp
@@ -147,33 +147,28 @@ void ncmlHandleAttribute(xmlNode *cur_node, CT::string NCMLVarName, CDFObject *c
           if (strncmp("String", pszAttributeType, 6) == 0) {
             var->setAttribute(pszAttributeName, attrType, pszAttributeValue, strlen(pszAttributeValue));
           } else {
-            size_t attrLen = 0;
-            CT::string t = pszAttributeValue;
-            auto t2 = t.splitToStack(",");
-            attrLen = t2.size();
-            double values[attrLen];
+            CT::string attributeValue = pszAttributeValue;
+            auto attributeValues = attributeValue.splitToStack(",");
+            auto attrLen = attributeValues.size();
+            double attributeValuesAsDouble[attrLen];
             for (size_t attrN = 0; attrN < attrLen; attrN++) {
-              values[attrN] = atof(t2[attrN].c_str());
-              // CDBDebug("%f",values[attrN]);
+              attributeValuesAsDouble[attrN] = atof(attributeValues[attrN].c_str());
             }
-            // if(attrLen==3)exit(2);
-
-            // double value=atof(pszAttributeValue);
             CDF::Attribute *attr = new CDF::Attribute();
             attr->name.copy(pszAttributeName);
             var->addAttribute(attr);
             attr->type = attrType;
             CDF::allocateData(attrType, &attr->data, attrLen);
             for (size_t attrN = 0; attrN < attrLen; attrN++) {
-              if (attrType == CDF_BYTE) ((char *)attr->data)[attrN] = (char)values[attrN];
-              if (attrType == CDF_UBYTE) ((unsigned char *)attr->data)[attrN] = (unsigned char)values[attrN];
-              if (attrType == CDF_CHAR) ((char *)attr->data)[attrN] = (char)values[attrN];
-              if (attrType == CDF_SHORT) ((short *)attr->data)[attrN] = (short)values[attrN];
-              if (attrType == CDF_USHORT) ((unsigned short *)attr->data)[attrN] = (unsigned short)values[attrN];
-              if (attrType == CDF_INT) ((int *)attr->data)[attrN] = (int)values[attrN];
-              if (attrType == CDF_UINT) ((unsigned int *)attr->data)[attrN] = (unsigned int)values[attrN];
-              if (attrType == CDF_FLOAT) ((float *)attr->data)[attrN] = (float)values[attrN];
-              if (attrType == CDF_DOUBLE) ((double *)attr->data)[attrN] = (double)values[attrN];
+              if (attrType == CDF_BYTE) ((char *)attr->data)[attrN] = (char)attributeValuesAsDouble[attrN];
+              if (attrType == CDF_UBYTE) ((unsigned char *)attr->data)[attrN] = (unsigned char)attributeValuesAsDouble[attrN];
+              if (attrType == CDF_CHAR) ((char *)attr->data)[attrN] = (char)attributeValuesAsDouble[attrN];
+              if (attrType == CDF_SHORT) ((short *)attr->data)[attrN] = (short)attributeValuesAsDouble[attrN];
+              if (attrType == CDF_USHORT) ((unsigned short *)attr->data)[attrN] = (unsigned short)attributeValuesAsDouble[attrN];
+              if (attrType == CDF_INT) ((int *)attr->data)[attrN] = (int)attributeValuesAsDouble[attrN];
+              if (attrType == CDF_UINT) ((unsigned int *)attr->data)[attrN] = (unsigned int)attributeValuesAsDouble[attrN];
+              if (attrType == CDF_FLOAT) ((float *)attr->data)[attrN] = (float)attributeValuesAsDouble[attrN];
+              if (attrType == CDF_DOUBLE) ((double *)attr->data)[attrN] = (double)attributeValuesAsDouble[attrN];
             }
             attr->length = attrLen;
           }

--- a/CCDFDataModel/CCDFPNGIO.cpp
+++ b/CCDFDataModel/CCDFPNGIO.cpp
@@ -358,7 +358,8 @@ int CDFPNGReader::_readVariableData(CDF::Variable *var, CDFType) {
       CDBDebug("Warning: reusing pngdata variable");
     } else {
       if (pngRaster != NULL && pngRaster->data) {
-        CDBDebug("Info: reusing pngRaster object with data.");
+        // Verbose logging:
+        // CDBDebug("Info: reusing pngRaster object with data.");
       } else {
         if (pngRaster != NULL) {
           CDBDebug("Info: reusing pngRaster object.");

--- a/CCDFDataModel/CCDFPNGIO.cpp
+++ b/CCDFDataModel/CCDFPNGIO.cpp
@@ -255,14 +255,13 @@ int CDFPNGReader::open(const char *fileName) {
   PNGData->setAttributeText("standard_name", "rgba");
 
   if (isSlippyMapFormat == true) {
-    CT::string *parts = this->fileName.splitToArray("/");
+    auto parts = this->fileName.splitToStack("/");
 
-    if (parts->count > 3) {
-      int zoom = parts[parts->count - 3].toInt();
+    if (parts.size() > 3) {
+      int zoom = parts[parts.size() - 3].toInt();
       int level = 17 - zoom;
       cdfObject->setAttribute("adaguctilelevel", CDF_INT, &level, 1);
     }
-    delete[] parts;
     CDF::Variable *CRS = cdfObject->addVariable(new CDF::Variable("crs", CDF_UINT, NULL, 0, false));
     CRS->setAttributeText("proj4", "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs");
   }
@@ -280,12 +279,12 @@ int CDFPNGReader::_readVariableData(CDF::Variable *var, CDFType) {
 
   double tilex1, tilex2, tiley1, tiley2;
   if (isSlippyMapFormat) {
-    CT::string *parts = this->fileName.splitToArray("/");
+    auto parts = this->fileName.splitToStack("/");
 
-    if (parts->count > 3) {
-      int zoom = parts[parts->count - 3].toInt();
-      int tile_y = parts[parts->count - 1].splitToStack(".")[0].toInt();
-      int tile_x = parts[parts->count - 2].toInt();
+    if (parts.size() > 3) {
+      int zoom = parts[parts.size() - 3].toInt();
+      int tile_y = parts[parts.size() - 1].splitToStack(".")[0].toInt();
+      int tile_x = parts[parts.size() - 2].toInt();
       auto bbox = getBounds(tile_x, tile_y, zoom);
 #ifdef CCDFPNGIO_DEBUG
       CDBDebug("%d %d %d", tile_x, tile_y, zoom);
@@ -295,7 +294,6 @@ int CDFPNGReader::_readVariableData(CDF::Variable *var, CDFType) {
       tilex2 = (bbox.right);
       tiley2 = (bbox.top);
     }
-    delete[] parts;
   }
   f8box bbox;
   bbox.left = -180;
@@ -358,7 +356,6 @@ int CDFPNGReader::_readVariableData(CDF::Variable *var, CDFType) {
     }
   }
   if (var->name.equals("pngdata")) {
-    CDBDebug("Reading PNG data");
     if (var->data != NULL) {
       CDBDebug("Warning: reusing pngdata variable");
     } else {

--- a/CCDFDataModel/CCDFPNGIO.cpp
+++ b/CCDFDataModel/CCDFPNGIO.cpp
@@ -136,7 +136,6 @@ int CDFPNGReader::open(const char *fileName) {
       delete pngRaster;
       CDBWarning("PNGRaster was already defined");
     }
-    CDBDebug("Reading PNG using CReadPNG_read_png_file");
     pngRaster = CReadPNG_read_png_file(this->fileName.c_str(), true);
     if (pngRaster == NULL) {
       CDBError("Unable to open PNG check logs");
@@ -344,7 +343,6 @@ int CDFPNGReader::_readVariableData(CDF::Variable *var, CDFType) {
     if (isSingleImageWithCoordinates) {
       for (size_t j = 0; j < yDim->getSize(); j++) {
         float r = ((float(j) + 0.5) / float(yDim->getSize())) * (bbox.top - bbox.bottom);
-        //((double*)yVar->data)[j]=(r + bbox.bottom);
         ((double *)yVar->data)[j] = (bbox.top - r);
       }
     }
@@ -360,23 +358,23 @@ int CDFPNGReader::_readVariableData(CDF::Variable *var, CDFType) {
       CDBDebug("Warning: reusing pngdata variable");
     } else {
       if (pngRaster != NULL && pngRaster->data) {
-        // CDBDebug("Info: reusing pngdata");
-        // return 0;
-        // delete pngRaster;
+        CDBDebug("Info: reusing pngRaster object with data.");
       } else {
-        if (pngRaster != NULL) delete pngRaster;
+        if (pngRaster != NULL) {
+          CDBDebug("Info: reusing pngRaster object.");
+          delete pngRaster;
+        }
         pngRaster = CReadPNG_read_png_file(this->fileName.c_str(), false);
       }
       var->allocateData(rasterWidth * rasterHeight);
+      // Copy PNG raster data into variable as unsigned it, representing RGBA as 4 bytes.
       for (size_t y = 0; y < rasterHeight; y++) {
         for (size_t x = 0; x < rasterWidth; x++) {
           size_t j = x + y * rasterWidth;
           ((unsigned int *)var->data)[x + y * rasterWidth] =
               pngRaster->data[j * 4 + 0] + pngRaster->data[j * 4 + 1] * 256 + pngRaster->data[j * 4 + 2] * 256 * 256 + pngRaster->data[j * 4 + 3] * (256 * 256 * 256);
-          // ((unsigned int*)var->data)[x+y*rasterWidth] = 255*256*256 + 255*(256*256*256);
         }
       }
-      // CDBDebug("Info: pngdata read");
     }
   }
   return 0;
@@ -410,7 +408,6 @@ int CDFPNGReader::_readVariableData(CDF::Variable *var, CDFType type, size_t *st
     delete dummyVar;
   }
 
-  CDBDebug("!");
   if (var->name.equals("pngdata")) {
     if (pngRaster != NULL && pngRaster->data) {
       CDBDebug("Info: reusing pngdata with start/count");

--- a/CCDFDataModel/CCDFPNGIO.h
+++ b/CCDFDataModel/CCDFPNGIO.h
@@ -39,27 +39,13 @@
 class CDFPNGReader : public CDFReader {
 private:
   DEF_ERRORFUNCTION();
-  bool isSlippyMapFormat;
-  size_t rasterWidth;
-  size_t rasterHeight;
-  CReadPNG::CPNGRaster *pngRaster;
+  bool isSlippyMapFormat = false;
+  size_t rasterWidth = 0;
+  size_t rasterHeight = 0;
+  CPNGRaster *pngRaster = nullptr;
 
 public:
-  CDFPNGReader() : CDFReader() {
-#ifdef CCDFPNGIO_DEBUG
-    CDBDebug("CCDFPNGIO init");
-#endif
-    pngRaster = NULL;
-    isSlippyMapFormat = false;
-    rasterWidth = 0;
-    rasterHeight = 0;
-  }
-  ~CDFPNGReader() {
-#ifdef CCDFPNGIO_DEBUG
-    CDBDebug("CCDFPNGIO ~CDFPNGReader");
-#endif
-    close();
-  }
+  ~CDFPNGReader();
 
   int open(const char *fileName);
 

--- a/CCDFDataModel/CProj4ToCF.cpp
+++ b/CCDFDataModel/CProj4ToCF.cpp
@@ -393,21 +393,25 @@ int CProj4ToCF::convertProjToCF(CDF::Variable *projectionVariable, const char *p
   std::vector<CProj4ToCF::KVP *> projKVPList;
   CT::string proj4CTString;
   proj4CTString.copy(proj4String);
-  CT::string *projElements = proj4CTString.splitToArray(" +");
+  auto projElements = proj4CTString.splitToStack(" ");
 
-  if (projElements->count < 2) {
-    delete[] projElements;
+  if (projElements.size() < 2) {
     return 1;
   }
-  for (size_t j = 0; j < projElements->count; j++) {
+  for (auto &projElement : projElements) {
     KVP *option = new KVP();
-    CT::string *element = projElements[j].splitToArray("=");
-    option->name.copy(&element[0]);
-    option->value.copy(&element[1]);
-    projKVPList.push_back(option);
-    delete[] element;
+    auto element = projElement.splitToStack("=");
+    if (element.size() > 0) {
+      option->name.copy(element[0]);
+      if (element.size() > 1) {
+        option->value.copy(element[1]);
+      }
+      if (option->name.startsWith("+")) {
+        option->name.substringSelf(1, -1);
+      }
+      projKVPList.push_back(option);
+    }
   }
-  delete[] projElements;
   CT::string cmpStr;
   int foundProj = 0;
   try {
@@ -658,14 +662,13 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
 
       proj4String.print("+proj=lcc +lat_0=%f", latitude_of_projection_origin.toDouble());
 
-      CT::string *stpList = standard_parallel.splitToArray(" ");
-      if (stpList->count == 1) {
+      auto stpList = standard_parallel.splitToStack(" ");
+      if (stpList.size() == 1) {
         proj4String.printconcat(" +lat_1=%f", stpList[0].toDouble());
       }
-      if (stpList->count == 2) {
+      if (stpList.size() == 2) {
         proj4String.printconcat(" +lat_1=%f +lat_2=%f", stpList[0].toDouble(), stpList[1].toDouble());
       }
-      delete[] stpList;
 
       proj4String.printconcat(" +lon_0=%f +k_0=1.0 +x_0=%f +y_0=%f +a=%f +b=%f", longitude_of_central_meridian.toDouble(), false_easting.toDouble(), false_northing.toDouble(), dfsemi_major_axis,
                               dfsemi_minor_axis);
@@ -899,14 +902,13 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
 
       proj4String.print("+proj=merc +lat_0=%f", latitude_of_projection_origin.toDouble());
 
-      CT::string *stpList = standard_parallel.splitToArray(" ");
-      if (stpList->count == 1) {
+      auto stpList = standard_parallel.splitToStack(" ");
+      if (stpList.size() == 1) {
         proj4String.printconcat(" +lat_1=%f", stpList[0].toDouble());
       }
-      if (stpList->count == 2) {
+      if (stpList.size() == 2) {
         proj4String.printconcat(" +lat_1=%f +lat_2=%f", stpList[0].toDouble(), stpList[1].toDouble());
       }
-      delete[] stpList;
 
       proj4String.printconcat(" +lon_0=%f +k_0=1.0 +x_0=%f +y_0=%f +a=%f ", longitude_of_central_meridian.toDouble(), false_easting.toDouble(), false_northing.toDouble(), semi_major_axis.toDouble());
     } else if (grid_mapping_name.equals("transverse_mercator")) {

--- a/CCDFDataModel/CReadPNG.cpp
+++ b/CCDFDataModel/CReadPNG.cpp
@@ -30,7 +30,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
-
+#include <algorithm>
+#include <cfenv>
+#include <cmath>
 #define PNG_DEBUG 3
 #include <png.h>
 
@@ -43,7 +45,6 @@ CPNGRaster::~CPNGRaster() {
     delete[] data;
     data = NULL;
   }
-  CDBDebug("Destructed PNGRaster");
 }
 
 CPNGRaster *CReadPNG_read_png_file(const char *file_name, bool pngReadHeaderOnly) {
@@ -98,7 +99,6 @@ CPNGRaster *CReadPNG_read_png_file(const char *file_name, bool pngReadHeaderOnly
 
   png_read_info(png_ptr, info_ptr);
 
-  CDBDebug("New PNGRaster");
   CPNGRaster *pngRaster = new CPNGRaster();
 
   pngRaster->width = png_get_image_width(png_ptr, info_ptr);
@@ -168,9 +168,11 @@ CPNGRaster *CReadPNG_read_png_file(const char *file_name, bool pngReadHeaderOnly
   }
 
   pngRaster->data = new unsigned char[pngRaster->width * pngRaster->height * 4];
+  size_t c = std::ceil(pngRaster->width / pngwidthdivisor);
+  size_t calcWidth = std::min(pngRaster->width, c);
   for (size_t y = 0; y < pngRaster->height; y++) {
     unsigned char *line = row_pointers[y];
-    for (size_t x = 0; x < (pngRaster->width / pngwidthdivisor) + 1; x += 1) {
+    for (size_t x = 0; x < calcWidth; x += 1) {
 
       /*  Each pixel is a palette index, using PLTE */
       if (color_type == 3) {
@@ -237,7 +239,6 @@ CPNGRaster *CReadPNG_read_png_file(const char *file_name, bool pngReadHeaderOnly
             bbpo = 2;
           }
         }
-
         /* Red */
         pngRaster->data[x * 4 + 0 + (y * pngRaster->width * 4)] = line[x * bpp + 0];
 

--- a/CCDFDataModel/CReadPNG.cpp
+++ b/CCDFDataModel/CReadPNG.cpp
@@ -68,7 +68,6 @@ CPNGRaster *CReadPNG_read_png_file(const char *file_name, bool pngReadHeaderOnly
   if (!fp) {
     CDBError("[read_png_file] File %s could not be opened for reading", file_name);
     png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
-    fclose(fp);
     return NULL;
   }
   (void)!fread(header, 1, 8, fp);

--- a/CCDFDataModel/CReadPNG.cpp
+++ b/CCDFDataModel/CReadPNG.cpp
@@ -168,7 +168,7 @@ CPNGRaster *CReadPNG_read_png_file(const char *file_name, bool pngReadHeaderOnly
   }
 
   pngRaster->data = new unsigned char[pngRaster->width * pngRaster->height * 4];
-  size_t c = std::ceil(pngRaster->width / pngwidthdivisor);
+  size_t c = std::ceil((pngRaster->width / pngwidthdivisor) + 1.f);
   size_t calcWidth = std::min(pngRaster->width, c);
   for (size_t y = 0; y < pngRaster->height; y++) {
     unsigned char *line = row_pointers[y];

--- a/CCDFDataModel/CReadPNG.h
+++ b/CCDFDataModel/CReadPNG.h
@@ -27,34 +27,15 @@
 #define CREADPNG_H
 #include "CDebugger.h"
 #include "CKeyValuePair.h"
-// #define CREADPNG_DEBUG
-class CReadPNG {
-private:
-  DEF_ERRORFUNCTION();
 
-public:
-  class CPNGRaster {
-  private:
-    DEF_ERRORFUNCTION();
-
-  public:
-    CPNGRaster() {
-      data = NULL;
-      hasOnlyHeaders = true;
-    }
-    ~CPNGRaster() {
-      if (data != NULL) {
-        delete[] data;
-        data = NULL;
-      }
-    }
-    bool hasOnlyHeaders;
-    CKeyValuePairs headers;
-    unsigned char *data;
-    size_t width, height;
-  };
-
-  static CPNGRaster *read_png_file(const char *file_name, bool readHeaderOnly);
+struct CPNGRaster {
+  ~CPNGRaster();
+  bool hasOnlyHeaders = true;
+  CKeyValuePairs headers;
+  unsigned char *data = nullptr;
+  size_t width, height;
 };
+
+CPNGRaster *CReadPNG_read_png_file(const char *file_name, bool readHeaderOnly);
 
 #endif

--- a/CCDFDataModel/CTime.cpp
+++ b/CCDFDataModel/CTime.cpp
@@ -238,11 +238,11 @@ int CTime::init(const char *units, const char *calendar) {
     CT::string YYYYMMDDPart;
     CT::string HHMMSSPart;
 
-    CT::string *timeItems = currentUnit.splitToArray(" ");
+    auto timeItems = currentUnit.splitToStack(" ");
 
     bool hasError = false;
     try {
-      if (timeItems->count < 3) {
+      if (timeItems.size() < 3) {
         CDBError("timeItems length <3 for %s", currentUnit.c_str());
         throw(__LINE__);
       }
@@ -288,9 +288,9 @@ int CTime::init(const char *units, const char *calendar) {
       // Determince the since part, e.g. 1949-12-01 00:00:00
       YYYYMMDDPart = timeItems[2].c_str();
 
-      CT::string *YYYYMMDDPartSplitted = YYYYMMDDPart.splitToArray("-");
+      auto YYYYMMDDPartSplitted = YYYYMMDDPart.splitToStack("-");
 
-      if (YYYYMMDDPartSplitted->count != 3) {
+      if (YYYYMMDDPartSplitted.size() != 3) {
         CDBError("YYYYMMDD part is incorrect [%s]", YYYYMMDDPart.c_str());
         hasError = true;
       } else {
@@ -299,13 +299,10 @@ int CTime::init(const char *units, const char *calendar) {
         timeUnits.date.day = YYYYMMDDPartSplitted[2].toInt();
       }
 
-      delete[] YYYYMMDDPartSplitted;
-
-      if (timeItems->count > 3) {
+      if (timeItems.size() > 3) {
         HHMMSSPart = timeItems[3].c_str();
-
-        CT::string *HHMMSSPartSplited = HHMMSSPart.splitToArray(":");
-        if (HHMMSSPartSplited->count != 3) {
+        auto HHMMSSPartSplited = HHMMSSPart.splitToStack(":");
+        if (HHMMSSPartSplited.size() != 3) {
           CDBError("HHMMSS part is incorrect [%s]", HHMMSSPart.c_str());
           hasError = true;
         } else {
@@ -313,12 +310,10 @@ int CTime::init(const char *units, const char *calendar) {
           timeUnits.date.minute = HHMMSSPartSplited[1].toInt();
           timeUnits.date.second = (double)HHMMSSPartSplited[2].toInt();
         }
-        delete[] HHMMSSPartSplited;
       }
     } catch (int e) {
       hasError = true;
     }
-    delete[] timeItems;
 
     // Check limits
     if (!(timeUnits.date.year >= 0 && timeUnits.date.year < 10000)) {
@@ -910,13 +905,11 @@ double CTime::quantizeTimeToISO8601(double offsetOrig, CT::string period, CT::st
 
   if (period.indexOf("T") != -1) { // Contains HMS
 
-    CT::string *items = period.splitToArray("T");
-    if (items->count != 2) {
-      delete[] items;
+    auto items = period.splitToStack("T");
+    if (items.size() != 2) {
       throw(-1);
     }
     CT::string hmsPart = items[1];
-    delete[] items;
 
     // hmsPart contains 15M, 1M, 12S, 6H, etc...
     if (hmsPart.indexOf("H") != -1) { // 6H

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@ IF (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64" OR CMAKE_HOST_SYSTEM_PROCESSOR 
   set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ffp-contract=off")
 ELSE()
   set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -Wall -Wextra -g3")
-  set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -Wall -Wextra -g3 -fsanitize=address") # <= Use to find memory issues
-  # set(CMAKE_CXX_FLAGS_RELEASE "-O3 -msse -msse2 -msse3 -mssse3 -mfpmath=sse")
+  #set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -Wall -Wextra -g3 -fsanitize=address") # <= Use to find memory issues
+  set(CMAKE_CXX_FLAGS_RELEASE "-O3 -msse -msse2 -msse3 -mssse3 -mfpmath=sse")
 ENDIF()
 MESSAGE(STATUS "CMAKE_CXX_FLAGS_DEBUG: ${CMAKE_CXX_FLAGS_DEBUG}")
 MESSAGE(STATUS "CMAKE_CXX_FLAGS_RELEASE: ${CMAKE_CXX_FLAGS_RELEASE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@ IF (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64" OR CMAKE_HOST_SYSTEM_PROCESSOR 
   set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ffp-contract=off")
 ELSE()
   set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -Wall -Wextra -g3")
-  #set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -Wall -Wextra -g3 -fsanitize=address") # <= Use to find memory issues
-  set(CMAKE_CXX_FLAGS_RELEASE "-O3 -msse -msse2 -msse3 -mssse3 -mfpmath=sse")
+  set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -Wall -Wextra -g3 -fsanitize=address") # <= Use to find memory issues
+  # set(CMAKE_CXX_FLAGS_RELEASE "-O3 -msse -msse2 -msse3 -mssse3 -mfpmath=sse")
 ENDIF()
 MESSAGE(STATUS "CMAKE_CXX_FLAGS_DEBUG: ${CMAKE_CXX_FLAGS_DEBUG}")
 MESSAGE(STATUS "CMAKE_CXX_FLAGS_RELEASE: ${CMAKE_CXX_FLAGS_RELEASE}")

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ USER root
 LABEL maintainer="adaguc@knmi.nl"
 
 # Version should be same as in Definitions.h
-LABEL version="4.3.4"
+LABEL version="4.3.5"
 
 # Try to update image packages
 RUN apt-get -q -y update \

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+**Version 4.3.6 - 2025-10-27**
+
+- Making tiles does not cause memory violations
+
 **Version 4.3.4 - 2025-10-16**
 
 - Files cleaned with CleanFiles will now not be used to make pyramid tiles.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-**Version 4.3.6 - 2025-10-27**
+**Version 4.3.5 - 2025-10-27**
 
 - Making tiles does not cause memory violations
 

--- a/adagucserverEC/CAutoConfigure.cpp
+++ b/adagucserverEC/CAutoConfigure.cpp
@@ -471,7 +471,7 @@ int CAutoConfigure::getFileNameForDataSource(CDataSource *dataSource, std::strin
   CT::string foundFileName = dataSource->getFileName();
   if (foundFileName.empty()) {
     /* Use the file specified as header file */
-    foundFileName = dataSource->headerFileName.c_str();
+    foundFileName = dataSource->headerFilename.c_str();
   }
   if (foundFileName.empty()) {
 
@@ -555,10 +555,13 @@ int CAutoConfigure::justLoadAFileHeader(CDataSource *dataSource) {
   try {
     // CDBDebug("Loading header [%s]", foundFileName.c_str());
     CDFObject *cdfObject = CDFObjectStore::getCDFObjectStore()->getCDFObjectHeader(dataSource, dataSource->srvParams, foundFileName.c_str());
-    if (cdfObject == NULL) throw(__LINE__);
+    if (cdfObject == NULL) {
+      CDBError("Unable to getCDFObjectHeader for %s ", foundFileName.c_str());
+      throw(__LINE__);
+    }
     dataSource->attachCDFObject(cdfObject);
   } catch (int linenr) {
-    CDBError("Returning from line %d");
+    CDBError("Returning from line %d", linenr);
     dataSource->detachCDFObject();
     return 1;
   }

--- a/adagucserverEC/CConvertH5VolScan.cpp
+++ b/adagucserverEC/CConvertH5VolScan.cpp
@@ -124,8 +124,8 @@ int CConvertH5VolScan::convertH5VolScanHeader(CDFObject *cdfObject, CServerParam
 
   for (size_t v = 0; v < cdfObject->variables.size(); v++) {
     CDF::Variable *var = cdfObject->variables[v];
-    CT::string *terms = var->name.splitToArray(".");
-    if (terms->count > 1) {
+    auto terms = var->name.splitToStack(".");
+    if (terms.size() > 1) {
       if (terms[0].startsWith("scan") && terms[1].startsWith("scan_") && terms[1].endsWith("_data")) {
         var->setAttributeText("ADAGUC_SKIP", "TRUE");
       }

--- a/adagucserverEC/CConvertLatLonBndsData.cpp
+++ b/adagucserverEC/CConvertLatLonBndsData.cpp
@@ -72,7 +72,7 @@ int CConvertLatLonBnds::convertLatLonBndsData(CDataSource *dataSource, int mode)
       fillValue->getData(&dblFill, 1);
       dataObjects[d]->dfNodataValue = dblFill;
       fltFill = (float)dblFill;
-      destRegularGrid[d]->getAttribute("_FillValue")->setData(CDF_DOUBLE, &fltFill, 1);
+      destRegularGrid[d]->getAttribute("_FillValue")->setData(CDF_FLOAT, &fltFill, 1);
     } else {
       dataObjects[d]->hasNodataValue = false;
     }

--- a/adagucserverEC/CDBFileScanner.cpp
+++ b/adagucserverEC/CDBFileScanner.cpp
@@ -75,24 +75,24 @@ int CDBFileScanner::createDBUpdateTables(CDataSource *dataSource, int &removeNon
 #endif
   int status = 0;
   CT::string query;
-  dataSource->headerFileName = (*fileList)[0].c_str();
+  dataSource->headerFilename = (*fileList)[0].c_str();
 
   CDBAdapterPostgreSQL *dbAdapter = CDBFactory::getDBAdapter(dataSource->srvParams->cfg);
 
   CDFObject *cdfObject = NULL;
   try {
     // Here the header of the file to scan is being read.
-    cdfObject = CDFObjectStore::getCDFObjectStore()->getCDFObject(dataSource, dataSource->headerFileName.c_str());
+    cdfObject = CDFObjectStore::getCDFObjectStore()->getCDFObject(dataSource, dataSource->headerFilename.c_str());
     if (cdfObject == NULL) throw __LINE__;
   } catch (int e) {
-    CDBError("Unable to get CDFObject for file %s", dataSource->headerFileName.c_str());
+    CDBError("Unable to get CDFObject for file %s", dataSource->headerFilename.c_str());
     return 1;
   }
 
   // Check if variable is in this file:
 
   if (cdfObject->getVariableNE(dataSource->getDataObject(0)->variableName.c_str()) == NULL) {
-    CDBError("Variable %s does not exist in %s ", dataSource->getDataObject(0)->variableName.c_str(), dataSource->headerFileName.c_str());
+    CDBError("Variable %s does not exist in %s ", dataSource->getDataObject(0)->variableName.c_str(), dataSource->headerFilename.c_str());
     return 1;
   }
 
@@ -863,6 +863,9 @@ int CDBFileScanner::updatedb(CDataSource *dataSource, CT::string *_tailPath, CT:
       fileToUpdate = layerPathToScan;
     }
   }
+  if (fileToUpdate.empty() == false) {
+    dataSource->setHeaderFilename(fileToUpdate);
+  }
   // This variable enables the query to remove files that no longer exist in the filesystem
   int removeNonExistingFiles = 1;
 
@@ -1073,8 +1076,7 @@ std::vector<std::string> CDBFileScanner::searchFileNames(const char *path, CT::s
       if (expr.empty() == false) { // dataSource->cfgLayer->FilePath[0]->attr.filter.c_str()
         fileFilterExpr.copy(&expr);
       }
-      //      CDBDebug("Reading directory %s with filter %s", filePath.c_str(), fileFilterExpr.c_str());
-
+      CDBDebug("Reading directory %s with filter %s", filePath.c_str(), fileFilterExpr.c_str());
       CDirReader *dirReader = CCachedDirReader::getDirReader(filePath.c_str(), fileFilterExpr.c_str());
       dirReader->listDirRecursive(filePath.c_str(), fileFilterExpr.c_str());
       std::vector<std::string> fileList;

--- a/adagucserverEC/CDataPostProcessors/CDataPostProcessor_AddFeatures.cpp
+++ b/adagucserverEC/CDataPostProcessors/CDataPostProcessor_AddFeatures.cpp
@@ -53,7 +53,7 @@ int CDPPAddFeatures::execute(CServerConfig::XMLE_DataPostProc *proc, CDataSource
     dataSource->getDataObject(0)->cdfVariable->setAttributeText("ADAGUC_GEOJSONPOINT", "1");
 
     unsigned short sf = 65535u;
-    newDataObject->cdfVariable->setAttribute("_FillValue", newDataObject->cdfVariable->getType(), &sf, 1);
+    newDataObject->cdfVariable->setAttribute("_FillValue", CDF_USHORT, &sf, 1);
   }
   if (mode == CDATAPOSTPROCESSOR_RUNAFTERREADING) {
     CDataSource featureDataSource;

--- a/adagucserverEC/CDataPostProcessors/CDataPostProcessor_WFP.cpp
+++ b/adagucserverEC/CDataPostProcessors/CDataPostProcessor_WFP.cpp
@@ -45,9 +45,9 @@ CDF::Variable *CDPPWFP::cloneVariable(CDF::Variable *varToClone, const char *nam
   var->setAttributeText("standard_name", name);
   var->setAttributeText("long_name", name);
   var->setAttributeText("units", "1");
-  float fill = -1;
+  float fill = -1.0;
 
-  var->setAttribute("_FillValue", var->getType(), &fill, 1);
+  var->setAttribute("_FillValue", CDF_FLOAT, &fill, 1);
   var->setCustomReader(CDF::Variable::CustomMemoryReaderInstance);
   return var;
 }

--- a/adagucserverEC/CDataPostProcessors/CDataPostProcessors_MSGCPP.cpp
+++ b/adagucserverEC/CDataPostProcessors/CDataPostProcessors_MSGCPP.cpp
@@ -61,12 +61,12 @@ int CDPPMSGCPPVisibleMask::execute(CServerConfig::XMLE_DataPostProc *proc, CData
     newDataObject->cdfVariable->removeAttribute("flag_meanings");
     short attrData[3];
     attrData[0] = -1;
-    newDataObject->cdfVariable->setAttribute("_FillValue", newDataObject->cdfVariable->getType(), attrData, 1);
+    newDataObject->cdfVariable->setAttribute("_FillValue", CDF_SHORT, attrData, 1);
 
     attrData[0] = 0;
     attrData[1] = 1;
-    newDataObject->cdfVariable->setAttribute("valid_range", newDataObject->cdfVariable->getType(), attrData, 2);
-    newDataObject->cdfVariable->setAttribute("flag_values", newDataObject->cdfVariable->getType(), attrData, 2);
+    newDataObject->cdfVariable->setAttribute("valid_range", CDF_SHORT, attrData, 2);
+    newDataObject->cdfVariable->setAttribute("flag_values", CDF_SHORT, attrData, 2);
     newDataObject->cdfVariable->setAttributeText("flag_meanings", "no yes");
 
     newDataObject->cdfVariable->setCustomReader(CDF::Variable::CustomMemoryReaderInstance);
@@ -162,12 +162,12 @@ int CDPPMSGCPPHIWCMask::execute(CServerConfig::XMLE_DataPostProc *proc, CDataSou
     newDataObject->cdfVariable->removeAttribute("flag_meanings");
     short attrData[3];
     attrData[0] = -1;
-    newDataObject->cdfVariable->setAttribute("_FillValue", newDataObject->cdfVariable->getType(), attrData, 1);
+    newDataObject->cdfVariable->setAttribute("_FillValue", CDF_SHORT, attrData, 1);
 
     attrData[0] = 0;
     attrData[1] = 1;
-    newDataObject->cdfVariable->setAttribute("valid_range", newDataObject->cdfVariable->getType(), attrData, 2);
-    newDataObject->cdfVariable->setAttribute("flag_values", newDataObject->cdfVariable->getType(), attrData, 2);
+    newDataObject->cdfVariable->setAttribute("valid_range", CDF_SHORT, attrData, 2);
+    newDataObject->cdfVariable->setAttribute("flag_values", CDF_SHORT, attrData, 2);
     newDataObject->cdfVariable->setAttributeText("flag_meanings", "no yes");
 
     newDataObject->cdfVariable->setCustomReader(CDF::Variable::CustomMemoryReaderInstance);

--- a/adagucserverEC/CDataSource.cpp
+++ b/adagucserverEC/CDataSource.cpp
@@ -386,7 +386,7 @@ int CDataSource::setCFGLayer(CServerParams *_srvParams, CServerConfig::XMLE_Conf
   }
 
   if (!_srvParams->internalAutoResourceLocation.empty()) {
-    headerFileName = _srvParams->internalAutoResourceLocation.c_str();
+    headerFilename = _srvParams->internalAutoResourceLocation.c_str();
   }
 
   isConfigured = true;
@@ -402,6 +402,8 @@ void CDataSource::addStep(const char *fileName, CCDFDims *dims) {
     timeStep->dims.copy(dims);
   }
 }
+
+void CDataSource::setHeaderFilename(CT::string headerFilename) { this->headerFilename = headerFilename; }
 
 const char *CDataSource::getFileName() {
   if (currentAnimationStep < 0) return NULL;

--- a/adagucserverEC/CDataSource.h
+++ b/adagucserverEC/CDataSource.h
@@ -367,10 +367,9 @@ public:
   CT::PointerList<CStyleConfiguration *> *getStyleListForDataSource(CDataSource *dataSource);
 
   static void calculateScaleAndOffsetFromMinMax(float &scale, float &offset, float min, float max, float log);
-  static CT::PointerList<CT::string *> *getLegendListForDataSource(CDataSource *dataSource, CServerConfig::XMLE_Style *style);
-  static CT::PointerList<CT::string *> *getStyleNames(std::vector<CServerConfig::XMLE_Styles *> Styles);
-
-  static CT::PointerList<CT::string *> *getRenderMethodListForDataSource(CDataSource *dataSource, CServerConfig::XMLE_Style *style);
+  static std::vector<CT::string> getLegendListForDataSource(CDataSource *dataSource, CServerConfig::XMLE_Style *style);
+  static std::vector<CT::string> getStyleNames(std::vector<CServerConfig::XMLE_Styles *> Styles);
+  static std::vector<CT::string> getRenderMethodListForDataSource(CDataSource *dataSource, CServerConfig::XMLE_Style *style);
 
   /**
    * Sets the style by name, can be a character string.

--- a/adagucserverEC/CDataSource.h
+++ b/adagucserverEC/CDataSource.h
@@ -89,12 +89,12 @@ private:
   DEF_ERRORFUNCTION();
 
 public:
+  CT::string headerFilename;
   struct StatusFlag {
     CT::string meaning;
     double value;
   };
   bool dimsAreAutoConfigured;
-  CT::string headerFileName;
 
 private:
   CT::PointerList<CStyleConfiguration *> *_styles;
@@ -334,6 +334,7 @@ public:
   int setCFGLayer(CServerParams *_srvParams, CServerConfig::XMLE_Configuration *_cfg, CServerConfig::XMLE_Layer *_cfgLayer, const char *_layerName, int layerIndex);
   void addStep(const char *fileName, CCDFDims *dims);
   const char *getFileName();
+  void setHeaderFilename(CT::string headerFileName);
 
   DataObject *getDataObjectByName(const char *name);
   DataObject *getDataObject(int j);

--- a/adagucserverEC/CDrawImage.cpp
+++ b/adagucserverEC/CDrawImage.cpp
@@ -1372,16 +1372,14 @@ int CDrawImage::createGDPalette(CServerConfig::XMLE_Legend *legend) {
         int offset = (int)(stops.get(j)->getAttrValue("offset").toFloat() * 2.4);
         CT::string color = stops.get(j)->getAttrValue("stop-color").c_str() + 4;
         color.setSize(color.length() - 1);
-        CT::string *colors = color.splitToArray(",");
-        if (colors->count != 3) {
-          delete[] colors;
+        auto colors = color.splitToStack(",");
+        if (colors.size() != 3) {
           CDBError("Number of specified colors is unequal to three");
           return 1;
         }
         unsigned char red = colors[0].toInt();
         unsigned char green = colors[1].toInt();
         unsigned char blue = colors[2].toInt();
-        delete[] colors;
         unsigned char alpha = (char)(stops.get(j)->getAttrValue("stop-opacity").toFloat() * 255);
         // CDBDebug("I%d R%d G%d B%d A%d",offset,red,green,blue,alpha);
         if (offset > 255)

--- a/adagucserverEC/CGDALDataWriter.cpp
+++ b/adagucserverEC/CGDALDataWriter.cpp
@@ -293,12 +293,12 @@ int CGDALDataWriter::addData(std::vector<CDataSource *> &dataSources) {
   GenericDataWarper genericDataWarper;
   GDWArgs args = {.warper = &warper, .sourceData = sourceData, .sourceGeoParams = &sourceGeo, .destGeoParams = srvParam->Geo};
 
-#define RENDER(CDFTYPE, CPPTYPE)                                                                                                                                                               \
+#define RENDER(CDFTYPE, CPPTYPE)                                                                                                                                                                       \
   if (dataType == CDFTYPE) genericDataWarper.render<CPPTYPE>(args, [&](int x, int y, CPPTYPE val, GDWState &warperState) { return drawFunction(x, y, val, warperState, drawFunctionState); });
-ENUMERATE_OVER_CDFTYPES(RENDER)
+  ENUMERATE_OVER_CDFTYPES(RENDER)
 #undef RENDER
 
-   CPLErr gdalStatus = GDALRasterIO(hSrcBand, GF_Write, 0, 0, srvParam->Geo->dWidth, srvParam->Geo->dHeight, warpedData, srvParam->Geo->dWidth, srvParam->Geo->dHeight, datatype, 0, 0);
+  CPLErr gdalStatus = GDALRasterIO(hSrcBand, GF_Write, 0, 0, srvParam->Geo->dWidth, srvParam->Geo->dHeight, warpedData, srvParam->Geo->dWidth, srvParam->Geo->dHeight, datatype, 0, 0);
   CDF::freeData(&warpedData);
 
   if (gdalStatus != CE_None) {
@@ -507,13 +507,11 @@ int CGDALDataWriter::end() {
   char **papszOptions = NULL;
 
   if (customOptions.length() > 2) {
-    CT::string *co = customOptions.splitToArray(",");
-    for (size_t j = 0; j < co->count; j++) {
-      CT::string *splittedco = customOptions.splitToArray("=");
+    auto co = customOptions.splitToStack(",");
+    for (size_t j = 0; j < co.size(); j++) {
+      auto splittedco = customOptions.splitToStack("=");
       papszOptions = CSLSetNameValue(papszOptions, splittedco[0].c_str(), splittedco[1].c_str());
-      delete[] splittedco;
     }
-    delete[] co;
   }
   if (driverName.equalsIgnoreCase("AAIGRID")) {
     // We allow the aagrid format writer to use a cellsize which does not have to be a square.

--- a/adagucserverEC/CImageDataWriter.cpp
+++ b/adagucserverEC/CImageDataWriter.cpp
@@ -1576,28 +1576,27 @@ int CImageDataWriter::calculateData(std::vector<CDataSource *> &dataSources) {
       float inputMapExprValuesLow[dataSources.size()];
       float inputMapExprValuesHigh[dataSources.size()];
 
-      CT::string *layerStyles = srvParam->Styles.splitToArray(",");
+      auto layerStyles = srvParam->Styles.splitToStack(",");
       CT::string style;
       //      bool errorOccured=false;
       for (size_t j = 0; j < dataSources.size(); j++) {
         size_t numberOfValues = 1;
-        CT::string *_style = layerStyles[j].splitToArray("|");
+        auto _style = layerStyles[j].splitToStack("|");
         style.copy(&_style[0]);
         CDBDebug("STYLE == %s", style.c_str());
         if (j == 0) {
           // Find the conditional expression for the first layer (the boolean map)
-          CT::string *conditionals = style.splitToArray("_");
-          if (!conditionals[0].equals("default") && conditionals->count != dataSources.size() - 2) {
-            CDBError("Incorrect number of conditional operators specified: %d  (expected %d)", conditionals->count, dataSources.size() - 2);
+          auto conditionals = style.splitToStack("_");
+          if (!conditionals[0].equals("default") && conditionals.size() != dataSources.size() - 2) {
+            CDBError("Incorrect number of conditional operators specified: %d  (expected %d)", conditionals.size(), dataSources.size() - 2);
             hasFailed = true;
           } else {
-            for (size_t i = 0; i < conditionals->count; i++) {
+            for (size_t i = 0; i < conditionals.size(); i++) {
               combineBooleanMapExpression[i] = myand;
               if (conditionals[i].equals("and")) combineBooleanMapExpression[i] = myand;
               if (conditionals[i].equals("or")) combineBooleanMapExpression[i] = myor;
             }
           }
-          delete[] conditionals;
         } else {
           inputMapExpression[j] = between;
           CT::string exprVal("0.0");
@@ -1622,8 +1621,8 @@ int CImageDataWriter::calculateData(std::vector<CDataSource *> &dataSources) {
             exprVal.copy(style.c_str() + 12);
             numberOfValues = 1;
           }
-          CT::string *LH = exprVal.splitToArray("_and_");
-          if (LH->count != numberOfValues) {
+          auto LH = exprVal.splitToStack("_and_");
+          if (LH.size() != numberOfValues) {
             CDBError("Invalid number of values in expression '%s'", style.c_str());
             hasFailed = true;
           } else {
@@ -1632,7 +1631,7 @@ int CImageDataWriter::calculateData(std::vector<CDataSource *> &dataSources) {
               inputMapExprValuesHigh[j] = LH[1].toFloat();
             }
           }
-          delete[] LH;
+
           if (numberOfValues == 1) {
             CDBDebug("'%f'", inputMapExprValuesLow[j]);
           }
@@ -1640,7 +1639,6 @@ int CImageDataWriter::calculateData(std::vector<CDataSource *> &dataSources) {
             CDBDebug("'%f' and '%f'", inputMapExprValuesLow[j], inputMapExprValuesHigh[j]);
           }
         }
-        delete[] _style;
       }
 
       CDBDebug("Start creating the boolean map");
@@ -1711,7 +1709,6 @@ int CImageDataWriter::calculateData(std::vector<CDataSource *> &dataSources) {
       imageWarperRenderer->render(&imageWarper, dataSource, &drawImage);
       delete imageWarperRenderer;
       imageWarper.closereproj();
-      delete[] layerStyles;
     }
     for (size_t j = 0; j < dataReaders.size(); j++) {
       if (dataReaders[j] != NULL) {
@@ -2618,9 +2615,9 @@ int CImageDataWriter::end() {
             CT::string key = dkit->first.c_str();
             CT::string value = dkit->second.c_str();
 
-            CT::string *dimValues = key.splitToArray(",");
+            auto dimValues = key.splitToStack(",");
             elP = &data;
-            for (size_t i = 0; i < dimValues->count; i++) {
+            for (size_t i = 0; i < dimValues.size(); i++) {
               try {
                 elP = elP->get(dimValues[i].c_str());
               } catch (int e) {
@@ -2628,7 +2625,6 @@ int CImageDataWriter::end() {
               }
             }
             elP->setValue(value.c_str());
-            delete[] dimValues;
           }
 
           paramElement.add(data);

--- a/adagucserverEC/CImgWarpBilinear.h
+++ b/adagucserverEC/CImgWarpBilinear.h
@@ -92,11 +92,10 @@ public:
 
     if (_definedIntervals != NULL) {
       CT::string defIntervalString = _definedIntervals;
-      CT::string *defIntervalList = defIntervalString.splitToArray(",");
-      for (size_t j = 0; j < defIntervalList->count; j++) {
+      auto defIntervalList = defIntervalString.splitToStack(",");
+      for (size_t j = 0; j < defIntervalList.size(); j++) {
         definedIntervals.push_back(defIntervalList[j].toFloat());
       }
-      delete[] defIntervalList;
     }
 
     if (_textFormat != NULL) {

--- a/adagucserverEC/CMakeEProfile.cpp
+++ b/adagucserverEC/CMakeEProfile.cpp
@@ -559,15 +559,14 @@ int EProfileUniqueRequests::drawEprofile(CDrawImage *drawImage, CDF::Variable *v
   }
 
   if (foundTimeDim != -1) {
-    CT::string *timeEntries = dataSource->srvParams->requestDims[foundTimeDim]->value.splitToArray("/");
-    if (timeEntries->count == 2) {
+    auto timeEntries = dataSource->srvParams->requestDims[foundTimeDim]->value.splitToStack("/");
+    if (timeEntries.size() == 2) {
 #ifdef CMakeEProfile_DEBUG
       CDBDebug("time=%s", dataSource->srvParams->requestDims[foundTimeDim]->value.c_str());
 #endif
       startGraphTime = adagucTime->dateToOffset(adagucTime->freeDateStringToDate(timeEntries[0].c_str()));
       stopGraphTime = adagucTime->dateToOffset(adagucTime->freeDateStringToDate(timeEntries[1].c_str()));
     }
-    delete[] timeEntries;
   }
 
   int foundElevationDim = -1;
@@ -579,8 +578,8 @@ int EProfileUniqueRequests::drawEprofile(CDrawImage *drawImage, CDF::Variable *v
   }
 
   if (foundElevationDim != -1) {
-    CT::string *elevationEntries = dataSource->srvParams->requestDims[foundElevationDim]->value.splitToArray("/");
-    if (elevationEntries->count == 2) {
+    auto elevationEntries = dataSource->srvParams->requestDims[foundElevationDim]->value.splitToStack("/");
+    if (elevationEntries.size() == 2) {
 #ifdef CMakeEProfile_DEBUG
       CDBDebug("elevation=%s", dataSource->srvParams->requestDims[foundElevationDim]->value.c_str());
 #endif
@@ -589,7 +588,6 @@ int EProfileUniqueRequests::drawEprofile(CDrawImage *drawImage, CDF::Variable *v
       stopGraphRange = elevationEntries[1].toDouble();
       ;
     }
-    delete[] elevationEntries;
   }
 
   if (dataSource->srvParams->InfoFormat.equals("application/json")) {

--- a/adagucserverEC/CRequest.cpp
+++ b/adagucserverEC/CRequest.cpp
@@ -1009,9 +1009,9 @@ int CRequest::fillDimValuesForDataSource(CDataSource *dataSource, CServerParams 
       // FIXME: checkTimeFormat used to get called on every dim value, not just datetime. Check if this is required
       if (!dim->isATimeDimension) continue;
 
-      CT::string *dimValues = dim->value.splitToArray(",");
-      for (size_t i = 0; i < dimValues->count; i++) {
-        if (!CServerParams::checkTimeFormat(dimValues[i])) {
+      auto dimValues = dim->value.splitToStack(",");
+      for (auto &dimValue : dimValues) {
+        if (!CServerParams::checkTimeFormat(dimValue)) {
           CDBError("Queried dimension %s=%s failed datetime regex", dim->name.c_str(), dim->value.c_str());
           throw InvalidDimensionValue;
         }

--- a/adagucserverEC/CRequest.h
+++ b/adagucserverEC/CRequest.h
@@ -73,10 +73,10 @@ public:
       headerSize = a + 10;
       CT::string header;
       header.copy(cacheBuffer.c_str(), a - 1);
-      CT::string *lines = header.splitToArray("\n");
-      for (size_t j = 0; j < (size_t)lines->count; j++) {
-        CT::string *params = lines[j].splitToArray(",");
-        if (params->count == 4) {
+      auto lines = header.splitToStack("\n");
+      for (size_t j = 0; j < (size_t)lines.size(); j++) {
+        auto params = lines[j].splitToStack(",");
+        if (params.size() == 4) {
           if (params[0].equals("string")) {
 
             Attribute *attr = new Attribute();
@@ -86,10 +86,7 @@ public:
             attr->end = attr->start + atoi(params[3].c_str());
           }
         }
-        delete[] params;
       }
-
-      delete[] lines;
 
     } else {
       CDBError("no [/header] found");

--- a/adagucserverEC/CServerError.cpp
+++ b/adagucserverEC/CServerError.cpp
@@ -76,9 +76,9 @@ void printerrorImage(void *_drawImage) {
   int y = 1;
   size_t w = drawImage->Geo->dWidth / 6, characters = 0;
   for (size_t i = 0; i < errormsgs.size() - 1; i++) {
-    CT::string *sp = errormsgs[i].splitToArray(" ");
+    auto sp = errormsgs[i].splitToStack(" ");
     CT::string concat = "";
-    for (size_t k = 0; k < sp->count; k++) {
+    for (size_t k = 0; k < sp.size(); k++) {
       if (characters + sp[k].length() < w) {
         concat.concat(&sp[k]);
         concat.concat(" ");
@@ -91,7 +91,6 @@ void printerrorImage(void *_drawImage) {
         characters = concat.length();
       }
     }
-    delete[] sp;
     drawImage->setText(concat.c_str(), concat.length(), 12, 5 + y * 15, 240, -1);
     y++;
   }

--- a/adagucserverEC/CServerParams.cpp
+++ b/adagucserverEC/CServerParams.cpp
@@ -166,9 +166,10 @@ int CServerParams::makeLayerGroupName(CT::string *groupName, CServerConfig::XMLE
   if (cfgLayer->Group.size() == 1) {
     if (cfgLayer->Group[0]->attr.value.c_str() != NULL) {
       CT::string layerName(cfgLayer->Group[0]->attr.value.c_str());
-      CT::string *groupElements = layerName.splitToArray("/");
-      groupName->copy(groupElements[0].c_str());
-      delete[] groupElements;
+      auto groupElements = layerName.splitToStack("/");
+      if (groupElements.size() > 0) {
+        groupName->copy(groupElements[0].c_str());
+      }
     }
   }
 
@@ -387,23 +388,20 @@ bool CServerParams::checkBBOXXYOrder(const char *projName) {
  * @param Legend a XMLE_Legend object configured in a style or in a layer
  * @return Pointer to a new stringlist with all possible legend names, must be deleted with delete. Is NULL on failure.
  */
-CT::PointerList<CT::string *> *CServerParams::getLegendNames(std::vector<CServerConfig::XMLE_Legend *> Legend) {
+std::vector<CT::string> CServerParams::getLegendNames(std::vector<CServerConfig::XMLE_Legend *> Legend) {
   if (Legend.size() == 0) {
     CT::string *autoLegendName = new CT::string("rainbow");
-    CT::PointerList<CT::string *> *legendList = new CT::PointerList<CT::string *>();
-    legendList->push_back(autoLegendName);
+    std::vector<CT::string> legendList;
+    legendList.push_back(autoLegendName);
     return legendList;
   }
-  CT::PointerList<CT::string *> *stringList = new CT::PointerList<CT::string *>();
-
+  std::vector<CT::string> stringList;
   for (size_t j = 0; j < Legend.size(); j++) {
     CT::string legendValue = Legend[j]->value.c_str();
     CT::StackList<CT::string> l1 = legendValue.splitToStack(",");
-    for (size_t i = 0; i < l1.size(); i++) {
-      if (l1[i].length() > 0) {
-        CT::string *val = new CT::string();
-        stringList->push_back(val);
-        val->copy(&l1[i]);
+    for (auto li : l1) {
+      if (li.length() > 0) {
+        stringList.push_back(li);
       }
     }
   }

--- a/adagucserverEC/CServerParams.h
+++ b/adagucserverEC/CServerParams.h
@@ -267,7 +267,7 @@ public:
    * @param Legend a XMLE_Legend object configured in a style or in a layer
    * @return Pointer to a new stringlist with all possible legend names, must be deleted with delete. Is NULL on failure.
    */
-  static CT::PointerList<CT::string *> *getLegendNames(std::vector<CServerConfig::XMLE_Legend *> Legend);
+  static std::vector<CT::string> getLegendNames(std::vector<CServerConfig::XMLE_Legend *> Legend);
 
   /**
    * Checks whether data is restricted or not based on the environment variable ADAGUC_DATARESTRICTION.

--- a/adagucserverEC/CXMLGen.cpp
+++ b/adagucserverEC/CXMLGen.cpp
@@ -158,23 +158,23 @@ int CXMLGen::getWMS_1_1_1_Capabilities(CT::string *XMLDoc, std::vector<MetadataL
       // if(groupKeys[groupIndex].size()>0)
       {
         CT::string key = groupKeys[groupIndex].c_str();
-        CT::string *subGroups = key.splitToArray("/");
-        groupDepth = subGroups->count;
+        auto subGroups = key.splitToStack("/");
+        groupDepth = subGroups.size();
 
         if (groupIndex > 0) {
           CT::string prevKey = groupKeys[groupIndex - 1].c_str();
-          CT::string *prevSubGroups = prevKey.splitToArray("/");
+          auto prevSubGroups = prevKey.splitToStack("/");
 
-          for (size_t j = subGroups->count; j < prevSubGroups->count; j++) {
+          for (size_t j = subGroups.size(); j < prevSubGroups.size(); j++) {
             // CDBError("<");
             currentGroupDepth--;
             XMLDoc->concat("</Layer>\n");
           }
 
-          // CDBError("subGroups->count %d",subGroups->count);
-          // CDBError("prevSubGroups->count %d",prevSubGroups->count);
+          // CDBError("subGroups.size() %d",subGroups.size());
+          // CDBError("prevSubGroups.size() %d",prevSubGroups.size());
           int removeGroups = 0;
-          for (size_t j = 0; j < subGroups->count && j < prevSubGroups->count; j++) {
+          for (size_t j = 0; j < subGroups.size() && j < prevSubGroups.size(); j++) {
             // CDBError("CC %d",j);
             if (subGroups[j].equals(&prevSubGroups[j]) == false || removeGroups == 1) {
               removeGroups = 1;
@@ -186,7 +186,7 @@ int CXMLGen::getWMS_1_1_1_Capabilities(CT::string *XMLDoc, std::vector<MetadataL
             }
           }
           // CDBDebug("!!! %d",currentGroupDepth);
-          for (size_t j = currentGroupDepth; j < subGroups->count; j++) {
+          for (size_t j = currentGroupDepth; j < subGroups.size(); j++) {
             XMLDoc->concat("<Layer>\n");
             XMLDoc->concat("<Title>");
             // CDBError("> %s",subGroups[j].c_str());
@@ -194,9 +194,8 @@ int CXMLGen::getWMS_1_1_1_Capabilities(CT::string *XMLDoc, std::vector<MetadataL
             XMLDoc->concat("</Title>\n");
           }
 
-          delete[] prevSubGroups;
         } else {
-          for (size_t j = 0; j < subGroups->count; j++) {
+          for (size_t j = 0; j < subGroups.size(); j++) {
             XMLDoc->concat("<Layer>\n");
             XMLDoc->concat("<Title>");
             // CDBError("> %s grpupindex %d",subGroups[j].c_str(),groupIndex);
@@ -204,7 +203,6 @@ int CXMLGen::getWMS_1_1_1_Capabilities(CT::string *XMLDoc, std::vector<MetadataL
             XMLDoc->concat("</Title>\n");
           }
         }
-        delete[] subGroups;
         currentGroupDepth = groupDepth;
         // CDBDebug("currentGroupDepth = %d",currentGroupDepth);
       }
@@ -522,23 +520,23 @@ int CXMLGen::getWMS_1_3_0_Capabilities(CT::string *XMLDoc, std::vector<MetadataL
       // if(groupKeys[groupIndex].size()>0)
       {
         CT::string key = groupKeys[groupIndex].c_str();
-        CT::string *subGroups = key.splitToArray("/");
-        groupDepth = subGroups->count;
+        auto subGroups = key.splitToStack("/");
+        groupDepth = subGroups.size();
 
         if (groupIndex > 0) {
           CT::string prevKey = groupKeys[groupIndex - 1].c_str();
-          CT::string *prevSubGroups = prevKey.splitToArray("/");
+          auto prevSubGroups = prevKey.splitToStack("/");
 
-          for (size_t j = subGroups->count; j < prevSubGroups->count; j++) {
+          for (size_t j = subGroups.size(); j < prevSubGroups.size(); j++) {
             // CDBError("<");
             currentGroupDepth--;
             XMLDoc->concat("</Layer>\n");
           }
 
-          // CDBError("subGroups->count %d",subGroups->count);
-          // CDBError("prevSubGroups->count %d",prevSubGroups->count);
+          // CDBError("subGroups.size() %d",subGroups.size());
+          // CDBError("prevSubGroups.size() %d",prevSubGroups.size());
           int removeGroups = 0;
-          for (size_t j = 0; j < subGroups->count && j < prevSubGroups->count; j++) {
+          for (size_t j = 0; j < subGroups.size() && j < prevSubGroups.size(); j++) {
             // CDBError("CC %d",j);
             if (subGroups[j].equals(&prevSubGroups[j]) == false || removeGroups == 1) {
               removeGroups = 1;
@@ -550,7 +548,7 @@ int CXMLGen::getWMS_1_3_0_Capabilities(CT::string *XMLDoc, std::vector<MetadataL
             }
           }
           // CDBDebug("!!! %d",currentGroupDepth);
-          for (size_t j = currentGroupDepth; j < subGroups->count; j++) {
+          for (size_t j = currentGroupDepth; j < subGroups.size(); j++) {
             XMLDoc->concat("<Layer>\n");
             XMLDoc->concat("<Title>");
             // CDBError("> %s",subGroups[j].c_str());
@@ -558,9 +556,8 @@ int CXMLGen::getWMS_1_3_0_Capabilities(CT::string *XMLDoc, std::vector<MetadataL
             XMLDoc->concat("</Title>\n");
           }
 
-          delete[] prevSubGroups;
         } else {
-          for (size_t j = 0; j < subGroups->count; j++) {
+          for (size_t j = 0; j < subGroups.size(); j++) {
             XMLDoc->concat("<Layer>\n");
             XMLDoc->concat("<Title>");
             // CDBError("> %s grpupindex %d",subGroups[j].c_str(),groupIndex);
@@ -568,7 +565,6 @@ int CXMLGen::getWMS_1_3_0_Capabilities(CT::string *XMLDoc, std::vector<MetadataL
             XMLDoc->concat("</Title>\n");
           }
         }
-        delete[] subGroups;
         currentGroupDepth = groupDepth;
         // CDBDebug("currentGroupDepth = %d",currentGroupDepth);
       }
@@ -798,22 +794,21 @@ void generateWCSRangeSet(CT::string *XMLDoc, MetadataLayer *layer) {
   for (size_t d = 0; d < layer->layerMetadata.dimList.size(); d++) {
     LayerMetadataDim *dim = &layer->layerMetadata.dimList[d];
     CT::string min, max, duration;
-    CT::string *valueSplit;
     std::vector<CT::string> valuesVector;
 
     // Case of min/max(/duration), for time dimension
-    valueSplit = dim->values.splitToArray("/");
-    if (valueSplit->count >= 2) {
+    auto valueSplit = dim->values.splitToStack("/");
+    if (valueSplit.size() >= 2) {
       min = valueSplit[0];
       max = valueSplit[1];
       // Third value is the interval duration
-      if (valueSplit->count == 3) {
+      if (valueSplit.size() == 3) {
         duration = valueSplit[2];
       }
     } else {
       // General case of a list of values (of any type)
-      valueSplit = dim->values.splitToArray(",");
-      valuesVector = std::vector<CT::string>(valueSplit, valueSplit + valueSplit->count);
+      valueSplit = dim->values.splitToStack(",");
+      valuesVector = valueSplit;
       std::sort(valuesVector.begin(), valuesVector.end(), multiTypeSort);
       min = valuesVector[0];
       max = valuesVector.back();
@@ -824,7 +819,7 @@ void generateWCSRangeSet(CT::string *XMLDoc, MetadataLayer *layer) {
                         "            <name>%s</name>\n"
                         "            <label>%s</label>\n",
                         dim->cdfName.c_str(), dim->cdfName.c_str());
-    if (valueSplit->count >= 2) {
+    if (valueSplit.size() >= 2) {
       XMLDoc->printconcat("            <values>\n"
                           "              <interval>\n"
                           "                <min>%s</min>\n"
@@ -836,8 +831,8 @@ void generateWCSRangeSet(CT::string *XMLDoc, MetadataLayer *layer) {
       }
       XMLDoc->printconcat("              </interval>\n");
       // Print all possible values if there is a relatively small number, for other dimensions
-      if ((valueSplit->count <= 100) && (dim->cdfName.indexOf("time") == -1)) {
-        for (size_t i = 0; i < valueSplit->count; i++) {
+      if ((valueSplit.size() <= 100) && (dim->cdfName.indexOf("time") == -1)) {
+        for (size_t i = 0; i < valueSplit.size(); i++) {
           XMLDoc->printconcat("              <singleValue>%s</singleValue>\n", valuesVector[i].c_str());
         }
       }
@@ -845,7 +840,6 @@ void generateWCSRangeSet(CT::string *XMLDoc, MetadataLayer *layer) {
     }
     XMLDoc->printconcat("          </AxisDescription>\n"
                         "        </axisDescription>\n");
-    delete[] valueSplit;
   }
 
   XMLDoc->concat("      </RangeSet>\n"
@@ -904,15 +898,14 @@ int CXMLGen::getWCS_1_0_0_DescribeCoverage(CT::string *XMLDoc, std::vector<Metad
 
               if (timeDimIndex >= 0) {
                 // For information about this, visit http://www.galdosinc.com/archives/151
-                CT::string *timeDimSplit = layer->layerMetadata.dimList[timeDimIndex].values.splitToArray("/");
-                if (timeDimSplit->count == 3) {
+                auto timeDimSplit = layer->layerMetadata.dimList[timeDimIndex].values.splitToStack("/");
+                if (timeDimSplit.size() == 3) {
                   XMLDoc->concat("        <gml:TimePeriod>\n");
                   XMLDoc->printconcat("          <gml:begin>%s</gml:begin>\n", timeDimSplit[0].c_str());
                   XMLDoc->printconcat("          <gml:end>%s</gml:end>\n", timeDimSplit[1].c_str());
                   XMLDoc->printconcat("          <gml:duration>%s</gml:duration>\n", timeDimSplit[2].c_str());
                   XMLDoc->concat("        </gml:TimePeriod>\n");
                 }
-                delete[] timeDimSplit;
               }
               XMLDoc->concat("  </lonLatEnvelope>\n"
                              "  <domainSet>\n"
@@ -960,22 +953,20 @@ int CXMLGen::getWCS_1_0_0_DescribeCoverage(CT::string *XMLDoc, std::vector<Metad
               if (timeDimIndex >= 0) {
                 XMLDoc->concat("      <temporalDomain>\n");
                 if (layer->layerMetadata.dimList[timeDimIndex].hasMultipleValues == 0) {
-                  CT::string *timeDimSplit = layer->layerMetadata.dimList[timeDimIndex].values.splitToArray("/");
-                  if (timeDimSplit->count == 3) {
+                  auto timeDimSplit = layer->layerMetadata.dimList[timeDimIndex].values.splitToStack("/");
+                  if (timeDimSplit.size() == 3) {
                     XMLDoc->concat("        <gml:TimePeriod>\n");
                     XMLDoc->printconcat("          <gml:begin>%s</gml:begin>\n", timeDimSplit[0].c_str());
                     XMLDoc->printconcat("          <gml:end>%s</gml:end>\n", timeDimSplit[1].c_str());
                     XMLDoc->printconcat("          <gml:duration>%s</gml:duration>\n", timeDimSplit[2].c_str());
                     XMLDoc->concat("        </gml:TimePeriod>\n");
                   }
-                  delete[] timeDimSplit;
                 } else {
 
-                  CT::string *positions = layer->layerMetadata.dimList[timeDimIndex].values.splitToArray(",");
-                  for (size_t p = 0; p < positions->count; p++) {
+                  auto positions = layer->layerMetadata.dimList[timeDimIndex].values.splitToStack(",");
+                  for (size_t p = 0; p < positions.size(); p++) {
                     XMLDoc->printconcat("        <gml:timePosition>%s</gml:timePosition>\n", (positions[p]).c_str());
                   }
-                  delete[] positions;
                 }
                 XMLDoc->concat("      </temporalDomain>\n");
               }

--- a/adagucserverEC/Definitions.h
+++ b/adagucserverEC/Definitions.h
@@ -28,7 +28,7 @@
 #ifndef Definitions_H
 #define Definitions_H
 
-#define ADAGUCSERVER_VERSION "4.3.4" // Please also update in the Dockerfile to the same version
+#define ADAGUCSERVER_VERSION "4.3.5" // Please also update in the Dockerfile to the same version
 
 // CConfigReaderLayerType
 #define CConfigReaderLayerTypeUnknown 0

--- a/adagucserverEC/testadagucserver.cpp
+++ b/adagucserverEC/testadagucserver.cpp
@@ -82,6 +82,7 @@ TEST(kilometerToMeter, CImageWarper) {
   CT::string projStringOut;
   double scaling;
   std::tie(projStringOut, scaling) = CImageWarper::fixProjection(projStringIn);
+  CDBDebug("projStringOut [%s]", projStringOut.c_str());
   CHECK(scaling == 1000.0);
   CHECK(projStringOut == projStringOutExpected);
 }

--- a/adagucserverEC/utils/LayerMetadataStore.cpp
+++ b/adagucserverEC/utils/LayerMetadataStore.cpp
@@ -403,6 +403,7 @@ int updateMetaDataTable(CDataSource *dataSource) {
   metadataLayer->layer = dataSource->cfgLayer;
   metadataLayer->srvParams = dataSource->srvParams;
   metadataLayer->dataSource = dataSource;
+  metadataLayer->fileName = dataSource->headerFilename;
   int statusA = populateMetadataLayerStruct(metadataLayer, false);
   int statusB = storemetadataLayerIntoMetadataDb(metadataLayer);
   delete metadataLayer;

--- a/adagucserverEC/utils/XMLGenUtils.cpp
+++ b/adagucserverEC/utils/XMLGenUtils.cpp
@@ -808,7 +808,6 @@ int getFileNameForLayer(MetadataLayer *metadataLayer) {
   CDBDebug("getFileNameForLayer");
 #endif
   if (!metadataLayer->fileName.empty()) {
-    CDBDebug("seems already done");
     return 0;
   }
   CServerParams *srvParam = metadataLayer->dataSource->srvParams;

--- a/hclasses/CDirReader.cpp
+++ b/hclasses/CDirReader.cpp
@@ -274,11 +274,11 @@ void CDirReader::makePublicDirectory(const char *dirname) {
   int intStat = stat(dirname, &stFileInfo);
   if (intStat != 0) {
     CT::string directory = dirname;
-    CT::string *directorySplitted = directory.splitToArray("/");
+    auto directorySplitted = directory.splitToStack("/");
     directory = "";
-    for (size_t j = 0; j < directorySplitted->count; j++) {
+    for (auto &directoryPart : directorySplitted) {
       directory.concat("/");
-      directory.concat(directorySplitted[j].c_str());
+      directory.concat(directoryPart);
       const char *part = directory.c_str();
       int intStat = stat(part, &stFileInfo);
       if (intStat != 0) {
@@ -287,7 +287,6 @@ void CDirReader::makePublicDirectory(const char *dirname) {
         chmod(part, 0777);
       }
     }
-    delete[] directorySplitted;
   }
 }
 

--- a/hclasses/CKeyValuePair.h
+++ b/hclasses/CKeyValuePair.h
@@ -29,13 +29,8 @@
 #include <vector>
 #include <stdio.h>
 #include "CTypes.h"
-class CKeyValuePair {
-public:
-  CKeyValuePair(CT::string name, CT::string value) {
-    this->name = name;
-    this->value = value;
-  }
-  CT::string name;
+struct CKeyValuePair {
+  CT::string key;
   CT::string value;
 };
 typedef CT::StackList<CKeyValuePair> CKeyValuePairs;

--- a/hclasses/CTString.cpp
+++ b/hclasses/CTString.cpp
@@ -7,24 +7,6 @@ const char *CT::string::className = "CT::string";
 #endif
 
 namespace CT {
-  PointerList<CT::string *> *string::splitToPointer(const char *_value) {
-    PointerList<CT::string *> *stringList = new PointerList<CT::string *>();
-    const char *fo = strstr(useStack ? stackValue : heapValue, _value);
-    const char *prevFo = useStack ? stackValue : heapValue;
-    while (fo != NULL) {
-      CT::string *val = new CT::string();
-      stringList->push_back(val);
-      val->copy(prevFo, (fo - prevFo));
-      prevFo = fo + 1;
-      fo = strstr(fo + 1, _value);
-    }
-    if (strlen(prevFo) > 0) {
-      CT::string *val = new CT::string();
-      stringList->push_back(val);
-      val->copy(prevFo);
-    }
-    return stringList;
-  }
 
   StackList<CT::string> string::splitToStack(const char *_value) {
     StackList<CT::string> stringList;
@@ -119,28 +101,6 @@ namespace CT {
   }
 
   string::operator const char *() const { return this->c_str(); }
-
-  string *string::splitToArray(const char *_value) {
-    string str(useStack ? stackValue : heapValue, privatelength);
-    void *temp[8000];
-    char *pch;
-    int n = 0;
-    pch = strtok(str.useStack ? str.stackValue : str.heapValue, _value);
-    while (pch != NULL) {
-      string *token = new string(pch);
-      temp[n] = token;
-      pch = strtok(NULL, _value);
-      n++;
-    }
-    string *strings = new string[n + 1];
-    for (int j = 0; j < n; j++) {
-      string *token = (string *)temp[j];
-      strings[j].copy(token->useStack ? token->stackValue : token->heapValue, token->privatelength);
-      strings[j].count = n;
-      delete token;
-    }
-    return strings;
-  };
 
   void string::_Free() {
     if (allocated != 0) {

--- a/hclasses/CTString.h
+++ b/hclasses/CTString.h
@@ -361,20 +361,6 @@ namespace CT {
     string trim();
 
     /**
-     * Function which returns an array of strings
-     * the count value is set in all string object, which indicates the length of the array
-     * @param _value The token to split the string on
-     */
-    string *splitToArray(const char *_value);
-
-    /**
-     * Function which returns a pointer of std::vector which holds a list of string pointers
-     * This function allocates new CT::strings, deleting the std::vector pointer will also delete the strings inside
-     * @param _value The token to split the string on
-     */
-    PointerList<CT::string *> *splitToPointer(const char *_value);
-
-    /**
      * Function which returns a std::vector on the stack with a list of strings allocated on the stack
      * This function links its data to string data, it does not allocate new data or copy the data
      * Resources are freed automatically


### PR DESCRIPTION
- Use splitToStack instead of splitToArray (more robust, less null pointers, self cleaning memory and less code)
- Applied more functional programming instead of using static methods in classes. Also converted classes to structs.
- Refactor of BoundingBox to f8box
- Refactor of P to f8point
- Ran tiling with  `-ggdb -Wall -Wextra -g3 -fsanitize=address` to find all memory issues
- Found and fixed memory issue in PNG reader
- Fixed all compiler warnings on gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0

Closes https://github.com/KNMI/adaguc-server/issues/529