### PR TITLE
Docker compose and test docker now works with PostgreSQL 17.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13
+        image: postgres:17
         env:
           POSTGRES_USER: adaguc
           POSTGRES_PASSWORD: adaguc

--- a/Docker/docker-compose-test.yml
+++ b/Docker/docker-compose-test.yml
@@ -1,6 +1,6 @@
 services:
   adaguc-test-db:
-    image: postgres:13
+    image: postgres:17
     container_name: adaguc-test-db
     hostname: adaguc-test-db
     environment:

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -133,7 +133,7 @@ services:
         max-size: "200k"
         max-file: "10"
   adaguc-db:
-    image: postgres:13
+    image: postgres:17
     container_name: adaguc-db
     hostname: adaguc-db
     # Ensures containers running in the adaguc-network docker network can connect to the database, provided they use the
@@ -141,7 +141,7 @@ services:
     networks:
       - adaguc-network
     volumes:
-      - adaguc-server-compose-adagucdb:/var/lib/postgresql/data
+      - adaguc-server-compose-adagucdb-pg17:/var/lib/postgresql/data
     environment:
       - "POSTGRES_USER=adaguc"
       - "POSTGRES_PASSWORD=adaguc"
@@ -160,7 +160,7 @@ services:
     networks:
       - adaguc-network
 volumes:
-  adaguc-server-compose-adagucdb:
+  adaguc-server-compose-adagucdb-pg17:
 networks:
   adaguc-network:
 #Run

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ USER root
 LABEL maintainer="adaguc@knmi.nl"
 
 # Version should be same as in Definitions.h
-LABEL version="6.1.1"
+LABEL version="6.2.0"
 
 # Try to update image packages
 RUN apt-get -q -y update \

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+**Version 6.2.0 - 2026-01-12**
+
+- Move from postgres 13 towards 17.
+
 **Version 6.1.1 - 2026-01-07**
 
 - Include style now works in combination with vectors (WIK request)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 **Version 6.2.0 - 2026-01-12**
 
-- Move from postgres 13 towards 17.
+- Move from postgres 13 to 17.
 
 **Version 6.1.1 - 2026-01-07**
 

--- a/adagucserverEC/Definitions.h
+++ b/adagucserverEC/Definitions.h
@@ -28,7 +28,7 @@
 #ifndef Definitions_H
 #define Definitions_H
 
-#define ADAGUCSERVER_VERSION "6.1.1" // Please also update in the Dockerfile to the same version
+#define ADAGUCSERVER_VERSION "6.2.0" // Please also update in the Dockerfile to the same version
 
 // CConfigReaderLayerType
 #define CConfigReaderLayerTypeUnknown 0

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -37,7 +37,7 @@ docker run --rm -d \
     -e POSTGRES_PASSWORD=adaguc \
     -e POSTGRES_DB=adaguc \
     -p 5432:5432 \
-    postgres:13.4
+    postgres:17.4
 ```
 
 When started, the database is available via username adaguc, databasename adaguc, password adaguc, and localhost. You can use the following to inspect the database:


### PR DESCRIPTION
**Version 6.2.0 - 2026-01-12**

- Move from postgres 13 to 17.


- github ci/cd is updated
- test docker compose us updated
- docker compose yml is updated.