### PR TITLE
Fixed include style in combination with vectors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ USER root
 LABEL maintainer="adaguc@knmi.nl"
 
 # Version should be same as in Definitions.h
-LABEL version="6.1.0"
+LABEL version="6.1.1"
 
 # Try to update image packages
 RUN apt-get -q -y update \

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+**Version 6.1.1 - 2026-01-07**
+
+- Include style now works in combination with vectors (WIK request)
+
 **Version 6.1.0 - 2025-11-28**
 
 - Polyline renderer can now render filled polygons and overlay them using alpha transparency and rendermethod `polygon`.

--- a/adagucserverEC/CConvertADAGUCPoint.cpp
+++ b/adagucserverEC/CConvertADAGUCPoint.cpp
@@ -791,6 +791,8 @@ int CConvertADAGUCPoint::convertADAGUCPointData(CDataSource *dataSource, int mod
     /**
      * The following code is for
      * https://github.com/KNMI/adaguc-server/blob/master/doc/configuration/Point.md#pointstyle-zoomablepoint
+     *
+     * TODO: https://github.com/KNMI/adaguc-server/issues/586
      */
     float discRadius = 8;
     float discRadiusX = discRadius;

--- a/adagucserverEC/CConvertADAGUCPoint.cpp
+++ b/adagucserverEC/CConvertADAGUCPoint.cpp
@@ -788,6 +788,10 @@ int CConvertADAGUCPoint::convertADAGUCPointData(CDataSource *dataSource, int mod
     CDBDebug("Date numStations = %d", numStations);
 #endif
 
+    /**
+     * The following code is for
+     * https://github.com/KNMI/adaguc-server/blob/master/doc/configuration/Point.md#pointstyle-zoomablepoint
+     */
     float discRadius = 8;
     float discRadiusX = discRadius;
     float discRadiusY = discRadius;

--- a/adagucserverEC/CConvertADAGUCPoint.cpp
+++ b/adagucserverEC/CConvertADAGUCPoint.cpp
@@ -795,12 +795,11 @@ int CConvertADAGUCPoint::convertADAGUCPointData(CDataSource *dataSource, int mod
     float discSize = 1;
     if (dataSource != NULL) {
       CStyleConfiguration *styleConfiguration = dataSource->getStyle();
-      if (styleConfiguration != NULL && styleConfiguration->styleConfig != NULL) {
-        if (styleConfiguration->styleConfig->Point.size() == 1) {
-
-          if (!styleConfiguration->styleConfig->Point[0]->attr.discradius.empty()) {
+      if (styleConfiguration != NULL) {
+        for (auto pointInterval : styleConfiguration->pointIntervals) {
+          if (!pointInterval->attr.discradius.empty()) {
             hasZoomableDiscRadius = true;
-            discSize = styleConfiguration->styleConfig->Point[0]->attr.discradius.toFloat();
+            discSize = pointInterval->attr.discradius.toFloat();
           }
         }
       }

--- a/adagucserverEC/CDataPostProcessors/CDataPostProcessor.cpp
+++ b/adagucserverEC/CDataPostProcessors/CDataPostProcessor.cpp
@@ -63,8 +63,8 @@ std::vector<CServerConfig::XMLE_DataPostProc *> getProcessorList(CDataSource *da
     dataProcessorList.push_back(dp);
   }
 
-  if (dataSource->getStyle() != nullptr && dataSource->getStyle()->styleConfig != nullptr) {
-    for (auto dp : dataSource->getStyle()->styleConfig->DataPostProc) {
+  if (dataSource->getStyle() != nullptr) {
+    for (auto dp : dataSource->getStyle()->dataPostProcessors) {
       dataProcessorList.push_back(dp);
     }
   }

--- a/adagucserverEC/CDataReader.cpp
+++ b/adagucserverEC/CDataReader.cpp
@@ -737,12 +737,11 @@ void CDataReader::determineStride2DMap(CDataSource *dataSource) const {
   }
 
   CStyleConfiguration *styleConfiguration = dataSource->getStyle();
-  if (styleConfiguration != NULL && styleConfiguration->styleConfig != NULL) {
-    if (styleConfiguration->styleConfig->RenderSettings.size() == 1) {
-      if ((styleConfiguration->styleConfig->RenderSettings[0])->attr.striding.empty() == false) {
-        dataSource->stride2DMap = styleConfiguration->styleConfig->RenderSettings[0]->attr.striding.toInt();
-        CREPORT_INFO_NODOC(CT::string("Determined a stride of ") + styleConfiguration->styleConfig->RenderSettings[0]->attr.striding + CT::string(" based on RenderSettings."),
-                           CReportMessage::Categories::GENERAL);
+  if (styleConfiguration != nullptr) {
+    for (auto renderSetting : styleConfiguration->renderSettings) {
+      if (renderSetting->attr.striding.empty() == false) {
+        dataSource->stride2DMap = renderSetting->attr.striding.toInt();
+        CREPORT_INFO_NODOC(CT::string("Determined a stride of ") + renderSetting->attr.striding + CT::string(" based on RenderSettings."), CReportMessage::Categories::GENERAL);
         return;
       }
     }

--- a/adagucserverEC/CDataSource.cpp
+++ b/adagucserverEC/CDataSource.cpp
@@ -921,10 +921,11 @@ CDataSource *CDataSource::clone() {
 }
 
 double CDataSource::getScaling() {
-  if (this->getStyle() != NULL && this->getStyle()->styleConfig != NULL) {
-    if (this->getStyle()->styleConfig->RenderSettings.size() > 0) {
-      if (!this->getStyle()->styleConfig->RenderSettings[0]->attr.scalewidth.empty()) {
-        double scaleWidth = this->getStyle()->styleConfig->RenderSettings[0]->attr.scalewidth.toDouble();
+  auto styleConfiguration = this->getStyle();
+  if (styleConfiguration != nullptr) {
+    for (auto renderSetting : styleConfiguration->renderSettings) {
+      if (!renderSetting->attr.scalewidth.empty()) {
+        double scaleWidth = renderSetting->attr.scalewidth.toDouble();
         double imageWidth = (double)this->srvParams->geoParams.width;
         return imageWidth / scaleWidth;
       }
@@ -934,10 +935,11 @@ double CDataSource::getScaling() {
 }
 
 double CDataSource::getContourScaling() {
-  if (this->getStyle() != NULL && this->getStyle()->styleConfig != NULL) {
-    if (this->getStyle()->styleConfig->RenderSettings.size() > 0) {
-      if (!this->getStyle()->styleConfig->RenderSettings[0]->attr.scalecontours.empty()) {
-        double scalecontours = this->getStyle()->styleConfig->RenderSettings[0]->attr.scalecontours.toDouble();
+  auto styleConfiguration = this->getStyle();
+  if (styleConfiguration != nullptr) {
+    for (auto renderSetting : styleConfiguration->renderSettings) {
+      if (!renderSetting->attr.scalecontours.empty()) {
+        double scalecontours = renderSetting->attr.scalecontours.toDouble();
         return scalecontours;
       }
     }

--- a/adagucserverEC/CImageDataWriter.cpp
+++ b/adagucserverEC/CImageDataWriter.cpp
@@ -468,10 +468,12 @@ int CImageDataWriter::init(CServerParams *srvParam, CDataSource *dataSource, int
 
   bool forceGDRenderer = false;
 
-  if (styleConfiguration != NULL && styleConfiguration->styleConfig != NULL && styleConfiguration->styleConfig->RenderSettings.size() == 1) {
+  if (styleConfiguration != NULL) {
     // XMLE_RenderSettings
-    if (styleConfiguration->styleConfig->RenderSettings[0]->attr.renderer.equals("gd")) {
-      forceGDRenderer = true;
+    for (auto renderSetting : styleConfiguration->renderSettings) {
+      if (renderSetting->attr.renderer.equals("gd")) {
+        forceGDRenderer = true;
+      }
     }
   }
 
@@ -1323,11 +1325,13 @@ int CImageDataWriter::warpImage(CDataSource *dataSource, CDrawImage *drawImage) 
         Check the if we want to use discrete type with the bilinear rendermethod.
         The bilinear Rendermethod can shade using ShadeInterval if renderhint in RenderSettings is set to RENDERHINT_DISCRETECLASSES
       */
-      if (styleConfiguration != NULL && styleConfiguration->styleConfig != NULL && styleConfiguration->styleConfig->RenderSettings.size() == 1) {
-        CT::string renderHint = styleConfiguration->styleConfig->RenderSettings[0]->attr.renderhint;
-        if (renderHint.equals(RENDERHINT_DISCRETECLASSES)) {
-          drawMap = false;   // Don't use continous legends with the bilinear renderer
-          drawShaded = true; // Use discrete legends defined by ShadeInterval with the bilinear renderer
+      if (styleConfiguration != nullptr) {
+        for (auto renderSetting : styleConfiguration->renderSettings) {
+          CT::string renderHint = renderSetting->attr.renderhint;
+          if (renderHint.equals(RENDERHINT_DISCRETECLASSES)) {
+            drawMap = false;   // Don't use continous legends with the bilinear renderer
+            drawShaded = true; // Use discrete legends defined by ShadeInterval with the bilinear renderer
+          }
         }
       }
 

--- a/adagucserverEC/CImgRenderStippling.cpp
+++ b/adagucserverEC/CImgRenderStippling.cpp
@@ -132,25 +132,25 @@ void CImgRenderStippling::render(CImageWarper *warper, CDataSource *dataSource, 
   discSize = 6;
   mode = CImgRenderStipplingModeDefault; // Mode 0 is standard stippling
 
-  if (styleConfiguration != NULL && styleConfiguration->styleConfig != NULL) {
-    if (styleConfiguration->styleConfig->Stippling.size() == 1) {
-      if (!styleConfiguration->styleConfig->Stippling[0]->attr.distancex.empty()) {
-        xDistance = styleConfiguration->styleConfig->Stippling[0]->attr.distancex.toInt();
+  if (styleConfiguration != nullptr) {
+    for (auto stippling : styleConfiguration->stipplingList) {
+      if (!stippling->attr.distancex.empty()) {
+        xDistance = stippling->attr.distancex.toInt();
       }
-      if (!styleConfiguration->styleConfig->Stippling[0]->attr.distancey.empty()) {
-        yDistance = styleConfiguration->styleConfig->Stippling[0]->attr.distancey.toInt();
+      if (!stippling->attr.distancey.empty()) {
+        yDistance = stippling->attr.distancey.toInt();
       }
-      if (!styleConfiguration->styleConfig->Stippling[0]->attr.discradius.empty()) {
-        discSize = styleConfiguration->styleConfig->Stippling[0]->attr.discradius.toInt();
+      if (!stippling->attr.discradius.empty()) {
+        discSize = stippling->attr.discradius.toInt();
       }
-      if (!styleConfiguration->styleConfig->Stippling[0]->attr.mode.empty()) {
-        CT::string smode = styleConfiguration->styleConfig->Stippling[0]->attr.mode;
+      if (!stippling->attr.mode.empty()) {
+        CT::string smode = stippling->attr.mode;
         if (smode.equals("threshold")) {
           mode = CImgRenderStipplingModeThreshold;
         }
       }
-      if (!styleConfiguration->styleConfig->Stippling[0]->attr.color.empty()) {
-        color = styleConfiguration->styleConfig->Stippling[0]->attr.color;
+      if (!stippling->attr.color.empty()) {
+        color = stippling->attr.color;
       }
     }
   }

--- a/adagucserverEC/CImgRenderers/CImgRenderPoints.cpp
+++ b/adagucserverEC/CImgRenderers/CImgRenderPoints.cpp
@@ -68,11 +68,15 @@ void drawTextsForVector(CDrawImage *drawImage, CDataSource *dataSource, VectorSt
   }
 }
 
-ThinningInfo getThinningInfo(CServerConfig::XMLE_Style *s) {
+ThinningInfo getThinningInfo(CStyleConfiguration *styleConfiguration) {
   ThinningInfo info;
-  if (s->Thinning.size() == 1 && !s->Thinning[0]->attr.radius.empty()) {
-    info.doThinning = true;
-    info.thinningRadius = s->Thinning[0]->attr.radius.toInt();
+  if (styleConfiguration != nullptr) {
+    for (auto thinning : styleConfiguration->thinningList) {
+      if (!thinning->attr.radius.empty()) {
+        info.doThinning = true;
+        info.thinningRadius = thinning->attr.radius.toInt();
+      }
+    }
   }
   return info;
 }
@@ -116,12 +120,7 @@ std::vector<size_t> doThinningGetIndices(std::vector<PointDVWithLatLon> &p1, boo
 }
 
 void renderVectorPoints(std::vector<size_t> thinnedPointIndexList, CImageWarper *warper, CDataSource *dataSource, CDrawImage *drawImage, CStyleConfiguration *styleConfiguration) {
-
-  if (styleConfiguration == nullptr || styleConfiguration->styleConfig == nullptr) {
-    return;
-  }
-  auto s = styleConfiguration->styleConfig;
-  if (s->Vector.size() == 0) {
+  if (styleConfiguration == nullptr || styleConfiguration->vectorIntervals.size() == 0) {
     return;
   }
 
@@ -152,7 +151,7 @@ void renderVectorPoints(std::vector<size_t> thinnedPointIndexList, CImageWarper 
 
   // Make a list of vector style objects based on the configuration.
   std::vector<VectorStyle> vectorStyles;
-  for (auto cfgVectorStyle : s->Vector) {
+  for (auto cfgVectorStyle : styleConfiguration->vectorIntervals) {
     vectorStyles.push_back(getVectorStyle(cfgVectorStyle, dataSource->srvParams->cfg));
   }
 
@@ -511,13 +510,12 @@ void renderSinglePoints(std::vector<size_t> thinnedPointIndexList, CDataSource *
 std::unordered_set<std::string> shouldUseFilterPoints(CStyleConfiguration *styleConfiguration) {
   std::unordered_set<std::string> usePoints;
 
-  CServerConfig::XMLE_Style *s = styleConfiguration->styleConfig;
-  if (s->FilterPoints.size() == 0) return usePoints;
-  auto attr = s->FilterPoints[0]->attr;
-
-  if (!attr.use.empty()) {
-    for (const auto &token : attr.use.splitToStack(",")) {
-      usePoints.insert(token.c_str());
+  if (styleConfiguration->filterPointList.size() == 0) return usePoints;
+  for (auto filterPoint : styleConfiguration->filterPointList) {
+    if (!filterPoint->attr.use.empty()) {
+      for (const auto &token : filterPoint->attr.use.splitToStack(",")) {
+        usePoints.insert(token.c_str());
+      }
     }
   }
   return usePoints;
@@ -626,20 +624,15 @@ void renderSingleDot(std::vector<size_t> thinnedPointIndexList, CDataSource *dat
 
 void CImgRenderPoints::render(CImageWarper *warper, CDataSource *dataSource, CDrawImage *drawImage) {
   CStyleConfiguration *styleConfiguration = dataSource->getStyle();
-  if (styleConfiguration == NULL || styleConfiguration->styleConfig == NULL) {
+  if (styleConfiguration == NULL) {
     CDBDebug("Note: No styleConfiguration. Skipping.");
     return;
   }
 
-  CServerConfig::XMLE_Style *styleConfig = styleConfiguration->styleConfig;
-  if (styleConfig == NULL) {
-    CDBError("styleConfiguration==NULL!");
-  }
-
   std::unordered_set<std::string> usePoints = shouldUseFilterPoints(styleConfiguration);
-  ThinningInfo thinningInfo = getThinningInfo(styleConfiguration->styleConfig);
+  ThinningInfo thinningInfo = getThinningInfo(styleConfiguration);
 
-  for (auto pointConfig : styleConfig->Point) {
+  for (auto pointConfig : styleConfiguration->pointIntervals) {
     PointStyle pointStyle = getPointStyle(pointConfig, dataSource->srvParams->cfg);
     auto thinnedPointIndexList = doThinningGetIndices(dataSource->getDataObject(0)->points, thinningInfo.doThinning, thinningInfo.thinningRadius, usePoints);
     CDBDebug("Point plotting %d elements %d", thinnedPointIndexList.size(), usePoints.size());

--- a/adagucserverEC/CImgWarpBilinear.cpp
+++ b/adagucserverEC/CImgWarpBilinear.cpp
@@ -406,8 +406,14 @@ void CImgWarpBilinear::render(CImageWarper *warper, CDataSource *sourceImage, CD
       }
     }
     if (enableBarb) {
-      bool rendertextforvectors = styleConfiguration != nullptr && styleConfiguration->styleConfig != nullptr && styleConfiguration->styleConfig->RenderSettings.size() > 0 &&
-                                  styleConfiguration->styleConfig->RenderSettings[0]->attr.rendertextforvectors.equals("true");
+      bool rendertextforvectors = false;
+      if (styleConfiguration != nullptr) {
+        for (auto r : styleConfiguration->renderSettings) {
+          if (r->attr.rendertextforvectors.equals("true")) {
+            rendertextforvectors = true;
+          }
+        }
+      }
       for (size_t sz = 0; sz < windVectors.size(); sz++) {
         CalculatedWindVector wv = windVectors[sz];
         float outlineWidth = 0;

--- a/adagucserverEC/CImgWarpNearestNeighbour.h
+++ b/adagucserverEC/CImgWarpNearestNeighbour.h
@@ -354,9 +354,9 @@ private:
 
     CStyleConfiguration *styleConfiguration = dataSource->getStyle();
     int renderSettings = 0; // auto
-    if (styleConfiguration->styleConfig != NULL && styleConfiguration->styleConfig->RenderSettings.size() == 1) {
-      if (!styleConfiguration->styleConfig->RenderSettings[0]->attr.settings.empty()) {
-        CT::string renderSettingsAttr = styleConfiguration->styleConfig->RenderSettings[0]->attr.settings;
+    for (auto renderSetting : styleConfiguration->renderSettings) {
+      if (!renderSetting->attr.settings.empty()) {
+        CT::string renderSettingsAttr = renderSetting->attr.settings;
         if (renderSettingsAttr.equals("fast")) {
           renderSettings = 1; // fast
         }

--- a/adagucserverEC/CLegendRenderers/CCreateLegend.cpp
+++ b/adagucserverEC/CLegendRenderers/CCreateLegend.cpp
@@ -19,20 +19,17 @@ int CCreateLegend::createLegend(CDataSource *dataSource, CDrawImage *legendImage
   if (dataSource->cfgLayer != NULL) {
     CStyleConfiguration *styleConfiguration = dataSource->getStyle();
     if (styleConfiguration != NULL) {
-      if (styleConfiguration->styleConfig != NULL) {
-        auto drawSettings = getDrawFunctionSettings(dataSource, legendImage, styleConfiguration);
-        if (drawSettings.drawgrid == false) {
-          legendImage->crop(4);
-          return 0;
-        }
-        if (styleConfiguration->styleConfig->LegendGraphic.size() == 1) {
-          if (styleConfiguration->styleConfig->LegendGraphic[0]->attr.value.empty() == false) {
-            const char *fileName = styleConfiguration->styleConfig->LegendGraphic[0]->attr.value.c_str();
-            legendImage->destroyImage();
-            legendImage->createImage(fileName);
-            return 0;
-          }
-        }
+
+      auto drawSettings = getDrawFunctionSettings(dataSource, legendImage, styleConfiguration);
+      if (drawSettings.drawgrid == false) {
+        legendImage->crop(4);
+        return 0;
+      }
+      if (styleConfiguration->legendGraphic.attr.value.empty() == false) {
+        const char *fileName = styleConfiguration->legendGraphic.attr.value.c_str();
+        legendImage->destroyImage();
+        legendImage->createImage(fileName);
+        return 0;
       }
     }
   }
@@ -147,10 +144,9 @@ int CCreateLegend::createLegend(CDataSource *dataSource, CDrawImage *legendImage
     legendType = discrete;
   }
 
-  if (styleConfiguration != NULL && styleConfiguration->styleConfig != NULL && styleConfiguration->styleConfig->RenderSettings.size() == 1) {
-    CT::string renderHint = styleConfiguration->styleConfig->RenderSettings[0]->attr.renderhint;
+  for (auto renderSetting : styleConfiguration->renderSettings) {
     /* When using the nearest or bilinear rendermethod, discrete classes defined by ShadeInterval can be used if the renderhint is set to RENDERHINT_DISCRETECLASSES */
-    if (renderHint.equals(RENDERHINT_DISCRETECLASSES)) {
+    if (renderSetting->attr.renderhint.equals(RENDERHINT_DISCRETECLASSES)) {
       legendType = discrete;
     }
   }

--- a/adagucserverEC/CLegendRenderers/CCreateLegendRenderContinuousLegend.cpp
+++ b/adagucserverEC/CLegendRenderers/CCreateLegendRenderContinuousLegend.cpp
@@ -53,9 +53,8 @@ int CCreateLegend::renderContinuousLegend(CDataSource *dataSource, CDrawImage *l
   CT::string textformatting;
 
   /* Take the textformatting from the Style->Legend configuration */
-  if (styleConfiguration != NULL && styleConfiguration->styleConfig != NULL && styleConfiguration->styleConfig->Legend.size() > 0 &&
-      !styleConfiguration->styleConfig->Legend[0]->attr.textformatting.empty()) {
-    textformatting = styleConfiguration->styleConfig->Legend[0]->attr.textformatting;
+  if (styleConfiguration != nullptr && !styleConfiguration->legend.attr.textformatting.empty()) {
+    textformatting = styleConfiguration->legend.attr.textformatting;
   }
   CDBDebug("TextFormatting=%s", textformatting.c_str());
   double scaling = dataSource->getScaling();

--- a/adagucserverEC/CLegendRenderers/CCreateLegendRenderDiscreteLegend.cpp
+++ b/adagucserverEC/CLegendRenderers/CCreateLegendRenderDiscreteLegend.cpp
@@ -128,9 +128,8 @@ int CCreateLegend::renderDiscreteLegend(CDataSource *dataSource, CDrawImage *leg
   CT::string textformatting;
 
   /* Take the textformatting from the Style->Legend configuration */
-  if (styleConfiguration != NULL && styleConfiguration->styleConfig != NULL && styleConfiguration->styleConfig->Legend.size() > 0 &&
-      !styleConfiguration->styleConfig->Legend[0]->attr.textformatting.empty()) {
-    textformatting = styleConfiguration->styleConfig->Legend[0]->attr.textformatting;
+  if (styleConfiguration != nullptr && styleConfiguration->legend.attr.textformatting.empty()) {
+    textformatting = styleConfiguration->legend.attr.textformatting;
   }
 
   // CDBDebug("styleTitle = [%s]", styleConfiguration->styleTitle.c_str());
@@ -249,9 +248,12 @@ int CCreateLegend::renderDiscreteLegend(CDataSource *dataSource, CDrawImage *leg
     int maxInterval = styleConfiguration->shadeIntervals.size();
     int angle = 0; // Text angle (in radians)
 
-    if (styleConfiguration->styleConfig != NULL && styleConfiguration->styleConfig->RenderSettings.size() == 1 && styleConfiguration->styleConfig->RenderSettings[0]->attr.cliplegend.equals("true")) {
-      std::tie(minInterval, maxInterval) = calculateShadedClassLegendClipping(minValue, maxValue, styleConfiguration);
+    for (auto renderSetting : styleConfiguration->renderSettings) {
+      if (renderSetting->attr.cliplegend.equals("true")) {
+        std::tie(minInterval, maxInterval) = calculateShadedClassLegendClipping(minValue, maxValue, styleConfiguration);
+      }
     }
+
     // Only a subset of intervals to appear on screen to save space
     size_t drawIntervals = maxInterval - minInterval;
 

--- a/adagucserverEC/CStyleConfiguration.cpp
+++ b/adagucserverEC/CStyleConfiguration.cpp
@@ -108,13 +108,12 @@ CT::string CStyleConfiguration::dump() {
 void parseStyleInfo(CStyleConfiguration *styleConfig, CDataSource *dataSource, int styleIndex, int depth) {
   // Get info from style
   CServerConfig::XMLE_Style *style = dataSource->cfg->Style[styleIndex];
-  styleConfig->styleConfig = style;
 
   //  INCLUDE other styles
   for (auto includeStyle : style->IncludeStyle) {
     int extraStyle = dataSource->srvParams->getServerStyleIndexByName(includeStyle->attr.name);
     if (extraStyle >= 0) {
-      // CDBDebug("Include style %d - %s", extraStyle, dataSource->cfg->Style[extraStyle]->attr.name.c_str());
+      CDBDebug("Include style %d - %s", extraStyle, dataSource->cfg->Style[extraStyle]->attr.name.c_str());
       parseStyleInfo(styleConfig, dataSource, extraStyle, depth + 1);
     }
   }
@@ -153,6 +152,19 @@ void parseStyleInfo(CStyleConfiguration *styleConfig, CDataSource *dataSource, i
   styleConfig->shadeIntervals.insert(styleConfig->shadeIntervals.end(), style->ShadeInterval.begin(), style->ShadeInterval.end());
   styleConfig->symbolIntervals.insert(styleConfig->symbolIntervals.end(), style->SymbolInterval.begin(), style->SymbolInterval.end());
   styleConfig->featureIntervals.insert(styleConfig->featureIntervals.end(), style->FeatureInterval.begin(), style->FeatureInterval.end());
+  styleConfig->pointIntervals.insert(styleConfig->pointIntervals.end(), style->Point.begin(), style->Point.end());
+  styleConfig->vectorIntervals.insert(styleConfig->vectorIntervals.end(), style->Vector.begin(), style->Vector.end());
+  styleConfig->dataPostProcessors.insert(styleConfig->dataPostProcessors.end(), style->DataPostProc.begin(), style->DataPostProc.end());
+  styleConfig->stipplingList.insert(styleConfig->stipplingList.end(), style->Stippling.begin(), style->Stippling.end());
+  styleConfig->filterPointList.insert(styleConfig->filterPointList.end(), style->FilterPoints.begin(), style->FilterPoints.end());
+  styleConfig->thinningList.insert(styleConfig->thinningList.end(), style->Thinning.begin(), style->Thinning.end());
+
+  if (style->Legend.size() > 0) {
+    styleConfig->legend = (*style->Legend[0]);
+  }
+  if (style->LegendGraphic.size() > 0) {
+    styleConfig->legendGraphic = (*style->LegendGraphic[0]);
+  }
 
   if (style->Legend.size() > 0) {
     if (style->Legend[0]->attr.tickinterval.empty() == false) {

--- a/adagucserverEC/CStyleConfiguration.h
+++ b/adagucserverEC/CStyleConfiguration.h
@@ -60,8 +60,14 @@ struct CStyleConfiguration {
   std::vector<CServerConfig::XMLE_ShadeInterval *> shadeIntervals;
   std::vector<CServerConfig::XMLE_SymbolInterval *> symbolIntervals;
   std::vector<CServerConfig::XMLE_FeatureInterval *> featureIntervals;
-
-  CServerConfig::XMLE_Style *styleConfig = nullptr; // Direct entrance to styleConfig configuration
+  std::vector<CServerConfig::XMLE_Point *> pointIntervals;
+  std::vector<CServerConfig::XMLE_Vector *> vectorIntervals;
+  std::vector<CServerConfig::XMLE_DataPostProc *> dataPostProcessors;
+  std::vector<CServerConfig::XMLE_Stippling *> stipplingList;
+  std::vector<CServerConfig::XMLE_FilterPoints *> filterPointList;
+  std::vector<CServerConfig::XMLE_Thinning *> thinningList;
+  CServerConfig::XMLE_Legend legend;
+  CServerConfig::XMLE_LegendGraphic legendGraphic;
 
   /**
    * Outputs styleConfiguration as string

--- a/adagucserverEC/Definitions.h
+++ b/adagucserverEC/Definitions.h
@@ -28,7 +28,7 @@
 #ifndef Definitions_H
 #define Definitions_H
 
-#define ADAGUCSERVER_VERSION "6.1.0" // Please also update in the Dockerfile to the same version
+#define ADAGUCSERVER_VERSION "6.1.1" // Please also update in the Dockerfile to the same version
 
 // CConfigReaderLayerType
 #define CConfigReaderLayerTypeUnknown 0

--- a/adagucserverEC/GenericDataWarper/GDWDrawFunctionSettings.cpp
+++ b/adagucserverEC/GenericDataWarper/GDWDrawFunctionSettings.cpp
@@ -44,13 +44,11 @@ GDWDrawFunctionSettings getDrawFunctionSettings(CDataSource *dataSource, CDrawIm
     }
   }
   /* Check the if we want to use discrete type */
-  if (styleConfiguration->styleConfig != nullptr) {
-    // For the generic renderer and when shadeinterval is set, always apply shading.
-    if (settings.isUsingShadeIntervals == false && styleConfiguration->shadeIntervals.size() > 0) {
-      size_t numRenderSettings = styleConfiguration->styleConfig->RenderMethod.size();
-      if (numRenderSettings == 0 || (numRenderSettings > 0 && styleConfiguration->renderMethod == RM_GENERIC)) {
-        settings.isUsingShadeIntervals = true;
-      }
+
+  // For the generic renderer and when shadeinterval is set, always apply shading.
+  if (settings.isUsingShadeIntervals == false && styleConfiguration->shadeIntervals.size() > 0) {
+    if (styleConfiguration->renderMethod == RM_GENERIC) {
+      settings.isUsingShadeIntervals = true;
     }
   }
 

--- a/data/config/datasets/adaguc.tests.harm_windbarbs.xml
+++ b/data/config/datasets/adaguc.tests.harm_windbarbs.xml
@@ -1,6 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
 
+
+  <Style name="wind_colors_from_kts">
+    <ShadeInterval min="0" max="7" label="0-7 (&lt;3 bft)" fillcolor="#FFFFB4"/>
+    <ShadeInterval min="7" max="11" label="7-11 (3 bft)" fillcolor="#FFFF00"/>
+    <ShadeInterval min="11" max="16" label="11-16 (4 bft)" fillcolor="#81FF00"/>
+    <ShadeInterval min="16" max="21" label="16-21 (5 bft)" fillcolor="#008D2C"/>
+    <ShadeInterval min="21" max="27" label="21-27 (6 bft)" fillcolor="#00FFFF"/>
+    <ShadeInterval min="27" max="34" label="27-34 (7 bft)" fillcolor="#74A3FF"/>
+    <ShadeInterval min="34" max="41" label="34-41 (8 bft)" fillcolor="#0000FF"/>
+    <ShadeInterval min="41" max="48" label="41-48 (9 bft)" fillcolor="#FF30FF"/>
+    <ShadeInterval min="48" max="56" label="48-56 (10 bft)" fillcolor="#FF8100"/>
+    <ShadeInterval min="56" max="64" label="56-64 (11 bft)" fillcolor="#FF0000"/>
+    <ShadeInterval min="64" max="74" label="64-74 (12 bft / sshws 1)" fillcolor="#FFFF00"/>
+    <ShadeInterval min="74" max="84" label="74-84 (sshws 1)" fillcolor="#C0C0C0"/>
+    <ShadeInterval min="84" max="100" label="84-100 (sshws 2)" fillcolor="#818181"/>
+    <ShadeInterval min="100" max="200" label="100-200 (sshws 3-5)" fillcolor="#3E3E3E"/>
+  </Style>
+
+  <Style name="wind_colors_from_ms">
+    <ShadeInterval min="0" max="0.3"     label=" 0  [  &lt; 0 kts] (&lt; 0.3 m/s)" fillcolor="#9600fe"/>
+    <ShadeInterval min="0.3" max="1.6"   label=" 1  [  1-3 kts  ] (0.3-1.6 m/s)" fillcolor="#9600fe"/>
+    <ShadeInterval min="1.6" max="3.4"   label=" 2  [  4-6 kts  ] (1.6-3.4 m/s)" fillcolor="#0064fe"/>
+    <ShadeInterval min="3.4" max="5.5"   label=" 3  [  7-10 kts ] (3.4-5.5 m/s)" fillcolor="#00c8fe"/>
+    <ShadeInterval min="5.5" max="8.0"   label=" 4  [ 11-16 kts ] (5.5-8.0 m/s)" fillcolor="#25c192"/>
+    <ShadeInterval min="8.0" max="10.8"  label=" 5  [ 17-21 kts ] (8.0-10.8 m/s)" fillcolor="#00e600"/>
+    <ShadeInterval min="10.8" max="13.9" label=" 6  [ 22-27 kts ] (10.8-13.9 m/s)" fillcolor="#00fa00"/>
+    <ShadeInterval min="13.9" max="17.2" label=" 7  [ 28-33 kts ] (13.9-17.2 m/s)" fillcolor="#feae00"/>
+    <ShadeInterval min="17.2" max="20.8" label=" 8  [ 34-40 kts ] (17.2-20.8 m/s)" fillcolor="#b40032"/>
+    <ShadeInterval min="20.8" max="24.5" label=" 9  [ 41-47 kts ] (20.8-24.5 m/s)" fillcolor="#fE0096"/>
+    <ShadeInterval min="24.5" max="200"  label="10 [  &gt;48 kts ] (&gt;24.5 m/s)" fillcolor="#420027"/>
+  </Style>
+  
   <Style name="Windbarbs">
     <Scale>1</Scale>
     <Offset>0</Offset>
@@ -19,20 +51,7 @@
   </Style>
 
   <Style name="windbarbs_kts">
-    <ShadeInterval min="0" max="7" label="0-7 (&lt;3 bft)" fillcolor="#FFFFB4"/>
-    <ShadeInterval min="7" max="11" label="7-11 (3 bft)" fillcolor="#FFFF00"/>
-    <ShadeInterval min="11" max="16" label="11-16 (4 bft)" fillcolor="#81FF00"/>
-    <ShadeInterval min="16" max="21" label="16-21 (5 bft)" fillcolor="#008D2C"/>
-    <ShadeInterval min="21" max="27" label="21-27 (6 bft)" fillcolor="#00FFFF"/>
-    <ShadeInterval min="27" max="34" label="27-34 (7 bft)" fillcolor="#74A3FF"/>
-    <ShadeInterval min="34" max="41" label="34-41 (8 bft)" fillcolor="#0000FF"/>
-    <ShadeInterval min="41" max="48" label="41-48 (9 bft)" fillcolor="#FF30FF"/>
-    <ShadeInterval min="48" max="56" label="48-56 (10 bft)" fillcolor="#FF8100"/>
-    <ShadeInterval min="56" max="64" label="56-64 (11 bft)" fillcolor="#FF0000"/>
-    <ShadeInterval min="64" max="74" label="64-74 (12 bft / sshws 1)" fillcolor="#FFFF00"/>
-    <ShadeInterval min="74" max="84" label="74-84 (sshws 1)" fillcolor="#C0C0C0"/>
-    <ShadeInterval min="84" max="100" label="84-100 (sshws 2)" fillcolor="#818181"/>
-    <ShadeInterval min="100" max="200" label="100-200 (sshws 3-5)" fillcolor="#3E3E3E"/>
+    <IncludeStyle name="wind_colors_from_kts"/>
     <ContourLine width="1" linecolor="#444444" textcolor="#444444" textformatting="%2.0f" classes="7,11,16,21,27,34,41,48,56,64,74,84,100,200"/>
     <RenderMethod>barbshaded,barbshadedcontour,vectorshaded,vectorshadedcontour,barb</RenderMethod>
     <NameMapping name="barbshaded" title="Wind barbs + filled wind speed contours" abstract="Rendered with barbs"/>
@@ -91,17 +110,7 @@
 
 
 <Style name="windbarbs_kts_shaded_withbarbs_for_grids">
-  <ShadeInterval min="0" max="0.3"     label=" 0  [  &lt; 0 kts] (&lt; 0.3 m/s)" fillcolor="#9600fe"/>
-  <ShadeInterval min="0.3" max="1.6"   label=" 1  [  1-3 kts  ] (0.3-1.6 m/s)" fillcolor="#9600fe"/>
-  <ShadeInterval min="1.6" max="3.4"   label=" 2  [  4-6 kts  ] (1.6-3.4 m/s)" fillcolor="#0064fe"/>
-  <ShadeInterval min="3.4" max="5.5"   label=" 3  [  7-10 kts ] (3.4-5.5 m/s)" fillcolor="#00c8fe"/>
-  <ShadeInterval min="5.5" max="8.0"   label=" 4  [ 11-16 kts ] (5.5-8.0 m/s)" fillcolor="#25c192"/>
-  <ShadeInterval min="8.0" max="10.8"  label=" 5  [ 17-21 kts ] (8.0-10.8 m/s)" fillcolor="#00e600"/>
-  <ShadeInterval min="10.8" max="13.9" label=" 6  [ 22-27 kts ] (10.8-13.9 m/s)" fillcolor="#00fa00"/>
-  <ShadeInterval min="13.9" max="17.2" label=" 7  [ 28-33 kts ] (13.9-17.2 m/s)" fillcolor="#feae00"/>
-  <ShadeInterval min="17.2" max="20.8" label=" 8  [ 34-40 kts ] (17.2-20.8 m/s)" fillcolor="#b40032"/>
-  <ShadeInterval min="20.8" max="24.5" label=" 9  [ 41-47 kts ] (20.8-24.5 m/s)" fillcolor="#fE0096"/>
-  <ShadeInterval min="24.5" max="200"  label="10 [  &gt;48 kts ] (&gt;24.5 m/s)" fillcolor="#420027"/>
+  <IncludeStyle name="wind_colors_from_ms"/>
 
   <Vector  min="0" max="1"     vectorstyle="barb" linewidth="2" linecolor="#FFFFFF" plotvalue="false" outlinewidth="1.6" outlinecolor="#000000" />
   <Vector min="1" max="3.4"      vectorstyle="barb" linewidth="0" linecolor="#000000" plotvalue="true" />
@@ -142,18 +151,7 @@
 
 <Style name="testgeneric">
   <Legend>bluewhitered</Legend>
-  <ShadeInterval min="0" max="0.3"     label=" 0  [  &lt; 0 kts] (&lt; 0.3 m/s)" fillcolor="#9600fe"/>
-  <ShadeInterval min="0.3" max="1.6"   label=" 1  [  1-3 kts  ] (0.3-1.6 m/s)" fillcolor="#9600fe"/>
-  <ShadeInterval min="1.6" max="3.4"   label=" 2  [  4-6 kts  ] (1.6-3.4 m/s)" fillcolor="#0064fe"/>
-  <ShadeInterval min="3.4" max="5.5"   label=" 3  [  7-10 kts ] (3.4-5.5 m/s)" fillcolor="#00c8fe"/>
-  <ShadeInterval min="5.5" max="8.0"   label=" 4  [ 11-16 kts ] (5.5-8.0 m/s)" fillcolor="#25c192"/>
-  <ShadeInterval min="8.0" max="10.8"  label=" 5  [ 17-21 kts ] (8.0-10.8 m/s)" fillcolor="#00e600"/>
-  <ShadeInterval min="10.8" max="13.9" label=" 6  [ 22-27 kts ] (10.8-13.9 m/s)" fillcolor="#00fa00"/>
-  <ShadeInterval min="13.9" max="17.2" label=" 7  [ 28-33 kts ] (13.9-17.2 m/s)" fillcolor="#feae00"/>
-  <ShadeInterval min="17.2" max="20.8" label=" 8  [ 34-40 kts ] (17.2-20.8 m/s)" fillcolor="#b40032"/>
-  <ShadeInterval min="20.8" max="24.5" label=" 9  [ 41-47 kts ] (20.8-24.5 m/s)" fillcolor="#fE0096"/>
-  <ShadeInterval min="24.5" max="200"  label="10 [  &gt;48 kts ] (&gt;24.5 m/s)" fillcolor="#420027"/>
-
+  <IncludeStyle name="wind_colors_from_ms"/>
   <Vector  min="0" max="1"     vectorstyle="barb" linewidth="2" linecolor="#FFFFFF" plotvalue="false" outlinewidth="1.6" outlinecolor="#000000" />
   <Vector min="1" max="3.4"      vectorstyle="barb" linewidth="0" linecolor="#000000" plotvalue="true" />
   <Vector min="3.4" max="8"      vectorstyle="barb" linewidth="3" linecolor="#FFFF00" plotvalue="true" />

--- a/data/config/datasets/test.uwcw_ha43_dini_5p5km_10x8.xml
+++ b/data/config/datasets/test.uwcw_ha43_dini_5p5km_10x8.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" ?>
 <Configuration>
- 
-  <OgcApiFeatures/>
 
-
- <Legend name="temperature_wow" type="interval">
+  <Legend name="temperature_wow" type="interval">
     <palette index="0" color="#2E2E73"/>
     <palette index="9" color="#282898"/>
     <palette index="18" color="#201FBB"/>
@@ -35,259 +32,144 @@
     <palette index="240" color="#871A44"/>
   </Legend>
 
-  <Style name="temperature_wow">
+  <Style name="temperature_colors">
+    <ShadeInterval min="-60" max="-59" label="-60--59" fillcolor="#BFB1FF"/>
+    <ShadeInterval min="-59" max="-58" label="-59--58" fillcolor="#8E7EE4"/>
+    <ShadeInterval min="-58" max="-57" label="-58--57" fillcolor="#6450CC"/>
+    <ShadeInterval min="-57" max="-56" label="-57--56" fillcolor="#422BB1"/>
+    <ShadeInterval min="-56" max="-55" label="-56--55" fillcolor="#260E99"/>
+    <ShadeInterval min="-55" max="-54" label="-55--54" fillcolor="#B1E4FF"/>
+    <ShadeInterval min="-54" max="-53" label="-54--53" fillcolor="#7EC3E4"/>
+    <ShadeInterval min="-53" max="-52" label="-53--52" fillcolor="#50A3CC"/>
+    <ShadeInterval min="-52" max="-51" label="-52--51" fillcolor="#2B85B1"/>
+    <ShadeInterval min="-51" max="-50" label="-51--50" fillcolor="#0E6B99"/>
+    <ShadeInterval min="-50" max="-49" label="-50--49" fillcolor="#E4FFB1"/>
+    <ShadeInterval min="-49" max="-48" label="-59--48" fillcolor="#C3E47E"/>
+    <ShadeInterval min="-48" max="-47" label="-48--47" fillcolor="#A3CC50"/>
+    <ShadeInterval min="-47" max="-46" label="-47--46" fillcolor="#85B12B"/>
+    <ShadeInterval min="-46" max="-45" label="-46--45" fillcolor="#6B990E"/>
+    <ShadeInterval min="-45" max="-44" label="-45--44" fillcolor="#FFD8B1"/>
+    <ShadeInterval min="-44" max="-43" label="-44--43" fillcolor="#E4B17E"/>
+    <ShadeInterval min="-43" max="-42" label="-43--42" fillcolor="#CC8E50"/>
+    <ShadeInterval min="-42" max="-41" label="-42--41" fillcolor="#B16E2B"/>
+    <ShadeInterval min="-41" max="-40" label="-41--40" fillcolor="#99540E"/>
+    <ShadeInterval min="-40" max="-39" label="-40--39" fillcolor="#FFB1B1"/>
+    <ShadeInterval min="-39" max="-38" label="-39--38" fillcolor="#E47E7E"/>
+    <ShadeInterval min="-38" max="-37" label="-38--37" fillcolor="#CC5050"/>
+    <ShadeInterval min="-37" max="-36" label="-37--36" fillcolor="#B12B2B"/>
+    <ShadeInterval min="-36" max="-35" label="-36--35" fillcolor="#990E0E"/>
+    <ShadeInterval min="-35" max="-34" label="-35--34" fillcolor="#BFB1FF"/>
+    <ShadeInterval min="-34" max="-33" label="-34--33" fillcolor="#8E7EE4"/>
+    <ShadeInterval min="-33" max="-32" label="-33--32" fillcolor="#6450CC"/>
+    <ShadeInterval min="-32" max="-31" label="-32--31" fillcolor="#422BB1"/>
+    <ShadeInterval min="-31" max="-30" label="-31--30" fillcolor="#260E99"/>
+    <ShadeInterval min="-30" max="-29" label="-30--29" fillcolor="#B1E4FF"/>
+    <ShadeInterval min="-29" max="-28" label="-29--28" fillcolor="#7EC3E4"/>
+    <ShadeInterval min="-28" max="-27" label="-28--27" fillcolor="#50A3CC"/>
+    <ShadeInterval min="-27" max="-26" label="-27--26" fillcolor="#2B85B1"/>
+    <ShadeInterval min="-26" max="-25" label="-26--25" fillcolor="#0E6B99"/>
+    <ShadeInterval min="-25" max="-24" label="-25--24" fillcolor="#E4FFB1"/>
+    <ShadeInterval min="-24" max="-23" label="-24--23" fillcolor="#C3E47E"/>
+    <ShadeInterval min="-23" max="-22" label="-23--22" fillcolor="#A3CC50"/>
+    <ShadeInterval min="-22" max="-21" label="-22--21" fillcolor="#85B12B"/>
+    <ShadeInterval min="-21" max="-20" label="-21--20" fillcolor="#6B990E"/>
+    <ShadeInterval min="-20" max="-19" label="-20--19" fillcolor="#FFD8B1"/>
+    <ShadeInterval min="-19" max="-18" label="-19--18" fillcolor="#E4B17E"/>
+    <ShadeInterval min="-18" max="-17" label="-18--17" fillcolor="#CC8E50"/>
+    <ShadeInterval min="-17" max="-16" label="-17--16" fillcolor="#B16E2B"/>
+    <ShadeInterval min="-16" max="-15" label="-16--15" fillcolor="#99540E"/>
+    <ShadeInterval min="-15" max="-14" label="-15--14" fillcolor="#FFB1B1"/>
+    <ShadeInterval min="-14" max="-13" label="-14--13" fillcolor="#E47E7E"/>
+    <ShadeInterval min="-13" max="-12" label="-13--12" fillcolor="#CC5050"/>
+    <ShadeInterval min="-12" max="-11" label="-12--11" fillcolor="#B12B2B"/>
+    <ShadeInterval min="-11" max="-10" label="-11--10" fillcolor="#990E0E"/>
+    <ShadeInterval min="-10" max="-9" label="-10--9" fillcolor="#BFB1FF"/>
+    <ShadeInterval min="-9" max="-8" label="-9--8" fillcolor="#8E7EE4"/>
+    <ShadeInterval min="-8" max="-7" label="-8--7" fillcolor="#6450CC"/>
+    <ShadeInterval min="-7" max="-6" label="-7--6" fillcolor="#422BB1"/>
+    <ShadeInterval min="-6" max="-5" label="-6--5" fillcolor="#260E99"/>
+    <ShadeInterval min="-5" max="-4" label="-5--4" fillcolor="#B1E4FF"/>
+    <ShadeInterval min="-4" max="-3" label="-4--3" fillcolor="#7EC3E4"/>
+    <ShadeInterval min="-3" max="-2" label="-3--2" fillcolor="#50A3CC"/>
+    <ShadeInterval min="-2" max="-1" label="-2--1" fillcolor="#2B85B1"/>
+    <ShadeInterval min="-1" max="0" label="-1-0" fillcolor="#0E6B99"/>
+    <ShadeInterval min="0" max="1" label="0-1" fillcolor="#E4FFB1"/>
+    <ShadeInterval min="1" max="2" label="1-2" fillcolor="#C3E47E"/>
+    <ShadeInterval min="2" max="3" label="2-3" fillcolor="#A3CC50"/>
+    <ShadeInterval min="3" max="4" label="3-4" fillcolor="#85B12B"/>
+    <ShadeInterval min="4" max="5" label="4-5" fillcolor="#6B990E"/>
+    <ShadeInterval min="5" max="6" label="5-6" fillcolor="#FFD8B1"/>
+    <ShadeInterval min="6" max="7" label="6-7" fillcolor="#E4B17E"/>
+    <ShadeInterval min="7" max="8" label="7-8" fillcolor="#CC8E50"/>
+    <ShadeInterval min="8" max="9" label="8-9" fillcolor="#B16E2B"/>
+    <ShadeInterval min="9" max="10" label="9-10" fillcolor="#99540E"/>
+    <ShadeInterval min="10" max="11" label="10-11" fillcolor="#FFB1B1"/>
+    <ShadeInterval min="11" max="12" label="11-12" fillcolor="#E47E7E"/>
+    <ShadeInterval min="12" max="13" label="12-13" fillcolor="#CC5050"/>
+    <ShadeInterval min="13" max="14" label="13-14" fillcolor="#B12B2B"/>
+    <ShadeInterval min="14" max="15" label="14-15" fillcolor="#990E0E"/>
+    <ShadeInterval min="15" max="16" label="15-16" fillcolor="#BFB1FF"/>
+    <ShadeInterval min="16" max="17" label="16-17" fillcolor="#8E7EE4"/>
+    <ShadeInterval min="17" max="18" label="17-18" fillcolor="#6450CC"/>
+    <ShadeInterval min="18" max="19" label="18-19" fillcolor="#422BB1"/>
+    <ShadeInterval min="19" max="20" label="19-20" fillcolor="#260E99"/>
+    <ShadeInterval min="20" max="21" label="20-21" fillcolor="#B1E4FF"/>
+    <ShadeInterval min="21" max="22" label="21-22" fillcolor="#7EC3E4"/>
+    <ShadeInterval min="22" max="23" label="22-23" fillcolor="#50A3CC"/>
+    <ShadeInterval min="23" max="24" label="23-24" fillcolor="#2B85B1"/>
+    <ShadeInterval min="24" max="25" label="24-25" fillcolor="#0E6B99"/>
+    <ShadeInterval min="25" max="26" label="25-26" fillcolor="#E4FFB1"/>
+    <ShadeInterval min="26" max="27" label="26-27" fillcolor="#C3E47E"/>
+    <ShadeInterval min="27" max="28" label="27-28" fillcolor="#A3CC50"/>
+    <ShadeInterval min="28" max="29" label="28-29" fillcolor="#85B12B"/>
+    <ShadeInterval min="29" max="30" label="29-30" fillcolor="#6B990E"/>
+    <ShadeInterval min="30" max="31" label="30-31" fillcolor="#FFD8B1"/>
+    <ShadeInterval min="31" max="32" label="31-32" fillcolor="#E4B17E"/>
+    <ShadeInterval min="32" max="33" label="32-33" fillcolor="#CC8E50"/>
+    <ShadeInterval min="33" max="34" label="33-34" fillcolor="#B16E2B"/>
+    <ShadeInterval min="34" max="35" label="34-35" fillcolor="#99540E"/>
+    <ShadeInterval min="35" max="36" label="35-36" fillcolor="#FFB1B1"/>
+    <ShadeInterval min="36" max="37" label="36-37" fillcolor="#E47E7E"/>
+    <ShadeInterval min="37" max="38" label="37-38" fillcolor="#CC5050"/>
+    <ShadeInterval min="38" max="39" label="38-39" fillcolor="#B12B2B"/>
+    <ShadeInterval min="39" max="40" label="39-40" fillcolor="#990E0E"/>
+    <ShadeInterval min="40" max="41" label="40-41" fillcolor="#FFD8B1"/>
+    <ShadeInterval min="41" max="42" label="41-42" fillcolor="#E4B17E"/>
+    <ShadeInterval min="42" max="43" label="42-43" fillcolor="#CC8E50"/>
+    <ShadeInterval min="43" max="44" label="43-44" fillcolor="#B16E2B"/>
+    <ShadeInterval min="44" max="45" label="44-45" fillcolor="#99540E"/>
+    <ShadeInterval min="45" max="46" label="45-46" fillcolor="#FFB1B1"/>
+    <ShadeInterval min="46" max="47" label="46-47" fillcolor="#E47E7E"/>
+    <ShadeInterval min="47" max="48" label="47-48" fillcolor="#CC5050"/>
+    <ShadeInterval min="48" max="49" label="48-49" fillcolor="#B12B2B"/>
+    <ShadeInterval min="49" max="50" label="49-50" fillcolor="#990E0E"/>
+  </Style>
+
+  <Style name="temperature_wow" title="Filled contours (WOW)" abstract="Filled background (WOW)">
     <Legend fixed="false" tickinterval="5">temperature_wow</Legend>
     <Min>-14</Min>
     <Max>39,33333333</Max>
     <ShadeInterval>2</ShadeInterval>
     <ContourLine width="0.8" linecolor="#1a1a1a" textcolor="#1a1a1a" textformatting="%2.0f" interval="10"/>
     <ContourLine width="0.3" linecolor="#444444" textcolor="#444444" textformatting="%2.0f" interval="2"/>
-    <RenderMethod>shaded,shadedcontour</RenderMethod>
-    <NameMapping name="shaded" title="Filled contours (WOW)" abstract="Filled background (WOW)"/>
-    <NameMapping name="shadedcontour" title="Filled contours and lines (WOW)" abstract="Contour lines with filled background (WOW)"/>
     <SmoothingFilter>0</SmoothingFilter>
     <StandardNames standard_name="dew_point_temperature,dewpoint_temperature,air_temperature,temperature,Temperature_2m"/>
   </Style>
 
-<Style name="temperature">
-    <ShadeInterval min="-60" max="-59" label="-60--59" fillcolor="#BFB1FF"/>
-    <ShadeInterval min="-59" max="-58" label="-59--58" fillcolor="#8E7EE4"/>
-    <ShadeInterval min="-58" max="-57" label="-58--57" fillcolor="#6450CC"/>
-    <ShadeInterval min="-57" max="-56" label="-57--56" fillcolor="#422BB1"/>
-    <ShadeInterval min="-56" max="-55" label="-56--55" fillcolor="#260E99"/>
-    <ShadeInterval min="-55" max="-54" label="-55--54" fillcolor="#B1E4FF"/>
-    <ShadeInterval min="-54" max="-53" label="-54--53" fillcolor="#7EC3E4"/>
-    <ShadeInterval min="-53" max="-52" label="-53--52" fillcolor="#50A3CC"/>
-    <ShadeInterval min="-52" max="-51" label="-52--51" fillcolor="#2B85B1"/>
-    <ShadeInterval min="-51" max="-50" label="-51--50" fillcolor="#0E6B99"/>
-    <ShadeInterval min="-50" max="-49" label="-50--49" fillcolor="#E4FFB1"/>
-    <ShadeInterval min="-49" max="-48" label="-59--48" fillcolor="#C3E47E"/>
-    <ShadeInterval min="-48" max="-47" label="-48--47" fillcolor="#A3CC50"/>
-    <ShadeInterval min="-47" max="-46" label="-47--46" fillcolor="#85B12B"/>
-    <ShadeInterval min="-46" max="-45" label="-46--45" fillcolor="#6B990E"/>
-    <ShadeInterval min="-45" max="-44" label="-45--44" fillcolor="#FFD8B1"/>
-    <ShadeInterval min="-44" max="-43" label="-44--43" fillcolor="#E4B17E"/>
-    <ShadeInterval min="-43" max="-42" label="-43--42" fillcolor="#CC8E50"/>
-    <ShadeInterval min="-42" max="-41" label="-42--41" fillcolor="#B16E2B"/>
-    <ShadeInterval min="-41" max="-40" label="-41--40" fillcolor="#99540E"/>
-    <ShadeInterval min="-40" max="-39" label="-40--39" fillcolor="#FFB1B1"/>
-    <ShadeInterval min="-39" max="-38" label="-39--38" fillcolor="#E47E7E"/>
-    <ShadeInterval min="-38" max="-37" label="-38--37" fillcolor="#CC5050"/>
-    <ShadeInterval min="-37" max="-36" label="-37--36" fillcolor="#B12B2B"/>
-    <ShadeInterval min="-36" max="-35" label="-36--35" fillcolor="#990E0E"/>
-    <ShadeInterval min="-35" max="-34" label="-35--34" fillcolor="#BFB1FF"/>
-    <ShadeInterval min="-34" max="-33" label="-34--33" fillcolor="#8E7EE4"/>
-    <ShadeInterval min="-33" max="-32" label="-33--32" fillcolor="#6450CC"/>
-    <ShadeInterval min="-32" max="-31" label="-32--31" fillcolor="#422BB1"/>
-    <ShadeInterval min="-31" max="-30" label="-31--30" fillcolor="#260E99"/>
-    <ShadeInterval min="-30" max="-29" label="-30--29" fillcolor="#B1E4FF"/>
-    <ShadeInterval min="-29" max="-28" label="-29--28" fillcolor="#7EC3E4"/>
-    <ShadeInterval min="-28" max="-27" label="-28--27" fillcolor="#50A3CC"/>
-    <ShadeInterval min="-27" max="-26" label="-27--26" fillcolor="#2B85B1"/>
-    <ShadeInterval min="-26" max="-25" label="-26--25" fillcolor="#0E6B99"/>
-    <ShadeInterval min="-25" max="-24" label="-25--24" fillcolor="#E4FFB1"/>
-    <ShadeInterval min="-24" max="-23" label="-24--23" fillcolor="#C3E47E"/>
-    <ShadeInterval min="-23" max="-22" label="-23--22" fillcolor="#A3CC50"/>
-    <ShadeInterval min="-22" max="-21" label="-22--21" fillcolor="#85B12B"/>
-    <ShadeInterval min="-21" max="-20" label="-21--20" fillcolor="#6B990E"/>
-    <ShadeInterval min="-20" max="-19" label="-20--19" fillcolor="#FFD8B1"/>
-    <ShadeInterval min="-19" max="-18" label="-19--18" fillcolor="#E4B17E"/>
-    <ShadeInterval min="-18" max="-17" label="-18--17" fillcolor="#CC8E50"/>
-    <ShadeInterval min="-17" max="-16" label="-17--16" fillcolor="#B16E2B"/>
-    <ShadeInterval min="-16" max="-15" label="-16--15" fillcolor="#99540E"/>
-    <ShadeInterval min="-15" max="-14" label="-15--14" fillcolor="#FFB1B1"/>
-    <ShadeInterval min="-14" max="-13" label="-14--13" fillcolor="#E47E7E"/>
-    <ShadeInterval min="-13" max="-12" label="-13--12" fillcolor="#CC5050"/>
-    <ShadeInterval min="-12" max="-11" label="-12--11" fillcolor="#B12B2B"/>
-    <ShadeInterval min="-11" max="-10" label="-11--10" fillcolor="#990E0E"/>
-    <ShadeInterval min="-10" max="-9" label="-10--9" fillcolor="#BFB1FF"/>
-    <ShadeInterval min="-9" max="-8" label="-9--8" fillcolor="#8E7EE4"/>
-    <ShadeInterval min="-8" max="-7" label="-8--7" fillcolor="#6450CC"/>
-    <ShadeInterval min="-7" max="-6" label="-7--6" fillcolor="#422BB1"/>
-    <ShadeInterval min="-6" max="-5" label="-6--5" fillcolor="#260E99"/>
-    <ShadeInterval min="-5" max="-4" label="-5--4" fillcolor="#B1E4FF"/>
-    <ShadeInterval min="-4" max="-3" label="-4--3" fillcolor="#7EC3E4"/>
-    <ShadeInterval min="-3" max="-2" label="-3--2" fillcolor="#50A3CC"/>
-    <ShadeInterval min="-2" max="-1" label="-2--1" fillcolor="#2B85B1"/>
-    <ShadeInterval min="-1" max="0" label="-1-0" fillcolor="#0E6B99"/>
-    <ShadeInterval min="0" max="1" label="0-1" fillcolor="#E4FFB1"/>
-    <ShadeInterval min="1" max="2" label="1-2" fillcolor="#C3E47E"/>
-    <ShadeInterval min="2" max="3" label="2-3" fillcolor="#A3CC50"/>
-    <ShadeInterval min="3" max="4" label="3-4" fillcolor="#85B12B"/>
-    <ShadeInterval min="4" max="5" label="4-5" fillcolor="#6B990E"/>
-    <ShadeInterval min="5" max="6" label="5-6" fillcolor="#FFD8B1"/>
-    <ShadeInterval min="6" max="7" label="6-7" fillcolor="#E4B17E"/>
-    <ShadeInterval min="7" max="8" label="7-8" fillcolor="#CC8E50"/>
-    <ShadeInterval min="8" max="9" label="8-9" fillcolor="#B16E2B"/>
-    <ShadeInterval min="9" max="10" label="9-10" fillcolor="#99540E"/>
-    <ShadeInterval min="10" max="11" label="10-11" fillcolor="#FFB1B1"/>
-    <ShadeInterval min="11" max="12" label="11-12" fillcolor="#E47E7E"/>
-    <ShadeInterval min="12" max="13" label="12-13" fillcolor="#CC5050"/>
-    <ShadeInterval min="13" max="14" label="13-14" fillcolor="#B12B2B"/>
-    <ShadeInterval min="14" max="15" label="14-15" fillcolor="#990E0E"/>
-    <ShadeInterval min="15" max="16" label="15-16" fillcolor="#BFB1FF"/>
-    <ShadeInterval min="16" max="17" label="16-17" fillcolor="#8E7EE4"/>
-    <ShadeInterval min="17" max="18" label="17-18" fillcolor="#6450CC"/>
-    <ShadeInterval min="18" max="19" label="18-19" fillcolor="#422BB1"/>
-    <ShadeInterval min="19" max="20" label="19-20" fillcolor="#260E99"/>
-    <ShadeInterval min="20" max="21" label="20-21" fillcolor="#B1E4FF"/>
-    <ShadeInterval min="21" max="22" label="21-22" fillcolor="#7EC3E4"/>
-    <ShadeInterval min="22" max="23" label="22-23" fillcolor="#50A3CC"/>
-    <ShadeInterval min="23" max="24" label="23-24" fillcolor="#2B85B1"/>
-    <ShadeInterval min="24" max="25" label="24-25" fillcolor="#0E6B99"/>
-    <ShadeInterval min="25" max="26" label="25-26" fillcolor="#E4FFB1"/>
-    <ShadeInterval min="26" max="27" label="26-27" fillcolor="#C3E47E"/>
-    <ShadeInterval min="27" max="28" label="27-28" fillcolor="#A3CC50"/>
-    <ShadeInterval min="28" max="29" label="28-29" fillcolor="#85B12B"/>
-    <ShadeInterval min="29" max="30" label="29-30" fillcolor="#6B990E"/>
-    <ShadeInterval min="30" max="31" label="30-31" fillcolor="#FFD8B1"/>
-    <ShadeInterval min="31" max="32" label="31-32" fillcolor="#E4B17E"/>
-    <ShadeInterval min="32" max="33" label="32-33" fillcolor="#CC8E50"/>
-    <ShadeInterval min="33" max="34" label="33-34" fillcolor="#B16E2B"/>
-    <ShadeInterval min="34" max="35" label="34-35" fillcolor="#99540E"/>
-    <ShadeInterval min="35" max="36" label="35-36" fillcolor="#FFB1B1"/>
-    <ShadeInterval min="36" max="37" label="36-37" fillcolor="#E47E7E"/>
-    <ShadeInterval min="37" max="38" label="37-38" fillcolor="#CC5050"/>
-    <ShadeInterval min="38" max="39" label="38-39" fillcolor="#B12B2B"/>
-    <ShadeInterval min="39" max="40" label="39-40" fillcolor="#990E0E"/>
-    <ShadeInterval min="40" max="41" label="40-41" fillcolor="#FFD8B1"/>
-    <ShadeInterval min="41" max="42" label="41-42" fillcolor="#E4B17E"/>
-    <ShadeInterval min="42" max="43" label="42-43" fillcolor="#CC8E50"/>
-    <ShadeInterval min="43" max="44" label="43-44" fillcolor="#B16E2B"/>
-    <ShadeInterval min="44" max="45" label="44-45" fillcolor="#99540E"/>
-    <ShadeInterval min="45" max="46" label="45-46" fillcolor="#FFB1B1"/>
-    <ShadeInterval min="46" max="47" label="46-47" fillcolor="#E47E7E"/>
-    <ShadeInterval min="47" max="48" label="47-48" fillcolor="#CC5050"/>
-    <ShadeInterval min="48" max="49" label="48-49" fillcolor="#B12B2B"/>
-    <ShadeInterval min="49" max="50" label="49-50" fillcolor="#990E0E"/>
+  <Style name="temperature"  title="Filled contours" abstract="Filled background">
+    <IncludeStyle name="temperature_colors"/>
     <ContourLine width="0.3" linecolor="#444444" textcolor="#444444" textformatting="%2.0f" interval="1"/>
-    <RenderMethod>shaded,shadedcontour</RenderMethod>
-    <NameMapping name="shaded" title="Filled contours" abstract="Filled background"/>
-    <NameMapping name="shadedcontour" title="Filled contours and lines" abstract="Contour lines with filled background"/>
     <SmoothingFilter>0</SmoothingFilter>
     <StandardNames standard_name="dew_point_temperature,dewpoint_temperature,air_temperature,temperature,Temperature_2m"/>
   </Style>
 
-  <Style name="temperature_clip">
+  <Style name="temperature_clip" title="Filled contours" abstract="Filled background">
+    <IncludeStyle name="temperature_colors"/>
     <RenderSettings cliplegend="true"/>
-    <ShadeInterval min="-60" max="-59" label="-60--59" fillcolor="#BFB1FF"/>
-    <ShadeInterval min="-59" max="-58" label="-59--58" fillcolor="#8E7EE4"/>
-    <ShadeInterval min="-58" max="-57" label="-58--57" fillcolor="#6450CC"/>
-    <ShadeInterval min="-57" max="-56" label="-57--56" fillcolor="#422BB1"/>
-    <ShadeInterval min="-56" max="-55" label="-56--55" fillcolor="#260E99"/>
-    <ShadeInterval min="-55" max="-54" label="-55--54" fillcolor="#B1E4FF"/>
-    <ShadeInterval min="-54" max="-53" label="-54--53" fillcolor="#7EC3E4"/>
-    <ShadeInterval min="-53" max="-52" label="-53--52" fillcolor="#50A3CC"/>
-    <ShadeInterval min="-52" max="-51" label="-52--51" fillcolor="#2B85B1"/>
-    <ShadeInterval min="-51" max="-50" label="-51--50" fillcolor="#0E6B99"/>
-    <ShadeInterval min="-50" max="-49" label="-50--49" fillcolor="#E4FFB1"/>
-    <ShadeInterval min="-49" max="-48" label="-59--48" fillcolor="#C3E47E"/>
-    <ShadeInterval min="-48" max="-47" label="-48--47" fillcolor="#A3CC50"/>
-    <ShadeInterval min="-47" max="-46" label="-47--46" fillcolor="#85B12B"/>
-    <ShadeInterval min="-46" max="-45" label="-46--45" fillcolor="#6B990E"/>
-    <ShadeInterval min="-45" max="-44" label="-45--44" fillcolor="#FFD8B1"/>
-    <ShadeInterval min="-44" max="-43" label="-44--43" fillcolor="#E4B17E"/>
-    <ShadeInterval min="-43" max="-42" label="-43--42" fillcolor="#CC8E50"/>
-    <ShadeInterval min="-42" max="-41" label="-42--41" fillcolor="#B16E2B"/>
-    <ShadeInterval min="-41" max="-40" label="-41--40" fillcolor="#99540E"/>
-    <ShadeInterval min="-40" max="-39" label="-40--39" fillcolor="#FFB1B1"/>
-    <ShadeInterval min="-39" max="-38" label="-39--38" fillcolor="#E47E7E"/>
-    <ShadeInterval min="-38" max="-37" label="-38--37" fillcolor="#CC5050"/>
-    <ShadeInterval min="-37" max="-36" label="-37--36" fillcolor="#B12B2B"/>
-    <ShadeInterval min="-36" max="-35" label="-36--35" fillcolor="#990E0E"/>
-    <ShadeInterval min="-35" max="-34" label="-35--34" fillcolor="#BFB1FF"/>
-    <ShadeInterval min="-34" max="-33" label="-34--33" fillcolor="#8E7EE4"/>
-    <ShadeInterval min="-33" max="-32" label="-33--32" fillcolor="#6450CC"/>
-    <ShadeInterval min="-32" max="-31" label="-32--31" fillcolor="#422BB1"/>
-    <ShadeInterval min="-31" max="-30" label="-31--30" fillcolor="#260E99"/>
-    <ShadeInterval min="-30" max="-29" label="-30--29" fillcolor="#B1E4FF"/>
-    <ShadeInterval min="-29" max="-28" label="-29--28" fillcolor="#7EC3E4"/>
-    <ShadeInterval min="-28" max="-27" label="-28--27" fillcolor="#50A3CC"/>
-    <ShadeInterval min="-27" max="-26" label="-27--26" fillcolor="#2B85B1"/>
-    <ShadeInterval min="-26" max="-25" label="-26--25" fillcolor="#0E6B99"/>
-    <ShadeInterval min="-25" max="-24" label="-25--24" fillcolor="#E4FFB1"/>
-    <ShadeInterval min="-24" max="-23" label="-24--23" fillcolor="#C3E47E"/>
-    <ShadeInterval min="-23" max="-22" label="-23--22" fillcolor="#A3CC50"/>
-    <ShadeInterval min="-22" max="-21" label="-22--21" fillcolor="#85B12B"/>
-    <ShadeInterval min="-21" max="-20" label="-21--20" fillcolor="#6B990E"/>
-    <ShadeInterval min="-20" max="-19" label="-20--19" fillcolor="#FFD8B1"/>
-    <ShadeInterval min="-19" max="-18" label="-19--18" fillcolor="#E4B17E"/>
-    <ShadeInterval min="-18" max="-17" label="-18--17" fillcolor="#CC8E50"/>
-    <ShadeInterval min="-17" max="-16" label="-17--16" fillcolor="#B16E2B"/>
-    <ShadeInterval min="-16" max="-15" label="-16--15" fillcolor="#99540E"/>
-    <ShadeInterval min="-15" max="-14" label="-15--14" fillcolor="#FFB1B1"/>
-    <ShadeInterval min="-14" max="-13" label="-14--13" fillcolor="#E47E7E"/>
-    <ShadeInterval min="-13" max="-12" label="-13--12" fillcolor="#CC5050"/>
-    <ShadeInterval min="-12" max="-11" label="-12--11" fillcolor="#B12B2B"/>
-    <ShadeInterval min="-11" max="-10" label="-11--10" fillcolor="#990E0E"/>
-    <ShadeInterval min="-10" max="-9" label="-10--9" fillcolor="#BFB1FF"/>
-    <ShadeInterval min="-9" max="-8" label="-9--8" fillcolor="#8E7EE4"/>
-    <ShadeInterval min="-8" max="-7" label="-8--7" fillcolor="#6450CC"/>
-    <ShadeInterval min="-7" max="-6" label="-7--6" fillcolor="#422BB1"/>
-    <ShadeInterval min="-6" max="-5" label="-6--5" fillcolor="#260E99"/>
-    <ShadeInterval min="-5" max="-4" label="-5--4" fillcolor="#B1E4FF"/>
-    <ShadeInterval min="-4" max="-3" label="-4--3" fillcolor="#7EC3E4"/>
-    <ShadeInterval min="-3" max="-2" label="-3--2" fillcolor="#50A3CC"/>
-    <ShadeInterval min="-2" max="-1" label="-2--1" fillcolor="#2B85B1"/>
-    <ShadeInterval min="-1" max="0" label="-1-0" fillcolor="#0E6B99"/>
-    <ShadeInterval min="0" max="1" label="0-1" fillcolor="#E4FFB1"/>
-    <ShadeInterval min="1" max="2" label="1-2" fillcolor="#C3E47E"/>
-    <ShadeInterval min="2" max="3" label="2-3" fillcolor="#A3CC50"/>
-    <ShadeInterval min="3" max="4" label="3-4" fillcolor="#85B12B"/>
-    <ShadeInterval min="4" max="5" label="4-5" fillcolor="#6B990E"/>
-    <ShadeInterval min="5" max="6" label="5-6" fillcolor="#FFD8B1"/>
-    <ShadeInterval min="6" max="7" label="6-7" fillcolor="#E4B17E"/>
-    <ShadeInterval min="7" max="8" label="7-8" fillcolor="#CC8E50"/>
-    <ShadeInterval min="8" max="9" label="8-9" fillcolor="#B16E2B"/>
-    <ShadeInterval min="9" max="10" label="9-10" fillcolor="#99540E"/>
-    <ShadeInterval min="10" max="11" label="10-11" fillcolor="#FFB1B1"/>
-    <ShadeInterval min="11" max="12" label="11-12" fillcolor="#E47E7E"/>
-    <ShadeInterval min="12" max="13" label="12-13" fillcolor="#CC5050"/>
-    <ShadeInterval min="13" max="14" label="13-14" fillcolor="#B12B2B"/>
-    <ShadeInterval min="14" max="15" label="14-15" fillcolor="#990E0E"/>
-    <ShadeInterval min="15" max="16" label="15-16" fillcolor="#BFB1FF"/>
-    <ShadeInterval min="16" max="17" label="16-17" fillcolor="#8E7EE4"/>
-    <ShadeInterval min="17" max="18" label="17-18" fillcolor="#6450CC"/>
-    <ShadeInterval min="18" max="19" label="18-19" fillcolor="#422BB1"/>
-    <ShadeInterval min="19" max="20" label="19-20" fillcolor="#260E99"/>
-    <ShadeInterval min="20" max="21" label="20-21" fillcolor="#B1E4FF"/>
-    <ShadeInterval min="21" max="22" label="21-22" fillcolor="#7EC3E4"/>
-    <ShadeInterval min="22" max="23" label="22-23" fillcolor="#50A3CC"/>
-    <ShadeInterval min="23" max="24" label="23-24" fillcolor="#2B85B1"/>
-    <ShadeInterval min="24" max="25" label="24-25" fillcolor="#0E6B99"/>
-    <ShadeInterval min="25" max="26" label="25-26" fillcolor="#E4FFB1"/>
-    <ShadeInterval min="26" max="27" label="26-27" fillcolor="#C3E47E"/>
-    <ShadeInterval min="27" max="28" label="27-28" fillcolor="#A3CC50"/>
-    <ShadeInterval min="28" max="29" label="28-29" fillcolor="#85B12B"/>
-    <ShadeInterval min="29" max="30" label="29-30" fillcolor="#6B990E"/>
-    <ShadeInterval min="30" max="31" label="30-31" fillcolor="#FFD8B1"/>
-    <ShadeInterval min="31" max="32" label="31-32" fillcolor="#E4B17E"/>
-    <ShadeInterval min="32" max="33" label="32-33" fillcolor="#CC8E50"/>
-    <ShadeInterval min="33" max="34" label="33-34" fillcolor="#B16E2B"/>
-    <ShadeInterval min="34" max="35" label="34-35" fillcolor="#99540E"/>
-    <ShadeInterval min="35" max="36" label="35-36" fillcolor="#FFB1B1"/>
-    <ShadeInterval min="36" max="37" label="36-37" fillcolor="#E47E7E"/>
-    <ShadeInterval min="37" max="38" label="37-38" fillcolor="#CC5050"/>
-    <ShadeInterval min="38" max="39" label="38-39" fillcolor="#B12B2B"/>
-    <ShadeInterval min="39" max="40" label="39-40" fillcolor="#990E0E"/>
-    <ShadeInterval min="40" max="41" label="40-41" fillcolor="#FFD8B1"/>
-    <ShadeInterval min="41" max="42" label="41-42" fillcolor="#E4B17E"/>
-    <ShadeInterval min="42" max="43" label="42-43" fillcolor="#CC8E50"/>
-    <ShadeInterval min="43" max="44" label="43-44" fillcolor="#B16E2B"/>
-    <ShadeInterval min="44" max="45" label="44-45" fillcolor="#99540E"/>
-    <ShadeInterval min="45" max="46" label="45-46" fillcolor="#FFB1B1"/>
-    <ShadeInterval min="46" max="47" label="46-47" fillcolor="#E47E7E"/>
-    <ShadeInterval min="47" max="48" label="47-48" fillcolor="#CC5050"/>
-    <ShadeInterval min="48" max="49" label="48-49" fillcolor="#B12B2B"/>
-    <ShadeInterval min="49" max="50" label="49-50" fillcolor="#990E0E"/>
     <ContourLine width="0.3" linecolor="#444444" textcolor="#444444" textformatting="%2.0f" interval="1"/>
-    <RenderMethod>shaded,shadedcontour</RenderMethod>
-    <NameMapping name="shaded" title="Filled contours" abstract="Filled background"/>
-    <NameMapping name="shadedcontour" title="Filled contours and lines" abstract="Contour lines with filled background"/>
     <SmoothingFilter>0</SmoothingFilter>
     <StandardNames standard_name="dew_point_temperature,dewpoint_temperature,air_temperature,temperature,Temperature_2m"/>
   </Style>
-
 
   <Layer type="database">"
     <Group collection="pressure_level"/>
@@ -299,7 +181,6 @@
     <Dimension name="forecast_reference_time" units="ISO8601">reference_time</Dimension>
     <Dimension name="temp_at_pl" units="hPa" default="max" hidden="false">pressure_level_in_hpa</Dimension>
     <Dimension name="time" units="ISO8601" interval="PT1H" default="min">time</Dimension>
-   
   </Layer>
         
 </Configuration>


### PR DESCRIPTION
Since 6.0.0 it is possible to include styles into each other. The styleConfig pointer can only point to one style. Therefore removed direct styleConfig link from CStyleConfiguration class. All info is now collected into dedicated properties.

See data/config/datasets/test.uwcw_ha43_dini_5p5km_10x8.xml (https://github.com/KNMI/adaguc-server/pull/583/files#diff-addca8be27235c8a76a0305bac7afeb619f323dadbad1bee18bc3de2c9457b7b )

Fixes https://github.com/KNMI/adaguc-server/issues/582 (WIK request)