### PR TITLE
Parametrize tests

### DIFF
--- a/tests/AdagucTests/TestCSV.py
+++ b/tests/AdagucTests/TestCSV.py
@@ -47,21 +47,6 @@ class TestCSV:
         assert status == 0
         assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
-    def test_CSV_windbarbs_GD_gif(self):
-        AdagucTestTools().cleanTempDir()
-
-        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader.xml")
-        update_db(env)
-
-        filename = "test_CSV_windbarbs.gif"
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=windallspeeds&width=600&height=300&CRS=EPSG:4326&STYLES=&EXCEPTIONS=INIMAGE&showlegend=false&0.817264530295692&bbox=-2,-1,11,32&transparent=true&FORMAT=image/gif&",
-            env=env,
-        )
-        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        assert status == 0
-        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
-
     def test_CSV_windbarbs_Cairo_png(self):
         AdagucTestTools().cleanTempDir()
 

--- a/tests/AdagucTests/TestCSV.py
+++ b/tests/AdagucTests/TestCSV.py
@@ -47,36 +47,6 @@ class TestCSV:
         assert status == 0
         assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
-    def test_CSV_windbarbs_Cairo_png(self):
-        AdagucTestTools().cleanTempDir()
-
-        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader.xml")
-        update_db(env)
-
-        filename = "test_CSV_windbarbs.png"
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=windallspeeds&width=1600&height=500&CRS=EPSG:4326&STYLES=&EXCEPTIONS=INIMAGE&showlegend=false&0.817264530295692&bbox=-11,-1,11,32&transparent=true&FORMAT=image/png&",
-            env=env,
-        )
-        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        assert status == 0
-        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
-
-    def test_CSV_negative_values(self):
-        AdagucTestTools().cleanTempDir()
-
-        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader.xml")
-        update_db(env)
-
-        filename = "test_CSV_negative_values.png"
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=tn&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=4000904.446200706,-1231688.3419664246,4468921.645102525,-685668.2765809689&STYLES=name/point&FORMAT=image/png&TRANSPARENT=TRUE&",
-            env=env,
-        )
-        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        assert status == 0
-        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
-
     def test_CSV_reference_time(self):
         AdagucTestTools().cleanTempDir()
 
@@ -126,6 +96,21 @@ class TestCSV:
         assert status == 0
         assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
+    def test_CSV_negative_values(self):
+        AdagucTestTools().cleanTempDir()
+
+        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader.xml")
+        update_db(env)
+
+        filename = "test_CSV_negative_values.png"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=tn&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=4000904.446200706,-1231688.3419664246,4468921.645102525,-685668.2765809689&STYLES=name/point&FORMAT=image/png&TRANSPARENT=TRUE&",
+            env=env,
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
+
     def test_CSV_radiusandvalue(self):
         AdagucTestTools().cleanTempDir()
 
@@ -154,6 +139,21 @@ class TestCSV:
             env=env,
         )
 
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
+
+    def test_CSV_windbarbs_Cairo_png(self):
+        AdagucTestTools().cleanTempDir()
+
+        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader.xml")
+        update_db(env)
+
+        filename = "test_CSV_windbarbs.png"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=windallspeeds&width=1600&height=500&CRS=EPSG:4326&STYLES=&EXCEPTIONS=INIMAGE&showlegend=false&0.817264530295692&bbox=-11,-1,11,32&transparent=true&FORMAT=image/png&",
+            env=env,
+        )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         assert status == 0
         assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)

--- a/tests/AdagucTests/TestCSV.py
+++ b/tests/AdagucTests/TestCSV.py
@@ -1,18 +1,13 @@
 import os
-import unittest
+import pytest
 from adaguc.AdagucTestTools import AdagucTestTools
 
 ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 
-class TestCSV(unittest.TestCase):
+class TestCSV:
     testresultspath = "testresults/TestCSV/"
     expectedoutputsspath = "expectedoutputs/TestCSV/"
-    env = {
-        "ADAGUC_CONFIG":
-        ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH +
-        "/data/config/datasets/adaguc.testCSVReader.xml"
-    }
 
     AdagucTestTools().mkdir_p(testresultspath)
 
@@ -23,279 +18,202 @@ class TestCSV(unittest.TestCase):
     # env={'ADAGUC_CONFIG' : ADAGUC_PATH + "/data/config/adaguc.autoresource.xml", 'ADAGUC_FONT': ADAGUC_PATH + "/data/fonts/FreeSans.ttf"}
     # status,data,headers = AdagucTestTools().runADAGUCServer("source=csvexample.csv&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=Index&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=-180,-90,180,90&STYLES=nearest&TRANSPARENT=TRUE", env = env,showLog = False)
     # AdagucTestTools().writetofile(self.testresultspath + filename,data.getvalue())
-    # self.assertEqual(status, 0)
+    # assert status == 0
     # self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
-    def test_CSV_12timesteps(self):
+    @pytest.mark.parametrize(
+        ("date"),
+        [
+            ("2018-12-04T12:00:00Z"),
+            ("2018-12-04T12:05:00Z"),
+            ("2018-12-04T12:10:00Z"),
+            ("2018-12-04T12:15:00Z"),
+            ("2018-12-04T12:20:00Z"),
+            ("2018-12-04T12:25:00Z"),
+            ("2018-12-04T12:30:00Z"),
+            ("2018-12-04T12:35:00Z"),
+            ("2018-12-04T12:40:00Z"),
+            ("2018-12-04T12:45:00Z"),
+            ("2018-12-04T12:50:00Z"),
+            ("2018-12-04T12:55:00Z"),
+        ],
+    )
+    def test_CSV_12timesteps(self, date: str):
         AdagucTestTools().cleanTempDir()
 
-        config = (ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," +
-                  ADAGUC_PATH +
-                  "/data/config/datasets/adaguc.testCSVReader.xml")
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config],
-            env=self.env,
+        env = {
+            "ADAGUC_CONFIG": f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml,"
+            + f"{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader.xml"
+        }
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", env["ADAGUC_CONFIG"]],
+            env=env,
             isCGI=False,
             showLog=False,
         )
-        self.assertEqual(status, 0)
+        assert status == 0
 
-        dates = [
-            "2018-12-04T12:00:00Z",
-            "2018-12-04T12:05:00Z",
-            "2018-12-04T12:10:00Z",
-            "2018-12-04T12:15:00Z",
-            "2018-12-04T12:20:00Z",
-            "2018-12-04T12:25:00Z",
-            "2018-12-04T12:30:00Z",
-            "2018-12-04T12:35:00Z",
-            "2018-12-04T12:40:00Z",
-            "2018-12-04T12:45:00Z",
-            "2018-12-04T12:50:00Z",
-            "2018-12-04T12:55:00Z",
-        ]
+        filename = ("test_CSV_timesupport" + date + ".png").replace(":", "_")
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=wind&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=-180,-90,180,90&STYLES=windbarb&FORMAT=image/png&TRANSPARENT=TRUE&TIME="
+            + date,
+            env=env,
+        )
 
-        outputs_differ = False
-        for date in dates:
-            filename = ("test_CSV_timesupport" + date + ".png").replace(":","_")
-            status, data, headers = AdagucTestTools().runADAGUCServer(
-                "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=wind&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=-180,-90,180,90&STYLES=windbarb&FORMAT=image/png&TRANSPARENT=TRUE&TIME="
-                + date,
-                env=self.env,
-            )
-            AdagucTestTools().writetofile(self.testresultspath + filename,
-                                          data.getvalue())
-            self.assertEqual(status, 0)
-            if data.getvalue() != AdagucTestTools().readfromfile(self.expectedoutputsspath + filename):
-                outputs_differ = True
-
-        self.assertFalse(outputs_differ)
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
     def test_CSV_reference_time(self):
         AdagucTestTools().cleanTempDir()
         env = {
-            "ADAGUC_CONFIG":
-            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," +
-            ADAGUC_PATH +
-            "/data/config/datasets/adaguc.testCSVReader_reference_time.xml"
+            "ADAGUC_CONFIG": f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml,"
+            + f"{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader_reference_time.xml"
         }
-        config = (
-            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," +
-            ADAGUC_PATH +
-            "/data/config/datasets/adaguc.testCSVReader_reference_time.xml")
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config],
-            env=env,
-            isCGI=False,
-            showLog=False)
-        self.assertEqual(status, 0)
+        status, *_ = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", env["ADAGUC_CONFIG"]], env=env, isCGI=False, showLog=False
+        )
+        assert status == 0
 
     def test_CSV_reference_time_GetCapabilities(self):
         AdagucTestTools().cleanTempDir()
         env = {
-            "ADAGUC_CONFIG":
-            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," +
-            ADAGUC_PATH +
-            "/data/config/datasets/adaguc.testCSVReader_reference_time.xml"
+            "ADAGUC_CONFIG": f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml,"
+            + f"{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader_reference_time.xml"
         }
-        config = (
-            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," +
-            ADAGUC_PATH +
-            "/data/config/datasets/adaguc.testCSVReader_reference_time.xml")
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config],
-            env=env,
-            isCGI=False,
-            showLog=False)
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", env["ADAGUC_CONFIG"]], env=env, isCGI=False, showLog=False
+        )
 
         # Test GetCapabilities
         filename = "test_CSV_reference_timesupport_GetCapabilities.xml"
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities",
-            env=env)
-        AdagucTestTools().writetofile(self.testresultspath + filename,
-                                      data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(
-            self.testresultspath + filename,
-            self.expectedoutputsspath + filename))
+        status, data, _ = AdagucTestTools().runADAGUCServer("&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities", env=env)
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
 
-    def test_CSV_reference_time_GetMap(self):
+        assert status == 0
+        assert AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename)
+
+    @pytest.mark.parametrize(
+        ("time", "reference_time"),
+        [
+            ("2018-12-04T12:00:00Z", "2018-12-04T12:00:00Z"),
+            ("2018-12-04T12:05:00Z", "2018-12-04T12:00:00Z"),
+            ("2018-12-04T12:05:00Z", "2018-12-04T12:05:00Z"),
+            ("2018-12-04T12:10:00Z", "2018-12-04T12:05:00Z"),
+        ],
+    )
+    def test_CSV_reference_time_GetMap(self, time: str, reference_time: str):
         AdagucTestTools().cleanTempDir()
         env = {
-            "ADAGUC_CONFIG":
-            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," +
-            ADAGUC_PATH +
-            "/data/config/datasets/adaguc.testCSVReader_reference_time.xml"
+            "ADAGUC_CONFIG": f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml,"
+            + f"{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader_reference_time.xml"
         }
-        config = (
-            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," +
-            ADAGUC_PATH +
-            "/data/config/datasets/adaguc.testCSVReader_reference_time.xml")
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config],
-            env=env,
-            isCGI=False,
-            showLog=False)
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", env["ADAGUC_CONFIG"]], env=env, isCGI=False, showLog=False
+        )
 
         # Test WMS GetMap
+        filename = ("test_CSV_reference_timesupport" + time + "_" + reference_time + ".png").replace(":", "_")
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=wind&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=-180,-90,180,90&STYLES=windbarb&FORMAT=image/png&TRANSPARENT=TRUE&TIME="
+            + time
+            + "&DIM_reference_time="
+            + reference_time,
+            env=env,
+        )
 
-        testcases = [
-            {
-                "time": "2018-12-04T12:00:00Z",
-                "reference_time": "2018-12-04T12:00:00Z"
-            },
-            {
-                "time": "2018-12-04T12:05:00Z",
-                "reference_time": "2018-12-04T12:00:00Z"
-            },
-            {
-                "time": "2018-12-04T12:05:00Z",
-                "reference_time": "2018-12-04T12:05:00Z"
-            },
-            {
-                "time": "2018-12-04T12:10:00Z",
-                "reference_time": "2018-12-04T12:05:00Z"
-            },
-        ]
-
-        for testcase in testcases:
-            date = testcase["time"]
-            DIM_reference_time = testcase["reference_time"]
-            filename = (("test_CSV_reference_timesupport" + date + "_" +
-                        DIM_reference_time + ".png").replace(":","_"))
-            status, data, headers = AdagucTestTools().runADAGUCServer(
-                "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=wind&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=-180,-90,180,90&STYLES=windbarb&FORMAT=image/png&TRANSPARENT=TRUE&TIME="
-                + date + "&DIM_reference_time=" + DIM_reference_time,
-                env=env,
-            )
-            AdagucTestTools().writetofile(self.testresultspath + filename,
-                                          data.getvalue())
-            self.assertEqual(status, 0)
-            self.assertEqual(
-                data.getvalue(),
-                AdagucTestTools().readfromfile(self.expectedoutputsspath +
-                                               filename),
-            )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
     def test_CSV_negative_values(self):
         AdagucTestTools().cleanTempDir()
 
-        config = (ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," +
-                  ADAGUC_PATH +
-                  "/data/config/datasets/adaguc.testCSVReader.xml")
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config],
-            env=self.env,
+        env = {
+            "ADAGUC_CONFIG": f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml,"
+            + f"{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader.xml"
+        }
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", env["ADAGUC_CONFIG"]],
+            env=env,
             isCGI=False,
             showLog=False,
         )
-        self.assertEqual(status, 0)
+        assert status == 0
         filename = "test_CSV_negative_values.png"
 
-        status, data, headers = AdagucTestTools().runADAGUCServer(
+        status, data, _ = AdagucTestTools().runADAGUCServer(
             "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=tn&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=4000904.446200706,-1231688.3419664246,4468921.645102525,-685668.2765809689&STYLES=name/point&FORMAT=image/png&TRANSPARENT=TRUE&",
-            env=self.env,
+            env=env,
         )
-        AdagucTestTools().writetofile(self.testresultspath + filename,
-                                      data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertEqual(
-            data.getvalue(),
-            AdagucTestTools().readfromfile(self.expectedoutputsspath +
-                                           filename),
-        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
     def test_CSV_radiusandvalue(self):
         AdagucTestTools().cleanTempDir()
         env = {
-            "ADAGUC_CONFIG":
-            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," +
-            ADAGUC_PATH +
-            "/data/config/datasets/adaguc.testCSV_radiusandvalue.xml"
+            "ADAGUC_CONFIG": f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml,"
+            + f"{ADAGUC_PATH}/data/config/datasets/adaguc.testCSV_radiusandvalue.xml"
         }
 
-        config = (ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," +
-                  ADAGUC_PATH +
-                  "/data/config/datasets/adaguc.testCSV_radiusandvalue.xml")
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config],
-            env=env,
-            isCGI=False,
-            showLog=False)
-        self.assertEqual(status, 0)
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", env["ADAGUC_CONFIG"]], env=env, isCGI=False, showLog=False
+        )
+        assert status == 0
         filename = "test_CSV_radiusandvalue.png"
 
-        status, data, headers = AdagucTestTools().runADAGUCServer(
+        status, data, _ = AdagucTestTools().runADAGUCServer(
             "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=radiusandvalue&WIDTH=256&HEIGHT=512&CRS=EPSG%3A3857&BBOX=-8003558.6330057755,1638420.481402514,-7346556.700484946,2491778.5155690867&STYLES=magnitude&FORMAT=image/png&TRANSPARENT=TRUE&showlegend=true",
             env=env,
         )
-        AdagucTestTools().writetofile(self.testresultspath + filename,
-                                      data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertEqual(
-            data.getvalue(),
-            AdagucTestTools().readfromfile(self.expectedoutputsspath +
-                                           filename),
-        )
+
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
     def test_CSV_radiusandvalue_and_symbol(self):
         AdagucTestTools().cleanTempDir()
         env = {
-            "ADAGUC_CONFIG":
-            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," +
-            ADAGUC_PATH +
-            "/data/config/datasets/adaguc.testCSV_radiusandvalue.xml"
+            "ADAGUC_CONFIG": f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml,"
+            + f"{ADAGUC_PATH}/data/config/datasets/adaguc.testCSV_radiusandvalue.xml"
         }
 
-        config = (ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," +
-                  ADAGUC_PATH +
-                  "/data/config/datasets/adaguc.testCSV_radiusandvalue.xml")
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config],
-            env=env,
-            isCGI=False,
-            showLog=False)
-        self.assertEqual(status, 0)
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", env["ADAGUC_CONFIG"]], env=env, isCGI=False, showLog=False
+        )
+        assert status == 0
         filename = "test_CSV_radiusandvalue_and_symbol.png"
 
-        status, data, headers = AdagucTestTools().runADAGUCServer(
+        status, data, _ = AdagucTestTools().runADAGUCServer(
             "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=radiusandvalue_and_symbol&WIDTH=256&HEIGHT=512&CRS=EPSG%3A3857&BBOX=-8003558.6330057755,1638420.481402514,-7346556.700484946,2491778.5155690867&STYLES=magnitude&FORMAT=image/png&TRANSPARENT=TRUE&showlegend=true",
             env=env,
         )
-        AdagucTestTools().writetofile(self.testresultspath + filename,
-                                      data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertEqual(
-            data.getvalue(),
-            AdagucTestTools().readfromfile(self.expectedoutputsspath +
-                                           filename),
-        )
+
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
     def test_CSV_windbarbs_Cairo_png(self):
         AdagucTestTools().cleanTempDir()
 
-        config = (ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," +
-                  ADAGUC_PATH +
-                  "/data/config/datasets/adaguc.testCSVReader.xml")
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config],
-            env=self.env,
+        env = {
+            "ADAGUC_CONFIG": f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml,"
+            + f"{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader.xml"
+        }
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", env["ADAGUC_CONFIG"]],
+            env=env,
             isCGI=False,
             showLog=False,
         )
-        self.assertEqual(status, 0)
+        assert status == 0
 
         filename = "test_CSV_windbarbs.png"
-        status, data, headers = AdagucTestTools().runADAGUCServer(
+        status, data, _ = AdagucTestTools().runADAGUCServer(
             "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=windallspeeds&width=1600&height=500&CRS=EPSG:4326&STYLES=&EXCEPTIONS=INIMAGE&showlegend=false&0.817264530295692&bbox=-11,-1,11,32&transparent=true&FORMAT=image/png&",
-            env=self.env,
+            env=env,
         )
-        AdagucTestTools().writetofile(self.testresultspath + filename,
-                                      data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertEqual(
-            data.getvalue(),
-            AdagucTestTools().readfromfile(self.expectedoutputsspath +
-                                           filename),
-        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)

--- a/tests/AdagucTests/TestCSV.py
+++ b/tests/AdagucTests/TestCSV.py
@@ -2,6 +2,8 @@ import os
 import pytest
 from adaguc.AdagucTestTools import AdagucTestTools
 
+from conftest import make_adaguc_env, update_db
+
 ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 
@@ -10,16 +12,6 @@ class TestCSV:
     expectedoutputsspath = "expectedoutputs/TestCSV/"
 
     AdagucTestTools().mkdir_p(testresultspath)
-
-    # TODO FONTS are rendered differently accros platforms. Maybe because of Cairo/Truetypes renders. This causes this test to fail
-    # def test_CSV_singlefile_autowms(self):
-    # AdagucTestTools().cleanTempDir()
-    # filename="test_CSV_csvexample_autowms.gif"
-    # env={'ADAGUC_CONFIG' : ADAGUC_PATH + "/data/config/adaguc.autoresource.xml", 'ADAGUC_FONT': ADAGUC_PATH + "/data/fonts/FreeSans.ttf"}
-    # status,data,headers = AdagucTestTools().runADAGUCServer("source=csvexample.csv&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=Index&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=-180,-90,180,90&STYLES=nearest&TRANSPARENT=TRUE", env = env,showLog = False)
-    # AdagucTestTools().writetofile(self.testresultspath + filename,data.getvalue())
-    # assert status == 0
-    # self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
     @pytest.mark.parametrize(
         ("date"),
@@ -41,17 +33,8 @@ class TestCSV:
     def test_CSV_12timesteps(self, date: str):
         AdagucTestTools().cleanTempDir()
 
-        env = {
-            "ADAGUC_CONFIG": f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml,"
-            + f"{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader.xml"
-        }
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", env["ADAGUC_CONFIG"]],
-            env=env,
-            isCGI=False,
-            showLog=False,
-        )
-        assert status == 0
+        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader.xml")
+        update_db(env)
 
         filename = ("test_CSV_timesupport" + date + ".png").replace(":", "_")
         status, data, _ = AdagucTestTools().runADAGUCServer(
@@ -64,26 +47,62 @@ class TestCSV:
         assert status == 0
         assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
+    def test_CSV_windbarbs_GD_gif(self):
+        AdagucTestTools().cleanTempDir()
+
+        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader.xml")
+        update_db(env)
+
+        filename = "test_CSV_windbarbs.gif"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=windallspeeds&width=600&height=300&CRS=EPSG:4326&STYLES=&EXCEPTIONS=INIMAGE&showlegend=false&0.817264530295692&bbox=-2,-1,11,32&transparent=true&FORMAT=image/gif&",
+            env=env,
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
+
+    def test_CSV_windbarbs_Cairo_png(self):
+        AdagucTestTools().cleanTempDir()
+
+        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader.xml")
+        update_db(env)
+
+        filename = "test_CSV_windbarbs.png"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=windallspeeds&width=1600&height=500&CRS=EPSG:4326&STYLES=&EXCEPTIONS=INIMAGE&showlegend=false&0.817264530295692&bbox=-11,-1,11,32&transparent=true&FORMAT=image/png&",
+            env=env,
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
+
+    def test_CSV_negative_values(self):
+        AdagucTestTools().cleanTempDir()
+
+        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader.xml")
+        update_db(env)
+
+        filename = "test_CSV_negative_values.png"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=tn&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=4000904.446200706,-1231688.3419664246,4468921.645102525,-685668.2765809689&STYLES=name/point&FORMAT=image/png&TRANSPARENT=TRUE&",
+            env=env,
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
+
     def test_CSV_reference_time(self):
         AdagucTestTools().cleanTempDir()
-        env = {
-            "ADAGUC_CONFIG": f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml,"
-            + f"{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader_reference_time.xml"
-        }
-        status, *_ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", env["ADAGUC_CONFIG"]], env=env, isCGI=False, showLog=False
-        )
-        assert status == 0
+
+        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader_reference_time.xml")
+        update_db(env)
 
     def test_CSV_reference_time_GetCapabilities(self):
         AdagucTestTools().cleanTempDir()
-        env = {
-            "ADAGUC_CONFIG": f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml,"
-            + f"{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader_reference_time.xml"
-        }
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", env["ADAGUC_CONFIG"]], env=env, isCGI=False, showLog=False
-        )
+
+        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader_reference_time.xml")
+        update_db(env)
 
         # Test GetCapabilities
         filename = "test_CSV_reference_timesupport_GetCapabilities.xml"
@@ -104,13 +123,9 @@ class TestCSV:
     )
     def test_CSV_reference_time_GetMap(self, time: str, reference_time: str):
         AdagucTestTools().cleanTempDir()
-        env = {
-            "ADAGUC_CONFIG": f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml,"
-            + f"{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader_reference_time.xml"
-        }
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", env["ADAGUC_CONFIG"]], env=env, isCGI=False, showLog=False
-        )
+
+        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader_reference_time.xml")
+        update_db(env)
 
         # Test WMS GetMap
         filename = ("test_CSV_reference_timesupport" + time + "_" + reference_time + ".png").replace(":", "_")
@@ -126,43 +141,13 @@ class TestCSV:
         assert status == 0
         assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
-    def test_CSV_negative_values(self):
-        AdagucTestTools().cleanTempDir()
-
-        env = {
-            "ADAGUC_CONFIG": f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml,"
-            + f"{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader.xml"
-        }
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", env["ADAGUC_CONFIG"]],
-            env=env,
-            isCGI=False,
-            showLog=False,
-        )
-        assert status == 0
-        filename = "test_CSV_negative_values.png"
-
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=tn&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=4000904.446200706,-1231688.3419664246,4468921.645102525,-685668.2765809689&STYLES=name/point&FORMAT=image/png&TRANSPARENT=TRUE&",
-            env=env,
-        )
-        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        assert status == 0
-        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
-
     def test_CSV_radiusandvalue(self):
         AdagucTestTools().cleanTempDir()
-        env = {
-            "ADAGUC_CONFIG": f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml,"
-            + f"{ADAGUC_PATH}/data/config/datasets/adaguc.testCSV_radiusandvalue.xml"
-        }
 
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", env["ADAGUC_CONFIG"]], env=env, isCGI=False, showLog=False
-        )
-        assert status == 0
+        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testCSV_radiusandvalue.xml")
+        update_db(env)
+
         filename = "test_CSV_radiusandvalue.png"
-
         status, data, _ = AdagucTestTools().runADAGUCServer(
             "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=radiusandvalue&WIDTH=256&HEIGHT=512&CRS=EPSG%3A3857&BBOX=-8003558.6330057755,1638420.481402514,-7346556.700484946,2491778.5155690867&STYLES=magnitude&FORMAT=image/png&TRANSPARENT=TRUE&showlegend=true",
             env=env,
@@ -174,46 +159,16 @@ class TestCSV:
 
     def test_CSV_radiusandvalue_and_symbol(self):
         AdagucTestTools().cleanTempDir()
-        env = {
-            "ADAGUC_CONFIG": f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml,"
-            + f"{ADAGUC_PATH}/data/config/datasets/adaguc.testCSV_radiusandvalue.xml"
-        }
 
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", env["ADAGUC_CONFIG"]], env=env, isCGI=False, showLog=False
-        )
-        assert status == 0
+        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testCSV_radiusandvalue.xml")
+        update_db(env)
+
         filename = "test_CSV_radiusandvalue_and_symbol.png"
-
         status, data, _ = AdagucTestTools().runADAGUCServer(
             "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=radiusandvalue_and_symbol&WIDTH=256&HEIGHT=512&CRS=EPSG%3A3857&BBOX=-8003558.6330057755,1638420.481402514,-7346556.700484946,2491778.5155690867&STYLES=magnitude&FORMAT=image/png&TRANSPARENT=TRUE&showlegend=true",
             env=env,
         )
 
-        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        assert status == 0
-        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
-
-    def test_CSV_windbarbs_Cairo_png(self):
-        AdagucTestTools().cleanTempDir()
-
-        env = {
-            "ADAGUC_CONFIG": f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml,"
-            + f"{ADAGUC_PATH}/data/config/datasets/adaguc.testCSVReader.xml"
-        }
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", env["ADAGUC_CONFIG"]],
-            env=env,
-            isCGI=False,
-            showLog=False,
-        )
-        assert status == 0
-
-        filename = "test_CSV_windbarbs.png"
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=windallspeeds&width=1600&height=500&CRS=EPSG:4326&STYLES=&EXCEPTIONS=INIMAGE&showlegend=false&0.817264530295692&bbox=-11,-1,11,32&transparent=true&FORMAT=image/png&",
-            env=env,
-        )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         assert status == 0
         assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)

--- a/tests/AdagucTests/TestGeoJSON.py
+++ b/tests/AdagucTests/TestGeoJSON.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from adaguc.AdagucTestTools import AdagucTestTools
+from conftest import make_adaguc_env, update_db
 
 ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
@@ -27,19 +28,13 @@ class TestGeoJSON:
 
     def test_GeoJSON_time_GetCapabilities(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"
-        )
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
-        )
 
-        assert status == 0
+        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testGeoJSONReader_time.xml")
+        update_db(env)
+
         # Test GetCapabilities
         filename = "test_GeoJSON_time_GetCapabilities.xml"
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities", env={"ADAGUC_CONFIG": config}
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer("&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities", env=env)
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
 
         assert status == 0
@@ -55,20 +50,16 @@ class TestGeoJSON:
     )
     def test_GeoJSON_3timesteps(self, date: str):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"
-        )
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
-        )
-        assert status == 0
+
+        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testGeoJSONReader_time.xml")
+        update_db(env)
 
         filename = f"test_GeoJSON_timesupport{date}.png".replace(":", "_")
 
         status, data, _ = AdagucTestTools().runADAGUCServer(
             "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=features&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=40,-10,60,40&STYLES=features&FORMAT=image/png&TRANSPARENT=TRUE&TIME="
             + date,
-            env={"ADAGUC_CONFIG": config},
+            env=env,
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
 

--- a/tests/AdagucTests/TestGeoJSON.py
+++ b/tests/AdagucTests/TestGeoJSON.py
@@ -1,72 +1,76 @@
 import os
-from io import BytesIO
-from adaguc.CGIRunner import CGIRunner
-import unittest
-import shutil
-import sys
-import subprocess
-from lxml import etree
-from lxml import objectify
-import re
+import pytest
 from adaguc.AdagucTestTools import AdagucTestTools
 
-ADAGUC_PATH = os.environ['ADAGUC_PATH']
+ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 
-class TestGeoJSON(unittest.TestCase):
-  testresultspath = "testresults/TestGeoJSON/"
-  expectedoutputsspath = "expectedoutputs/TestGeoJSON/"
-  env = {'ADAGUC_CONFIG': ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," +
-         ADAGUC_PATH + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"}
+class TestGeoJSON:
+    testresultspath = "testresults/TestGeoJSON/"
+    expectedoutputsspath = "expectedoutputs/TestGeoJSON/"
 
-  AdagucTestTools().mkdir_p(testresultspath)
+    AdagucTestTools().mkdir_p(testresultspath)
 
-  def test_GeoJSON_countries_autowms(self):
-    AdagucTestTools().cleanTempDir()
-    filename = "test_GeoJSON_countries_autowms.png"
-    env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-           "/data/config/adaguc.autoresource.xml"}
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "source=countries.geojson&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=features&WIDTH=256&HEIGHT=128&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=default&FORMAT=image/png&TRANSPARENT=TRUE", env=env, showLog=False)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue(), AdagucTestTools(
-    ).readfromfile(self.expectedoutputsspath + filename))
+    def test_GeoJSON_countries_autowms(self):
+        AdagucTestTools().cleanTempDir()
+        filename = "test_GeoJSON_countries_autowms.png"
+        env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "source=countries.geojson&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=features&WIDTH=256&HEIGHT=128&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=default&FORMAT=image/png&TRANSPARENT=TRUE",
+            env=env,
+            showLog=False,
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
 
-  def test_GeoJSON_time_GetCapabilities(self):
-    AdagucTestTools().cleanTempDir()
-    config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-        ADAGUC_PATH + '/data/config/datasets/adaguc.testGeoJSONReader_time.xml'
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        args=['--updatedb', '--config', config], env={'ADAGUC_CONFIG': config}, isCGI=False, showLog=False)
-    self.assertEqual(status, 0)
-    # Test GetCapabilities
-    filename = "test_GeoJSON_time_GetCapabilities.xml"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities", env={'ADAGUC_CONFIG': config})
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(
-        self.testresultspath + filename, self.expectedoutputsspath + filename))
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
-  def test_GeoJSON_3timesteps(self):
-    AdagucTestTools().cleanTempDir()
-    config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-        ADAGUC_PATH + '/data/config/datasets/adaguc.testGeoJSONReader_time.xml'
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        args=['--updatedb', '--config', config], env={'ADAGUC_CONFIG': config}, isCGI=False, showLog=False)
-    self.assertEqual(status, 0)
+    def test_GeoJSON_time_GetCapabilities(self):
+        AdagucTestTools().cleanTempDir()
+        config = (
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"
+        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
+        )
 
-    dates = ['2018-12-04T12:00:00Z',
-             '2018-12-04T12:05:00Z',
-             '2018-12-04T12:10:00Z']
+        assert status == 0
+        # Test GetCapabilities
+        filename = "test_GeoJSON_time_GetCapabilities.xml"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities", env={"ADAGUC_CONFIG": config}
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
 
-    for date in dates:
-      filename = ("test_GeoJSON_timesupport"+date+".png").replace(":","_")
-      
-      status, data, headers = AdagucTestTools().runADAGUCServer(
-          "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=features&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=40,-10,60,40&STYLES=features&FORMAT=image/png&TRANSPARENT=TRUE&TIME=" + date, env={'ADAGUC_CONFIG': config})
-      AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-      self.assertEqual(status, 0)
-      self.assertEqual(data.getvalue(), AdagucTestTools(
-      ).readfromfile(self.expectedoutputsspath + filename))
+        assert status == 0
+        assert AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename)
+
+    @pytest.mark.parametrize(
+        "date",
+        [
+            ("2018-12-04T12:00:00Z"),
+            ("2018-12-04T12:05:00Z"),
+            ("2018-12-04T12:10:00Z"),
+        ],
+    )
+    def test_GeoJSON_3timesteps(self, date: str):
+        AdagucTestTools().cleanTempDir()
+        config = (
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"
+        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
+        )
+        assert status == 0
+
+        filename = f"test_GeoJSON_timesupport{date}.png".replace(":", "_")
+
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=features&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=40,-10,60,40&STYLES=features&FORMAT=image/png&TRANSPARENT=TRUE&TIME="
+            + date,
+            env={"ADAGUC_CONFIG": config},
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)

--- a/tests/AdagucTests/TestKMDS.py
+++ b/tests/AdagucTests/TestKMDS.py
@@ -3,18 +3,14 @@ import os
 import pytest
 from adaguc.AdagucTestTools import AdagucTestTools
 
+from conftest import make_adaguc_env, update_db
+
 ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 
 class TestKMDS:
     testresultspath = "testresults/TestKMDS/"
     expectedoutputsspath = "expectedoutputs/TestKMDS/"
-    env = {
-        "ADAGUC_CONFIG": ADAGUC_PATH
-        + "/data/config/adaguc.tests.dataset.xml,"
-        + ADAGUC_PATH
-        + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"
-    }
 
     AdagucTestTools().mkdir_p(testresultspath)
 
@@ -43,10 +39,8 @@ class TestKMDS:
     def test_kmds_alle_stations_10001_getmap_requests(self, filename: str, layers: str, styles: str):
         AdagucTestTools().cleanTempDir()
 
-        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.test.kmds_alle_stations_10001.xml"
-        env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
-        assert status == 0
+        env = make_adaguc_env("adaguc.test.kmds_alle_stations_10001.xml")
+        update_db(env)
 
         status, data, _ = AdagucTestTools().runADAGUCServer(
             f"LAYERS=baselayer,{layers},overlay&STYLES=default,{styles},default&DATASET=adaguc.test.kmds_alle_stations_10001&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&WIDTH=400&HEIGHT=600&CRS=EPSG%3A3857&BBOX=269422.313123934,6357145.5563671775,939865.5563671777,7457638.879961043&FORMAT=image/png32&TRANSPARENT=FALSE&&time=2025-11-06T09%3A20%3A00Z",
@@ -70,10 +64,8 @@ class TestKMDS:
     def test_kmds_alle_stations_10001_getfeatureinfo_requests(self, filename: str, layers: str, units: str):
         AdagucTestTools().cleanTempDir()
 
-        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.test.kmds_alle_stations_10001.xml"
-        env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
-        assert status == 0
+        env = make_adaguc_env("adaguc.test.kmds_alle_stations_10001.xml")
+        update_db(env)
 
         status, data, _ = AdagucTestTools().runADAGUCServer(
             f"dataset=adaguc.test.kmds_alle_stations_10001&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS={layers}&QUERY_LAYERS={layers}&CRS=EPSG%3A3857&BBOX=-141702.05839427316,6126251.383284947,1317478.0003938763,7367966.542989185&WIDTH=1550&HEIGHT=1319&I=765&J=585&INFO_FORMAT=application/json&STYLES=&&time=2025-11-06T09%3A20%3A00Z",
@@ -89,10 +81,8 @@ class TestKMDS:
     def test_kmds_alle_stations_10001_getmetadata_adjusted_units(self):
         AdagucTestTools().cleanTempDir()
 
-        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.test.kmds_alle_stations_10001.xml"
-        env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
-        assert status == 0
+        env = make_adaguc_env("adaguc.test.kmds_alle_stations_10001.xml")
+        update_db(env)
 
         status, data, _ = AdagucTestTools().runADAGUCServer(
             "dataset=adaguc.test.kmds_alle_stations_10001&&service=WMS&request=getmetadata&format=application/json&layers=10M/wind_adjust",

--- a/tests/AdagucTests/TestKMDS.py
+++ b/tests/AdagucTests/TestKMDS.py
@@ -1,20 +1,12 @@
 import json
 import os
-from io import BytesIO
-from adaguc.CGIRunner import CGIRunner
-import unittest
-import shutil
-import sys
-import subprocess
-from lxml import etree
-from lxml import objectify
-import re
+import pytest
 from adaguc.AdagucTestTools import AdagucTestTools
 
 ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 
-class TestKMDS(unittest.TestCase):
+class TestKMDS:
     testresultspath = "testresults/TestKMDS/"
     expectedoutputsspath = "expectedoutputs/TestKMDS/"
     env = {
@@ -26,179 +18,88 @@ class TestKMDS(unittest.TestCase):
 
     AdagucTestTools().mkdir_p(testresultspath)
 
-    def test_kmds_alle_stations_10001_getmap_requests(self):
+    @pytest.mark.parametrize(
+        ("filename", "layers", "styles"),
+        [
+            ("test_kmds_alle_stations_10001_10Mwind_barballpoint.png", "10M%2Fwind", "barball%2Fpoint"),
+            ("test_kmds_alle_stations_10001_10Mwind_barbthinnedpoint.png", "10M%2Fwind", "barbthinned%2Fpoint"),
+            ("test_kmds_alle_stations_10001_10Mwind_barbpoint.png", "10M%2Fwind", "barb%2Fpoint"),
+            ("test_kmds_alle_stations_10001_10Mwind_barbdisc.png", "10M%2Fwind", "barbdisc%2Fpoint"),
+            ("test_kmds_alle_stations_10001_10Mwind_barbvector.png", "10M%2Fwind", "barbvector%2Fpoint"),
+            ("test_kmds_alle_stations_10001_10Mwind_barballvector.png", "10M%2Fwind", "barballvector%2Fpoint"),
+            ("test_kmds_alle_stations_10001_10Mwindbft_bftalldisc.png", "10M%2Fwind_bft", "bftalldisc%2Fpoint"),
+            ("test_kmds_alle_stations_10001_10Mwindms_barballpoint.png", "10M%2Fwind_mps", "barballpoint%2Fpoint"),
+            ("test_kmds_alle_stations_10001_10Mta_observation-temperature.png", "10M%2Fta", "observation.temperature%2Fpoint"),
+            # Animated gif KDP_WWWRADARTEMP_loop
+            ("test_kmds_alle_stations_10001_10M_animgif_ta_temperaturedisc.png", "10M%2Fta", "temperaturedisc%2Fpoint"),
+            # Animated gif KDP_WWWRADARBFT_loop, still uses rendermethod barb
+            ("test_kmds_alle_stations_10001_10M_animgif_windbft_bftdiscbarb.png", "10M%2Fwind_bft", "bftdisc%2Fbarb"),
+            # Animated gif KDP_WWWRADARWIND_loop, still uses rendermethod barb
+            ("test_kmds_alle_stations_10001_10M_animgif_windmps_barbdiscbarb.png", "10M%2Fwind_mps", "barbdisc%2Fbarb"),
+            # <SymbolInterval>
+            ("test_kmds_alle_stations_10001_10M_nc_symbolinterval_okta.png", "10M%2Fnc", "observation.okta"),
+        ],
+    )
+    def test_kmds_alle_stations_10001_getmap_requests(self, filename: str, layers: str, styles: str):
         AdagucTestTools().cleanTempDir()
 
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,adaguc.test.kmds_alle_stations_10001.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.test.kmds_alle_stations_10001.xml"
         env = {"ADAGUC_CONFIG": config}
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
+        assert status == 0
+
         status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
+            f"LAYERS=baselayer,{layers},overlay&STYLES=default,{styles},default&DATASET=adaguc.test.kmds_alle_stations_10001&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&WIDTH=400&HEIGHT=600&CRS=EPSG%3A3857&BBOX=269422.313123934,6357145.5563671775,939865.5563671777,7457638.879961043&FORMAT=image/png32&TRANSPARENT=FALSE&&time=2025-11-06T09%3A20%3A00Z",
+            env=env,
         )
-        self.assertEqual(status, 0)
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
 
-        test_cases = [
-            {
-                "filetocheck": "test_kmds_alle_stations_10001_10Mwind_barballpoint.png",
-                "layers": "10M%2Fwind",
-                "styles": "barball%2Fpoint",
-            },
-            {
-                "filetocheck": "test_kmds_alle_stations_10001_10Mwind_barbthinnedpoint.png",
-                "layers": "10M%2Fwind",
-                "styles": "barbthinned%2Fpoint",
-            },
-            {
-                "filetocheck": "test_kmds_alle_stations_10001_10Mwind_barbpoint.png",
-                "layers": "10M%2Fwind",
-                "styles": "barb%2Fpoint",
-            },
-            {
-                "filetocheck": "test_kmds_alle_stations_10001_10Mwind_barbdisc.png",
-                "layers": "10M%2Fwind",
-                "styles": "barbdisc%2Fpoint",
-            },
-            {
-                "filetocheck": "test_kmds_alle_stations_10001_10Mwind_barbvector.png",
-                "layers": "10M%2Fwind",
-                "styles": "barbvector%2Fpoint",
-            },
-            {
-                "filetocheck": "test_kmds_alle_stations_10001_10Mwind_barballvector.png",
-                "layers": "10M%2Fwind",
-                "styles": "barballvector%2Fpoint",
-            },
-            {
-                "filetocheck": "test_kmds_alle_stations_10001_10Mwindbft_bftalldisc.png",
-                "layers": "10M%2Fwind_bft",
-                "styles": "bftalldisc%2Fpoint",
-            },
-            {
-                "filetocheck": "test_kmds_alle_stations_10001_10Mwindms_barballpoint.png",
-                "layers": "10M%2Fwind_mps",
-                "styles": "barballpoint%2Fpoint",
-            },
-            {
-                "filetocheck": "test_kmds_alle_stations_10001_10Mta_observation-temperature.png",
-                "layers": "10M%2Fta",
-                "styles": "observation.temperature%2Fpoint",
-            },
-            {
-                "filetocheck": "test_kmds_alle_stations_10001_10M_animgif_ta_temperaturedisc.png",
-                "layers": "10M%2Fta",
-                "styles": "temperaturedisc%2Fpoint",
-            },  # Animated gif KDP_WWWRADARTEMP_loop
-            {
-                "filetocheck": "test_kmds_alle_stations_10001_10M_animgif_windbft_bftdiscbarb.png",
-                "layers": "10M%2Fwind_bft",
-                "styles": "bftdisc%2Fbarb",
-            },  # Animated gif KDP_WWWRADARBFT_loop, still uses rendermethod barb
-            {
-                "filetocheck": "test_kmds_alle_stations_10001_10M_animgif_windmps_barbdiscbarb.png",
-                "layers": "10M%2Fwind_mps",
-                "styles": "barbdisc%2Fbarb",
-            },  # Animated gif KDP_WWWRADARWIND_loop, still uses rendermethod barb
-            {
-                "filetocheck": "test_kmds_alle_stations_10001_10M_nc_symbolinterval_okta.png",
-                "layers": "10M%2Fnc",
-                "styles": "observation.okta",
-            },  # <SymbolInterval
-        ]
-        for test_case in test_cases:
-            filename = test_case["filetocheck"]
-            status, data, headers = AdagucTestTools().runADAGUCServer(
-                f"LAYERS=baselayer,{test_case['layers']},overlay&STYLES=default,{test_case['styles']},default&DATASET=adaguc.test.kmds_alle_stations_10001&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&WIDTH=400&HEIGHT=600&CRS=EPSG%3A3857&BBOX=269422.313123934,6357145.5563671775,939865.5563671777,7457638.879961043&FORMAT=image/png32&TRANSPARENT=FALSE&&time=2025-11-06T09%3A20%3A00Z",
-                env=env,
-                showLog=False,
-            )
-            AdagucTestTools().writetofile(
-                self.testresultspath + filename, data.getvalue()
-            )
+        assert status == 0
+        assert AdagucTestTools().compareImage(
+            self.expectedoutputsspath + filename, self.testresultspath + filename, maxAllowedColorDifference=30
+        )
 
-            self.assertEqual(status, 0)
-            self.assertTrue(
-                AdagucTestTools().compareImage(
-                    self.expectedoutputsspath + filename,
-                    self.testresultspath + filename,
-                    30,
-                )
-            )
-
-    def test_kmds_alle_stations_10001_getfeatureinfo_requests(self):
+    @pytest.mark.parametrize(
+        ("filename", "layers", "units"),
+        [
+            ("test_kmds_alle_stations_10001_10M_animgif_wind.json", "10M%2Fwind", "kts"),  # Should be kts
+            ("test_kmds_alle_stations_10001_10M_animgif_windbft.json", "10M%2Fwind_bft", "bft"),  # Should be bft
+            ("test_kmds_alle_stations_10001_10M_animgif_windmps.json", "10M%2Fwind_mps", "m s-1"),  # Should be m/s
+        ],
+    )
+    def test_kmds_alle_stations_10001_getfeatureinfo_requests(self, filename: str, layers: str, units: str):
         AdagucTestTools().cleanTempDir()
 
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,adaguc.test.kmds_alle_stations_10001.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.test.kmds_alle_stations_10001.xml"
         env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
-        self.assertEqual(status, 0)
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
+        assert status == 0
 
-        test_cases = [
-            {
-                "filetocheck": "test_kmds_alle_stations_10001_10M_animgif_wind.json",
-                "layers": "10M%2Fwind",
-                "units": "kts",
-            },  # Should be kts
-            {
-                "filetocheck": "test_kmds_alle_stations_10001_10M_animgif_windbft.json",
-                "layers": "10M%2Fwind_bft",
-                "units": "bft",
-            },  # Should be bft
-            {
-                "filetocheck": "test_kmds_alle_stations_10001_10M_animgif_windmps.json",
-                "layers": "10M%2Fwind_mps",
-                "units": "m s-1",
-            },  # Should be m/s
-        ]
-        for test_case in test_cases:
-            filename = test_case["filetocheck"]
-            status, data, headers = AdagucTestTools().runADAGUCServer(
-                f"dataset=adaguc.test.kmds_alle_stations_10001&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS={test_case['layers']}&QUERY_LAYERS={test_case['layers']}&CRS=EPSG%3A3857&BBOX=-141702.05839427316,6126251.383284947,1317478.0003938763,7367966.542989185&WIDTH=1550&HEIGHT=1319&I=765&J=585&INFO_FORMAT=application/json&STYLES=&&time=2025-11-06T09%3A20%3A00Z",
-                env=env,
-                showLog=False,
-            )
-            AdagucTestTools().writetojson(
-                self.testresultspath + filename, data.getvalue()
-            )
-            self.assertEqual(status, 0)
-            self.assertEqual(
-                json.loads(data.getvalue())[0]["units"], test_case["units"]
-            )
-            # TODO: Value does not seem to be stored in the json.
-            self.assertTrue(
-                AdagucTestTools().compareFile(
-                    self.expectedoutputsspath + filename,
-                    self.testresultspath + filename,
-                )
-            )
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            f"dataset=adaguc.test.kmds_alle_stations_10001&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS={layers}&QUERY_LAYERS={layers}&CRS=EPSG%3A3857&BBOX=-141702.05839427316,6126251.383284947,1317478.0003938763,7367966.542989185&WIDTH=1550&HEIGHT=1319&I=765&J=585&INFO_FORMAT=application/json&STYLES=&&time=2025-11-06T09%3A20%3A00Z",
+            env=env,
+        )
+        AdagucTestTools().writetojson(self.testresultspath + filename, data.getvalue())
+        assert status == 0
+        assert json.loads(data.getvalue())[0]["units"] == units
+
+        # TODO: Value does not seem to be stored in the json.
+        assert AdagucTestTools().compareFile(self.expectedoutputsspath + filename, self.testresultspath + filename)
 
     def test_kmds_alle_stations_10001_getmetadata_adjusted_units(self):
         AdagucTestTools().cleanTempDir()
 
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,adaguc.test.kmds_alle_stations_10001.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.test.kmds_alle_stations_10001.xml"
         env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
-        self.assertEqual(status, 0)
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
+        assert status == 0
 
-        status, data, headers = AdagucTestTools().runADAGUCServer(
+        status, data, _ = AdagucTestTools().runADAGUCServer(
             "dataset=adaguc.test.kmds_alle_stations_10001&&service=WMS&request=getmetadata&format=application/json&layers=10M/wind_adjust",
             env=env,
-            showLog=False,
         )
-        self.assertEqual(status, 0)
-        layer = json.loads(data.getvalue())["adaguc.test.kmds_alle_stations_10001"][
-            "10M/wind_adjust"
-        ]["layer"]
-        self.assertEqual(layer["variables"][0]["units"], "mym s -1")
-        self.assertEqual(layer["variables"][1]["units"], "mydegrees")
+        assert status == 0
+
+        layer = json.loads(data.getvalue())["adaguc.test.kmds_alle_stations_10001"]["10M/wind_adjust"]["layer"]
+        assert layer["variables"][0]["units"] == "mym s -1"
+        assert layer["variables"][1]["units"] == "mydegrees"

--- a/tests/AdagucTests/TestRendering.py
+++ b/tests/AdagucTests/TestRendering.py
@@ -1,181 +1,191 @@
 import os
-from io import BytesIO
-from adaguc.CGIRunner import CGIRunner
-import unittest
-import shutil
-import sys
-import subprocess
-from lxml import etree
-from lxml import objectify
-import re
+import pytest
 from adaguc.AdagucTestTools import AdagucTestTools
 
-ADAGUC_PATH = os.environ['ADAGUC_PATH']
+ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 
-class TestRendering(unittest.TestCase):
+class TestRendering:
     testresultspath = "testresults/TestRendering/"
     expectedoutputsspath = "expectedoutputs/TestRendering/"
-    env = {'ADAGUC_CONFIG': ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," +
-            ADAGUC_PATH + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"}
+    env = {
+        "ADAGUC_CONFIG": ADAGUC_PATH
+        + "/data/config/adaguc.tests.dataset.xml,"
+        + ADAGUC_PATH
+        + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"
+    }
 
     AdagucTestTools().mkdir_p(testresultspath)
 
     def test_RenderingGeoJSON_countries_autowms(self):
         AdagucTestTools().cleanTempDir()
         filename = "test_RenderingGeoJSON_countries_autowms.png"
-        env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-            "/data/config/adaguc.autoresource.xml"}
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            "source=countries.geojson&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=features&WIDTH=256&HEIGHT=128&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=default&FORMAT=image/png&TRANSPARENT=TRUE", env=env, showLog=False)
+        env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "source=countries.geojson&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=features&WIDTH=256&HEIGHT=128&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=default&FORMAT=image/png&TRANSPARENT=TRUE",
+            env=env,
+            showLog=False,
+        )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertEqual(data.getvalue(), AdagucTestTools(
-        ).readfromfile(self.expectedoutputsspath + filename))
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
     def test_RenderingGeoJSON_time_GetCapabilities(self):
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-            ADAGUC_PATH + '/data/config/datasets/adaguc.testGeoJSONReader_time.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env={'ADAGUC_CONFIG': config}, isCGI=False, showLog=False)
-        self.assertEqual(status, 0)
+        config = (
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"
+        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
+        )
+        assert status == 0
+
         # Test GetCapabilities
         filename = "test_RenderingGeoJSON_time_GetCapabilities.xml"
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities", env={'ADAGUC_CONFIG': config})
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities", env={"ADAGUC_CONFIG": config}
+        )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(
-            self.testresultspath + filename, self.expectedoutputsspath + filename))
+        assert status == 0
+        assert AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename)
 
-    def test_RenderingGeoJSON_3timesteps(self):
+    @pytest.mark.parametrize(
+        ("date"),
+        [
+            ("2018-12-04T12:00:00Z"),
+            ("2018-12-04T12:05:00Z"),
+            ("2018-12-04T12:10:00Z"),
+        ],
+    )
+    def test_RenderingGeoJSON_3timesteps(self, date: str):
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-            ADAGUC_PATH + '/data/config/datasets/adaguc.testGeoJSONReader_time.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env={'ADAGUC_CONFIG': config}, isCGI=False, showLog=False)
-        self.assertEqual(status, 0)
+        config = (
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"
+        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
+        )
+        assert status == 0
 
-        dates = ['2018-12-04T12:00:00Z',
-                '2018-12-04T12:05:00Z',
-                '2018-12-04T12:10:00Z']
+        filename = f"test_RenderingGeoJSON_3timesteps{date}.png".replace(":", "_")
 
-        for date in dates:
-            filename = ("test_RenderingGeoJSON_3timesteps"+date+".png").replace(":","_")
-        
-            status, data, headers = AdagucTestTools().runADAGUCServer(
-                "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=features&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=40,-10,60,40&STYLES=features&FORMAT=image/png&TRANSPARENT=TRUE&TIME=" + date, env={'ADAGUC_CONFIG': config})
-            AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-            self.assertEqual(status, 0)
-            self.assertEqual(data.getvalue(), AdagucTestTools(
-            ).readfromfile(self.expectedoutputsspath + filename))
-
-
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=features&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=40,-10,60,40&STYLES=features&FORMAT=image/png&TRANSPARENT=TRUE&TIME="
+            + date,
+            env={"ADAGUC_CONFIG": config},
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
     def test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMap_AutoWMS(self):
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + 'data/config/adaguc.autoresource.xml'
+        config = ADAGUC_PATH + "data/config/adaguc.autoresource.xml"
         AdagucTestTools().runADAGUCServer(
-            "source=geojsons/EHAM_Schiphol.geojson&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities", env={'ADAGUC_CONFIG': config})
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            "source=geojsons/EHAM_Schiphol.geojson&service=WMS&request=getmap&format=image/png&layers=features&width=400&CRS=EPSG:4326&STYLES=&EXCEPTIONS=INIMAGE&showlegend=true&0.5975561120796958", env={'ADAGUC_CONFIG': config})        
+            "source=geojsons/EHAM_Schiphol.geojson&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities",
+            env={"ADAGUC_CONFIG": config},
+        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "source=geojsons/EHAM_Schiphol.geojson&service=WMS&request=getmap&format=image/png&layers=features&width=400&CRS=EPSG:4326&STYLES=&EXCEPTIONS=INIMAGE&showlegend=true&0.5975561120796958",
+            env={"ADAGUC_CONFIG": config},
+        )
         filename = "test_GeoJSON_CTR_EHAM_Schiphol_GetMap_AutoWMS.png"
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertTrue(AdagucTestTools().compareImage(
-            self.testresultspath + filename, self.expectedoutputsspath + filename))
+        assert status == 0
+        assert AdagucTestTools().compareImage(self.testresultspath + filename, self.expectedoutputsspath + filename)
 
     def test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMapNoPoints(self):
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,adaguc.tests.CTRRendering.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env={'ADAGUC_CONFIG': config}, isCGI=False, showLog=False)
-        self.assertEqual(status, 0)
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            "DATASET=adaguc.tests.CTRRendering&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=EHAM_Schiphol_onlyoutlines&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=480839.95441816666,6790323.698828231,596332.8754416516,6931740.434113708&STYLES=EHAM_Schiphol_filled%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&&0.9458806689743082", env={'ADAGUC_CONFIG': config})        
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.CTRRendering.xml"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
+        )
+        assert status == 0
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "DATASET=adaguc.tests.CTRRendering&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=EHAM_Schiphol_onlyoutlines&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=480839.95441816666,6790323.698828231,596332.8754416516,6931740.434113708&STYLES=EHAM_Schiphol_filled%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&&0.9458806689743082",
+            env={"ADAGUC_CONFIG": config},
+        )
         filename = "test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMapNoPoints.png"
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertTrue(AdagucTestTools().compareImage(
-            self.testresultspath + filename, self.expectedoutputsspath + filename))
+        assert status == 0
+        assert AdagucTestTools().compareImage(self.testresultspath + filename, self.expectedoutputsspath + filename)
 
     def test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMapOnlyLines(self):
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,adaguc.tests.CTRRendering.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env={'ADAGUC_CONFIG': config}, isCGI=False, showLog=False)
-        self.assertEqual(status, 0)
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            "DATASET=adaguc.tests.CTRRendering&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=EHAM_Schiphol_onlyoutlines&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=480839.95441816666,6790323.698828231,596332.8754416516,6931740.434113708&STYLES=EHAM_Schiphol_onlyoutlines%2Fpolylines&FORMAT=image/png&TRANSPARENT=TRUE&&0.9458806689743082", env={'ADAGUC_CONFIG': config})        
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.CTRRendering.xml"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
+        )
+        assert status == 0
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "DATASET=adaguc.tests.CTRRendering&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=EHAM_Schiphol_onlyoutlines&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=480839.95441816666,6790323.698828231,596332.8754416516,6931740.434113708&STYLES=EHAM_Schiphol_onlyoutlines%2Fpolylines&FORMAT=image/png&TRANSPARENT=TRUE&&0.9458806689743082",
+            env={"ADAGUC_CONFIG": config},
+        )
         filename = "test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMapOnlyLines.png"
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertTrue(AdagucTestTools().compareImage(
-            self.testresultspath + filename, self.expectedoutputsspath + filename))
+        assert status == 0
+        assert AdagucTestTools().compareImage(self.testresultspath + filename, self.expectedoutputsspath + filename)
 
     def test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMapLinesPointsAndNearest(self):
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,adaguc.tests.CTRRendering.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env={'ADAGUC_CONFIG': config}, isCGI=False, showLog=False)
-        self.assertEqual(status, 0)
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            "DATASET=adaguc.tests.CTRRendering&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=EHAM_Schiphol_onlyoutlines&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=480839.95441816666,6790323.698828231,596332.8754416516,6931740.434113708&STYLES=EHAM_Schiphol_filledoutlines_and_points%2Fnearestpolyline&FORMAT=image/png&TRANSPARENT=TRUE&&0.9458806689743082", env={'ADAGUC_CONFIG': config})        
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.CTRRendering.xml"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
+        )
+        assert status == 0
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "DATASET=adaguc.tests.CTRRendering&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=EHAM_Schiphol_onlyoutlines&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=480839.95441816666,6790323.698828231,596332.8754416516,6931740.434113708&STYLES=EHAM_Schiphol_filledoutlines_and_points%2Fnearestpolyline&FORMAT=image/png&TRANSPARENT=TRUE&&0.9458806689743082",
+            env={"ADAGUC_CONFIG": config},
+        )
         filename = "test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMapLinesPointsAndNearest.png"
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertTrue(AdagucTestTools().compareImage(
-            self.testresultspath + filename, self.expectedoutputsspath + filename))        
-
+        assert status == 0
+        assert AdagucTestTools().compareImage(self.testresultspath + filename, self.expectedoutputsspath + filename)
 
     def test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMapOnlyPoints(self):
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,adaguc.tests.CTRRendering.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env={'ADAGUC_CONFIG': config}, isCGI=False, showLog=False)
-        self.assertEqual(status, 0)
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            "DATASET=adaguc.tests.CTRRendering&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=EHAM_Schiphol_onlyoutlines&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=480839.95441816666,6790323.698828231,596332.8754416516,6931740.434113708&STYLES=EHAM_Schiphol_only_points%2Fpoint&FORMAT=image/png&TRANSPARENT=TRUE&&0.9458806689743082", env={'ADAGUC_CONFIG': config})        
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.CTRRendering.xml"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
+        )
+        assert status == 0
+
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "DATASET=adaguc.tests.CTRRendering&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=EHAM_Schiphol_onlyoutlines&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=480839.95441816666,6790323.698828231,596332.8754416516,6931740.434113708&STYLES=EHAM_Schiphol_only_points%2Fpoint&FORMAT=image/png&TRANSPARENT=TRUE&&0.9458806689743082",
+            env={"ADAGUC_CONFIG": config},
+        )
         filename = "test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMapOnlyPoints.png"
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertTrue(AdagucTestTools().compareImage(
-            self.testresultspath + filename, self.expectedoutputsspath + filename))        
+        assert status == 0
+        assert AdagucTestTools().compareImage(self.testresultspath + filename, self.expectedoutputsspath + filename)
 
     def test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetFeatureInfoNoPoints(self):
         AdagucTestTools().cleanTempDir()
         config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,adaguc.tests.CTRRendering.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
+        status, data, _ = AdagucTestTools().runADAGUCServer(
             args=['--updatedb', '--config', config], env={'ADAGUC_CONFIG': config}, isCGI=False, showLog=False)
-        self.assertEqual(status, 0)
-        status, data, headers = AdagucTestTools().runADAGUCServer(
+        assert status == 0
+        status, data, _ = AdagucTestTools().runADAGUCServer(
             "dataset=adaguc.tests.CTRRendering&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS=EHAM_Schiphol_onlyoutlines&QUERY_LAYERS=EHAM_Schiphol_onlyoutlines&CRS=EPSG%3A3857&BBOX=463835.69270030205,6790367.198023051,579328.613723787,6905987.034344364&WIDTH=910&HEIGHT=911&I=493&J=439&INFO_FORMAT=application/json&STYLES=&", env={'ADAGUC_CONFIG': config})
         filename = "test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetFeatureInfoNoPoints.json"
         AdagucTestTools().writetojson(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertTrue(AdagucTestTools().compareFile(
-            self.testresultspath + filename, self.expectedoutputsspath + filename))        
-
+        assert status == 0
+        assert AdagucTestTools().compareFile(self.testresultspath + filename, self.expectedoutputsspath + filename)
 
     def test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetFeatureInfoExactlyOnPoint(self):
         """
         Note: https://github.com/KNMI/adaguc-server/issues/544
         The getfeatureinfo should return both the point and the polygon info.
-
         """
+
         AdagucTestTools().cleanTempDir()
         config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,adaguc.tests.CTRRendering.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
+        status, data, _ = AdagucTestTools().runADAGUCServer(
             args=['--updatedb', '--config', config], env={'ADAGUC_CONFIG': config}, isCGI=False, showLog=False)
-        self.assertEqual(status, 0)
-        status, data, headers = AdagucTestTools().runADAGUCServer(
+        assert status == 0
+        status, data, _ = AdagucTestTools().runADAGUCServer(
             "dataset=adaguc.tests.CTRRendering&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS=EHAM_Schiphol_onlyoutlines&QUERY_LAYERS=EHAM_Schiphol_onlyoutlines&CRS=EPSG%3A3857&BBOX=444505.27315159835,6795686.027258951,579300.9326094447,6930629.813815102&WIDTH=910&HEIGHT=911&I=571&J=489&INFO_FORMAT=application/jsonl&STYLES=&", env={'ADAGUC_CONFIG': config})
         filename = "test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetFeatureInfoExactlyOnPoint.json"
         AdagucTestTools().writetojson(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertTrue(AdagucTestTools().compareFile(
-            self.testresultspath + filename, self.expectedoutputsspath + filename))        
-
-        
-
+        assert status == 0
+        assert AdagucTestTools().compareFile(self.testresultspath + filename, self.expectedoutputsspath + filename)

--- a/tests/AdagucTests/TestRendering.py
+++ b/tests/AdagucTests/TestRendering.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from adaguc.AdagucTestTools import AdagucTestTools
+from conftest import make_adaguc_env, update_db
 
 ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
@@ -8,12 +9,6 @@ ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 class TestRendering:
     testresultspath = "testresults/TestRendering/"
     expectedoutputsspath = "expectedoutputs/TestRendering/"
-    env = {
-        "ADAGUC_CONFIG": ADAGUC_PATH
-        + "/data/config/adaguc.tests.dataset.xml,"
-        + ADAGUC_PATH
-        + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"
-    }
 
     AdagucTestTools().mkdir_p(testresultspath)
 
@@ -32,19 +27,13 @@ class TestRendering:
 
     def test_RenderingGeoJSON_time_GetCapabilities(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"
-        )
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
-        )
-        assert status == 0
+
+        env = make_adaguc_env(f"{ADAGUC_PATH}/data/config/datasets/adaguc.testGeoJSONReader_time.xml")
+        update_db(env)
 
         # Test GetCapabilities
         filename = "test_RenderingGeoJSON_time_GetCapabilities.xml"
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities", env={"ADAGUC_CONFIG": config}
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer("&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities", env=env)
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         assert status == 0
         assert AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename)
@@ -59,20 +48,16 @@ class TestRendering:
     )
     def test_RenderingGeoJSON_3timesteps(self, date: str):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"
-        )
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
-        )
-        assert status == 0
+
+        env = make_adaguc_env(f"{ADAGUC_PATH}/data/config/datasets/adaguc.testGeoJSONReader_time.xml")
+        update_db(env)
 
         filename = f"test_RenderingGeoJSON_3timesteps{date}.png".replace(":", "_")
 
         status, data, _ = AdagucTestTools().runADAGUCServer(
             "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=features&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=40,-10,60,40&STYLES=features&FORMAT=image/png&TRANSPARENT=TRUE&TIME="
             + date,
-            env={"ADAGUC_CONFIG": config},
+            env=env,
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         assert status == 0
@@ -96,14 +81,13 @@ class TestRendering:
 
     def test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMapNoPoints(self):
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.CTRRendering.xml"
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
-        )
-        assert status == 0
+
+        env = make_adaguc_env("adaguc.tests.CTRRendering.xml")
+        update_db(env)
+
         status, data, _ = AdagucTestTools().runADAGUCServer(
             "DATASET=adaguc.tests.CTRRendering&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=EHAM_Schiphol_onlyoutlines&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=480839.95441816666,6790323.698828231,596332.8754416516,6931740.434113708&STYLES=EHAM_Schiphol_filled%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&&0.9458806689743082",
-            env={"ADAGUC_CONFIG": config},
+            env=env,
         )
         filename = "test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMapNoPoints.png"
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
@@ -112,14 +96,13 @@ class TestRendering:
 
     def test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMapOnlyLines(self):
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.CTRRendering.xml"
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
-        )
-        assert status == 0
+
+        env = make_adaguc_env("adaguc.tests.CTRRendering.xml")
+        update_db(env)
+
         status, data, _ = AdagucTestTools().runADAGUCServer(
             "DATASET=adaguc.tests.CTRRendering&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=EHAM_Schiphol_onlyoutlines&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=480839.95441816666,6790323.698828231,596332.8754416516,6931740.434113708&STYLES=EHAM_Schiphol_onlyoutlines%2Fpolylines&FORMAT=image/png&TRANSPARENT=TRUE&&0.9458806689743082",
-            env={"ADAGUC_CONFIG": config},
+            env=env,
         )
         filename = "test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMapOnlyLines.png"
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
@@ -128,14 +111,13 @@ class TestRendering:
 
     def test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMapLinesPointsAndNearest(self):
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.CTRRendering.xml"
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
-        )
-        assert status == 0
+
+        env = make_adaguc_env("adaguc.tests.CTRRendering.xml")
+        update_db(env)
+
         status, data, _ = AdagucTestTools().runADAGUCServer(
             "DATASET=adaguc.tests.CTRRendering&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=EHAM_Schiphol_onlyoutlines&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=480839.95441816666,6790323.698828231,596332.8754416516,6931740.434113708&STYLES=EHAM_Schiphol_filledoutlines_and_points%2Fnearestpolyline&FORMAT=image/png&TRANSPARENT=TRUE&&0.9458806689743082",
-            env={"ADAGUC_CONFIG": config},
+            env=env,
         )
         filename = "test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMapLinesPointsAndNearest.png"
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
@@ -144,15 +126,13 @@ class TestRendering:
 
     def test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMapOnlyPoints(self):
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.CTRRendering.xml"
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
-        )
-        assert status == 0
+
+        env = make_adaguc_env("adaguc.tests.CTRRendering.xml")
+        update_db(env)
 
         status, data, _ = AdagucTestTools().runADAGUCServer(
             "DATASET=adaguc.tests.CTRRendering&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=EHAM_Schiphol_onlyoutlines&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=480839.95441816666,6790323.698828231,596332.8754416516,6931740.434113708&STYLES=EHAM_Schiphol_only_points%2Fpoint&FORMAT=image/png&TRANSPARENT=TRUE&&0.9458806689743082",
-            env={"ADAGUC_CONFIG": config},
+            env=env,
         )
         filename = "test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetMapOnlyPoints.png"
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
@@ -161,12 +141,14 @@ class TestRendering:
 
     def test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetFeatureInfoNoPoints(self):
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,adaguc.tests.CTRRendering.xml'
+
+        env = make_adaguc_env("adaguc.tests.CTRRendering.xml")
+        update_db(env)
+
         status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env={'ADAGUC_CONFIG': config}, isCGI=False, showLog=False)
-        assert status == 0
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            "dataset=adaguc.tests.CTRRendering&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS=EHAM_Schiphol_onlyoutlines&QUERY_LAYERS=EHAM_Schiphol_onlyoutlines&CRS=EPSG%3A3857&BBOX=463835.69270030205,6790367.198023051,579328.613723787,6905987.034344364&WIDTH=910&HEIGHT=911&I=493&J=439&INFO_FORMAT=application/json&STYLES=&", env={'ADAGUC_CONFIG': config})
+            "dataset=adaguc.tests.CTRRendering&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS=EHAM_Schiphol_onlyoutlines&QUERY_LAYERS=EHAM_Schiphol_onlyoutlines&CRS=EPSG%3A3857&BBOX=463835.69270030205,6790367.198023051,579328.613723787,6905987.034344364&WIDTH=910&HEIGHT=911&I=493&J=439&INFO_FORMAT=application/json&STYLES=&",
+            env=env,
+        )
         filename = "test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetFeatureInfoNoPoints.json"
         AdagucTestTools().writetojson(self.testresultspath + filename, data.getvalue())
         assert status == 0
@@ -179,12 +161,14 @@ class TestRendering:
         """
 
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,adaguc.tests.CTRRendering.xml'
+
+        env = make_adaguc_env("adaguc.tests.CTRRendering.xml")
+        update_db(env)
+
         status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env={'ADAGUC_CONFIG': config}, isCGI=False, showLog=False)
-        assert status == 0
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            "dataset=adaguc.tests.CTRRendering&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS=EHAM_Schiphol_onlyoutlines&QUERY_LAYERS=EHAM_Schiphol_onlyoutlines&CRS=EPSG%3A3857&BBOX=444505.27315159835,6795686.027258951,579300.9326094447,6930629.813815102&WIDTH=910&HEIGHT=911&I=571&J=489&INFO_FORMAT=application/jsonl&STYLES=&", env={'ADAGUC_CONFIG': config})
+            "dataset=adaguc.tests.CTRRendering&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS=EHAM_Schiphol_onlyoutlines&QUERY_LAYERS=EHAM_Schiphol_onlyoutlines&CRS=EPSG%3A3857&BBOX=444505.27315159835,6795686.027258951,579300.9326094447,6930629.813815102&WIDTH=910&HEIGHT=911&I=571&J=489&INFO_FORMAT=application/jsonl&STYLES=&",
+            env=env,
+        )
         filename = "test_RenderingGeoJSON_CTR_EHAM_Schiphol_GetFeatureInfoExactlyOnPoint.json"
         AdagucTestTools().writetojson(self.testresultspath + filename, data.getvalue())
         assert status == 0

--- a/tests/AdagucTests/TestWMS.py
+++ b/tests/AdagucTests/TestWMS.py
@@ -26,19 +26,6 @@ class TestWMS(unittest.TestCase):
 
     AdagucTestTools().mkdir_p(testresultspath)
 
-    def checkreport(self, report_filename="", expected_report_filename=""):
-        """
-        Tests file check reporting functionality
-        """
-        self.assertTrue(os.path.exists(report_filename))
-        self.assertEqual(
-            AdagucTestTools().readfromfile(report_filename),
-            AdagucTestTools().readfromfile(
-                self.expectedoutputsspath + expected_report_filename
-            ),
-        )
-        os.remove(report_filename)
-
     def test_WMSGetCapabilities_testdatanc(self):
         AdagucTestTools().cleanTempDir()
         filename = "test_WMSGetCapabilities_testdatanc.xml"

--- a/tests/AdagucTests/TestWMSPolylineRenderer.py
+++ b/tests/AdagucTests/TestWMSPolylineRenderer.py
@@ -1,168 +1,190 @@
 import os
-from io import BytesIO
-from adaguc.CGIRunner import CGIRunner
-import unittest
-import shutil
-import sys
-import subprocess
-from lxml import etree
-from lxml import objectify
-import re
+import pytest
 from adaguc.AdagucTestTools import AdagucTestTools
 
-ADAGUC_PATH = os.environ['ADAGUC_PATH']
+ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 
-# TODO: Parametrize
-class TestWMSPolylineRenderer(unittest.TestCase):
+class TestWMSPolylineRenderer:
     testresultspath = "testresults/TestWMSPolylineRenderer/"
     expectedoutputsspath = "expectedoutputs/TestWMSPolylineRenderer/"
-    env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-            "/data/config/adaguc.tests.dataset.xml"}
+    env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml"}
 
     AdagucTestTools().mkdir_p(testresultspath)
 
-    def test_WMSPolylineRenderer_borderwidth_1px(self):
+    @pytest.mark.parametrize(
+        ("stylename"),
+        [
+            ("polyline_black_0.5px"),
+            ("polyline_blue_0.5px"),
+            ("polyline_blue_1px"),
+            ("polyline_blue_2px"),
+            ("polyline_yellow_2px"),
+            ("polyline_red_6px"),
+        ],
+    )
+    def test_WMSPolylineRenderer_borderwidth_1px(self, stylename: str):
         AdagucTestTools().cleanTempDir()
 
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-            ADAGUC_PATH + '/data/config/datasets/adaguc.testwmspolylinerenderer.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env=self.env, isCGI=False)
-        self.assertEqual(status, 0)
+        config = (
+            ADAGUC_PATH
+            + "/data/config/adaguc.tests.dataset.xml,"
+            + ADAGUC_PATH
+            + "/data/config/datasets/adaguc.testwmspolylinerenderer.xml"
+        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
+        assert status == 0
 
-        stylenames = ["polyline_black_0.5px", "polyline_blue_0.5px", "polyline_blue_1px",
-                    "polyline_blue_2px", "polyline_yellow_2px", "polyline_red_6px"]
-        for stylename in stylenames:
-            sys.stdout.write("\ntest style %s " % stylename)
-            sys.stdout.flush()
-            filename = "test_WMSPolylineRenderer_"+stylename+".png"
-            status, data, headers = AdagucTestTools().runADAGUCServer("DATASET=adaguc.testwmspolylinerenderer&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=neddis&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=51.05009024158416,2.254746,54.44300975841584,7.054254&STYLES=" +
-                                                                        stylename+"%2Fpolyline&FORMAT=image/png&TRANSPARENT=TRUE&", env=self.env)
-            AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-            self.assertEqual(status, 0)
-            self.assertTrue(AdagucTestTools().compareImage(self.expectedoutputsspath + filename, self.testresultspath + filename, maxAllowedColorDifference=2, maxAllowedColorPercentage=0.025))
-
+        filename = "test_WMSPolylineRenderer_" + stylename + ".png"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "DATASET=adaguc.testwmspolylinerenderer&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=neddis&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=51.05009024158416,2.254746,54.44300975841584,7.054254&STYLES="
+            + stylename
+            + "%2Fpolyline&FORMAT=image/png&TRANSPARENT=TRUE&",
+            env=self.env,
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        assert status == 0
+        assert AdagucTestTools().compareImage(
+            self.expectedoutputsspath + filename,
+            self.testresultspath + filename,
+            maxAllowedColorDifference=2,
+            maxAllowedColorPercentage=0.025,
+        )
 
     def test_WMSPolylineRenderer_cellwarn_fillpolysalpha(self):
         AdagucTestTools().cleanTempDir()
 
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-            ADAGUC_PATH + '/data/config/datasets/adaguc.testwmspolylinerenderer.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env=self.env, isCGI=False)
-        self.assertEqual(status, 0)
+        config = (
+            ADAGUC_PATH
+            + "/data/config/adaguc.tests.dataset.xml,"
+            + ADAGUC_PATH
+            + "/data/config/datasets/adaguc.testwmspolylinerenderer.xml"
+        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
+        assert status == 0
 
         filename = "test_WMSPolylineRenderer_cellwarn_fillpolysalpha.png"
-        status, data, headers = AdagucTestTools().runADAGUCServer("DATASET=adaguc.testwmspolylinerenderer&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=cellwarn_hail_combined&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=540000,6600000,850000,6750000&STYLES=polygon_innerparts_coloured&FORMAT=image/png&TRANSPARENT=TRUE&", env=self.env)
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "DATASET=adaguc.testwmspolylinerenderer&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=cellwarn_hail_combined&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=540000,6600000,850000,6750000&STYLES=polygon_innerparts_coloured&FORMAT=image/png&TRANSPARENT=TRUE&",
+            env=self.env,
+        )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertTrue(AdagucTestTools().compareImage(self.expectedoutputsspath + filename, self.testresultspath + filename, maxAllowedColorDifference=2, maxAllowedColorPercentage=0.025))
-
+        assert status == 0
+        assert AdagucTestTools().compareImage(
+            self.expectedoutputsspath + filename,
+            self.testresultspath + filename,
+            maxAllowedColorDifference=2,
+            maxAllowedColorPercentage=0.025,
+        )
 
     def test_WMSPointRenderer_usgs_earthquakes_geojson_auto_nearest_GetMap(self):
-        env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-           "/data/config/adaguc.autoresource.xml"}
+        env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
 
-        filename="test_WMSPointRenderer_usgs_earthquakes_geojson_auto_nearest_GetMap.png"
-        status, data, headers = AdagucTestTools().runADAGUCServer("source=usgs_earthquakes.geojson&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=baselayer,mag&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=-21270915.530506067,-12592019.023145191,-1311264.2622161265,17664837.49309645&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&", env=env,  showLog=True)
+        filename = "test_WMSPointRenderer_usgs_earthquakes_geojson_auto_nearest_GetMap.png"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "source=usgs_earthquakes.geojson&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=baselayer,mag&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=-21270915.530506067,-12592019.023145191,-1311264.2622161265,17664837.49309645&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&",
+            env=env,
+            showLog=True,
+        )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertEqual(data.getvalue(), AdagucTestTools(
-        ).readfromfile(self.expectedoutputsspath + filename))
-
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
     def test_WMSPointRenderer_usgs_earthquakes_geojson_auto_point_GetMap(self):
-        env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-           "/data/config/adaguc.autoresource.xml"}
+        env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
 
-        filename="test_WMSPointRenderer_usgs_earthquakes_geojson_auto_point_GetMap.png"
-        status, data, headers = AdagucTestTools().runADAGUCServer("source=usgs_earthquakes.geojson&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=baselayer,mag&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=-21270915.530506067,-12592019.023145191,-1311264.2622161265,17664837.49309645&STYLES=auto%2Fpoint&FORMAT=image/png&TRANSPARENT=TRUE&", env=env)
+        filename = "test_WMSPointRenderer_usgs_earthquakes_geojson_auto_point_GetMap.png"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "source=usgs_earthquakes.geojson&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=baselayer,mag&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=-21270915.530506067,-12592019.023145191,-1311264.2622161265,17664837.49309645&STYLES=auto%2Fpoint&FORMAT=image/png&TRANSPARENT=TRUE&",
+            env=env,
+        )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertEqual(data.getvalue(), AdagucTestTools(
-        ).readfromfile(self.expectedoutputsspath + filename))
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
     def test_WMSPointRenderer_usgs_earthquakes_geojson_auto_nearest_GetMapColorScaleRange0_20(self):
-        env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-           "/data/config/adaguc.autoresource.xml"}
+        env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
 
-        filename="test_WMSPointRenderer_usgs_earthquakes_geojson_auto_nearest_GetMapColorScaleRange0_20.png"
-        status, data, headers = AdagucTestTools().runADAGUCServer("source=usgs_earthquakes.geojson&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=baselayer,mag&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=-21270915.530506067,-12592019.023145191,-1311264.2622161265,17664837.49309645&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&e&colorscalerange=0,20", env=env)
+        filename = "test_WMSPointRenderer_usgs_earthquakes_geojson_auto_nearest_GetMapColorScaleRange0_20.png"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "source=usgs_earthquakes.geojson&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=baselayer,mag&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=-21270915.530506067,-12592019.023145191,-1311264.2622161265,17664837.49309645&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&e&colorscalerange=0,20",
+            env=env,
+        )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertEqual(data.getvalue(), AdagucTestTools(
-        ).readfromfile(self.expectedoutputsspath + filename))
-
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
     def test_WMSPointRenderer_usgs_earthquakes_geojson_auto_point_GetMapColorScaleRange0_20(self):
-        env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-           "/data/config/adaguc.autoresource.xml"}
+        env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
 
-        filename="test_WMSPointRenderer_usgs_earthquakes_geojson_auto_point_GetMapColorScaleRange0_20.png"
-        status, data, headers = AdagucTestTools().runADAGUCServer("source=usgs_earthquakes.geojson&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=baselayer,mag&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=-21270915.530506067,-12592019.023145191,-1311264.2622161265,17664837.49309645&STYLES=auto%2Fpoint&FORMAT=image/png&TRANSPARENT=TRUE&e&colorscalerange=0,20", env=env)
+        filename = "test_WMSPointRenderer_usgs_earthquakes_geojson_auto_point_GetMapColorScaleRange0_20.png"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "source=usgs_earthquakes.geojson&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=baselayer,mag&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=-21270915.530506067,-12592019.023145191,-1311264.2622161265,17664837.49309645&STYLES=auto%2Fpoint&FORMAT=image/png&TRANSPARENT=TRUE&e&colorscalerange=0,20",
+            env=env,
+        )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertEqual(data.getvalue(), AdagucTestTools(
-        ).readfromfile(self.expectedoutputsspath + filename))
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
     def test_WMSPointRenderer_usgs_earthquakes_geojson_GetFeatureInfoJSON(self):
-        env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-           "/data/config/adaguc.autoresource.xml"}
+        env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
 
         filename="test_WMSPointRenderer_usgs_earthquakes_geojson_GetFeatureInfoJSON.json"
-        status, data, headers = AdagucTestTools().runADAGUCServer("source=usgs_earthquakes.geojson&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS=mag&QUERY_LAYERS=mag&CRS=EPSG%3A3857&BBOX=-23104664.410278287,-14378748.700871969,-3145013.1419883464,15878107.815369671&WIDTH=849&HEIGHT=1287&I=460&J=438&INFO_FORMAT=application/json&", env=env)
+        status, data, _ = AdagucTestTools().runADAGUCServer("source=usgs_earthquakes.geojson&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS=mag&QUERY_LAYERS=mag&CRS=EPSG%3A3857&BBOX=-23104664.410278287,-14378748.700871969,-3145013.1419883464,15878107.815369671&WIDTH=849&HEIGHT=1287&I=460&J=438&INFO_FORMAT=application/json&", env=env)
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertEqual(data.getvalue(), AdagucTestTools(
-        ).readfromfile(self.expectedoutputsspath + filename))
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
     def test_WMSPointRenderer_usgs_earthquakes_geojson_GetFeatureInfoJSONOutsidePoint(self):
-        env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-           "/data/config/adaguc.autoresource.xml"}
+        env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
 
         filename="test_WMSPointRenderer_usgs_earthquakes_geojson_GetFeatureInfoJSONOutsidePoint.json"
-        status, data, headers = AdagucTestTools().runADAGUCServer("source=usgs_earthquakes.geojson&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS=mag&QUERY_LAYERS=mag&CRS=EPSG%3A3857&BBOX=-15726290.605935914,1725196.0890940144,-10964171.442404782,6983730.098762937&WIDTH=825&HEIGHT=911&I=248&J=368&INFO_FORMAT=application/json&STYLES=&", env=env)
+        status, data, _ = AdagucTestTools().runADAGUCServer("source=usgs_earthquakes.geojson&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS=mag&QUERY_LAYERS=mag&CRS=EPSG%3A3857&BBOX=-15726290.605935914,1725196.0890940144,-10964171.442404782,6983730.098762937&WIDTH=825&HEIGHT=911&I=248&J=368&INFO_FORMAT=application/json&STYLES=&", env=env)
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertEqual(data.getvalue(), AdagucTestTools(
-        ).readfromfile(self.expectedoutputsspath + filename))
-
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
     def test_WMSPointRenderer_usgs_earthquakes_geojson_auto_nearest_GetLegendGraphic(self):
-        env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-           "/data/config/adaguc.autoresource.xml"}
+        env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
 
-        filename="test_WMSPointRenderer_usgs_earthquakes_geojson_auto_nearest_GetLegendGraphic.png"
-        status, data, headers = AdagucTestTools().runADAGUCServer("source%3Dusgs_earthquakes%2Egeojson&SERVICE=WMS&&version=1.1.1&service=WMS&request=GetLegendGraphic&layer=mag&format=image/png&STYLE=auto/nearest&layers=mag&&&transparent=true", env=env)
+        filename = "test_WMSPointRenderer_usgs_earthquakes_geojson_auto_nearest_GetLegendGraphic.png"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "source%3Dusgs_earthquakes%2Egeojson&SERVICE=WMS&&version=1.1.1&service=WMS&request=GetLegendGraphic&layer=mag&format=image/png&STYLE=auto/nearest&layers=mag&&&transparent=true",
+            env=env,
+        )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertEqual(data.getvalue(), AdagucTestTools(
-        ).readfromfile(self.expectedoutputsspath + filename))
-        
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
+
     def test_WMSPointRenderer_usgs_earthquakes_geojson_auto_nearest_GetLegendGraphicColorScaleRange0_20(self):
-        env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-           "/data/config/adaguc.autoresource.xml"}
+        env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
 
-        filename="test_WMSPointRenderer_usgs_earthquakes_geojson_auto_nearest_GetLegendGraphicColorScaleRange0_20.png"
-        status, data, headers = AdagucTestTools().runADAGUCServer("source%3Dusgs_earthquakes%2Egeojson&SERVICE=WMS&&version=1.1.1&service=WMS&request=GetLegendGraphic&layer=mag&format=image/png&STYLE=auto/nearest&layers=mag&&&transparent=true&colorscalerange=0,20", env=env)
+        filename = "test_WMSPointRenderer_usgs_earthquakes_geojson_auto_nearest_GetLegendGraphicColorScaleRange0_20.png"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "source%3Dusgs_earthquakes%2Egeojson&SERVICE=WMS&&version=1.1.1&service=WMS&request=GetLegendGraphic&layer=mag&format=image/png&STYLE=auto/nearest&layers=mag&&&transparent=true&colorscalerange=0,20",
+            env=env,
+        )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertEqual(data.getvalue(), AdagucTestTools(
-        ).readfromfile(self.expectedoutputsspath + filename))
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
 
     def test_WMSPointRenderer_usgs_earthquakes_geojson_GetMap_MultiVar(self):
         AdagucTestTools().cleanTempDir()
 
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-            ADAGUC_PATH + '/data/config/datasets/adaguc.testGeoJSONReaderMultivariable.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env=self.env, isCGI=False)
-        self.assertEqual(status, 0)
+        config = (
+            ADAGUC_PATH
+            + "/data/config/adaguc.tests.dataset.xml,"
+            + ADAGUC_PATH
+            + "/data/config/datasets/adaguc.testGeoJSONReaderMultivariable.xml"
+        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
+        assert status == 0
 
-        filename="test_WMSPointRenderer_usgs_earthquakes_geojson_GetMap_MultiVar.png"
-        status, data, headers = AdagucTestTools().runADAGUCServer("DATASET=adaguc.testGeoJSONReaderMultivariable&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=usgs_earthquakes_age_magnitude_geojson&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=500571.08859811374,5790835.942920016,1024650.2598764997,7187305.365464885&STYLES=age_magnitude_triangles%2Fpoint&FORMAT=image/png&TRANSPARENT=TRUE&&time=2022-09-22T07%3A25%3A20Z&", env=self.env)
+        filename = "test_WMSPointRenderer_usgs_earthquakes_geojson_GetMap_MultiVar.png"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "DATASET=adaguc.testGeoJSONReaderMultivariable&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=usgs_earthquakes_age_magnitude_geojson&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=500571.08859811374,5790835.942920016,1024650.2598764997,7187305.365464885&STYLES=age_magnitude_triangles%2Fpoint&FORMAT=image/png&TRANSPARENT=TRUE&&time=2022-09-22T07%3A25%3A20Z&",
+            env=self.env,
+        )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertEqual(status, 0)
-        self.assertEqual(data.getvalue(), AdagucTestTools(
-        ).readfromfile(self.expectedoutputsspath + filename))
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)

--- a/tests/AdagucTests/TestWMSPolylineRenderer.py
+++ b/tests/AdagucTests/TestWMSPolylineRenderer.py
@@ -13,6 +13,7 @@ from adaguc.AdagucTestTools import AdagucTestTools
 ADAGUC_PATH = os.environ['ADAGUC_PATH']
 
 
+# TODO: Parametrize
 class TestWMSPolylineRenderer(unittest.TestCase):
     testresultspath = "testresults/TestWMSPolylineRenderer/"
     expectedoutputsspath = "expectedoutputs/TestWMSPolylineRenderer/"

--- a/tests/AdagucTests/TestWMSPolylineRenderer.py
+++ b/tests/AdagucTests/TestWMSPolylineRenderer.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from adaguc.AdagucTestTools import AdagucTestTools
+from conftest import make_adaguc_env, update_db
 
 ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
@@ -8,7 +9,6 @@ ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 class TestWMSPolylineRenderer:
     testresultspath = "testresults/TestWMSPolylineRenderer/"
     expectedoutputsspath = "expectedoutputs/TestWMSPolylineRenderer/"
-    env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml"}
 
     AdagucTestTools().mkdir_p(testresultspath)
 
@@ -26,21 +26,15 @@ class TestWMSPolylineRenderer:
     def test_WMSPolylineRenderer_borderwidth_1px(self, stylename: str):
         AdagucTestTools().cleanTempDir()
 
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.testwmspolylinerenderer.xml"
-        )
-        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
-        assert status == 0
+        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testwmspolylinerenderer.xml")
+        update_db(env)
 
         filename = "test_WMSPolylineRenderer_" + stylename + ".png"
         status, data, _ = AdagucTestTools().runADAGUCServer(
             "DATASET=adaguc.testwmspolylinerenderer&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=neddis&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=51.05009024158416,2.254746,54.44300975841584,7.054254&STYLES="
             + stylename
             + "%2Fpolyline&FORMAT=image/png&TRANSPARENT=TRUE&",
-            env=self.env,
+            env=env,
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         assert status == 0
@@ -54,19 +48,13 @@ class TestWMSPolylineRenderer:
     def test_WMSPolylineRenderer_cellwarn_fillpolysalpha(self):
         AdagucTestTools().cleanTempDir()
 
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.testwmspolylinerenderer.xml"
-        )
-        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
-        assert status == 0
+        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testwmspolylinerenderer.xml")
+        update_db(env)
 
         filename = "test_WMSPolylineRenderer_cellwarn_fillpolysalpha.png"
         status, data, _ = AdagucTestTools().runADAGUCServer(
             "DATASET=adaguc.testwmspolylinerenderer&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=cellwarn_hail_combined&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=540000,6600000,850000,6750000&STYLES=polygon_innerparts_coloured&FORMAT=image/png&TRANSPARENT=TRUE&",
-            env=self.env,
+            env=env,
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         assert status == 0
@@ -171,19 +159,13 @@ class TestWMSPolylineRenderer:
     def test_WMSPointRenderer_usgs_earthquakes_geojson_GetMap_MultiVar(self):
         AdagucTestTools().cleanTempDir()
 
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.testGeoJSONReaderMultivariable.xml"
-        )
-        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
-        assert status == 0
+        env = make_adaguc_env("{ADAGUC_PATH}/data/config/datasets/adaguc.testGeoJSONReaderMultivariable.xml")
+        update_db(env)
 
         filename = "test_WMSPointRenderer_usgs_earthquakes_geojson_GetMap_MultiVar.png"
         status, data, _ = AdagucTestTools().runADAGUCServer(
             "DATASET=adaguc.testGeoJSONReaderMultivariable&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=usgs_earthquakes_age_magnitude_geojson&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=500571.08859811374,5790835.942920016,1024650.2598764997,7187305.365464885&STYLES=age_magnitude_triangles%2Fpoint&FORMAT=image/png&TRANSPARENT=TRUE&&time=2022-09-22T07%3A25%3A20Z&",
-            env=self.env,
+            env=env,
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         assert status == 0

--- a/tests/AdagucTests/TestWMSSLD.py
+++ b/tests/AdagucTests/TestWMSSLD.py
@@ -26,16 +26,6 @@ class TestWMSSLD(unittest.TestCase):
 
     AdagucTestTools().mkdir_p(testresultspath)
 
-    def checkReport(self, reportFilename="", expectedReportFilename=""):
-        self.assertTrue(os.path.exists(reportFilename))
-        self.assertEqual(
-            AdagucTestTools().readfromfile(reportFilename),
-            AdagucTestTools().readfromfile(
-                self.expectedoutputsspath + expectedReportFilename
-            ),
-        )
-        os.remove(reportFilename)
-
     def test_WMSGetMap_testdatanc_NOSLD(self):
         AdagucTestTools().cleanTempDir()
         filename = "test_WMSGetMap_testdatanc_NOSLD.png"

--- a/tests/AdagucTests/TestWMSVolScan.py
+++ b/tests/AdagucTests/TestWMSVolScan.py
@@ -1,70 +1,83 @@
 import os
-import os.path
-import unittest
+import pytest
 
 from adaguc.AdagucTestTools import AdagucTestTools
 
 ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 
-# TODO: Parametrize
-class TestWMSVolScan(unittest.TestCase):
+class TestWMSVolScan:
     testresultspath = "testresults/TestWMSVolScan/"
     expectedoutputsspath = "expectedoutputs/TestWMSVolScan/"
     env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
 
     AdagucTestTools().mkdir_p(testresultspath)
 
-    def checkReport(self, reportFilename="", expectedReportFilename=""):
-        self.assertTrue(os.path.exists(reportFilename))
-        self.assertEqual(
-            AdagucTestTools().readfromfile(reportFilename),
-            AdagucTestTools().readfromfile(
-                self.expectedoutputsspath + expectedReportFilename
-            ),
+    @pytest.mark.parametrize(
+        "file_type",
+        [
+            ("ODIM"),
+            ("KNMI"),
+        ],
+    )
+    def test_WMSGetCapabilities_VolScan(self, file_type: str):
+        AdagucTestTools().cleanTempDir()
+
+        filename = f"test_WMSGetCapabilities_{file_type}_VolScan.xml"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            f"source=test/volscan/{file_type}_RAD_NL62_VOL_NA_202106181850.h5&SERVICE=WMS&request=getcapabilities",
+            env=self.env,
         )
-        os.remove(reportFilename)
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
 
-    def test_WMSGetCapabilities_VolScan(self):
-        AdagucTestTools().cleanTempDir()
-        for file_type in ["ODIM", "KNMI"]:
-            filename = f"test_WMSGetCapabilities_{file_type}_VolScan.xml"
-            status, data, headers = AdagucTestTools().runADAGUCServer(
-                f"source=test/volscan/{file_type}_RAD_NL62_VOL_NA_202106181850.h5&SERVICE=WMS&request=getcapabilities",
-                env=self.env,
-            )
-            AdagucTestTools().writetofile(
-                self.testresultspath + filename, data.getvalue()
-            )
-            self.assertEqual(status, 0)
-            self.assertTrue(
-                AdagucTestTools().compareGetCapabilitiesXML(
-                    self.testresultspath + filename,
-                    self.expectedoutputsspath + filename,
-                )
-            )
+        assert status == 0
+        assert AdagucTestTools().compareGetCapabilitiesXML(
+            self.testresultspath + filename,
+            self.expectedoutputsspath + filename,
+        )
 
-    def test_WMSGetMap_VolScan(self):
+    @pytest.mark.parametrize(
+        ("file_type", "layer", "elevation"),
+        [
+            ("ODIM", "ZDR", "0.3l"),
+            ("ODIM", "ZDR", "0.3"),
+            ("ODIM", "ZDR", "8"),
+            ("ODIM", "KDP", "0.3l"),
+            ("ODIM", "KDP", "0.3"),
+            ("ODIM", "KDP", "8"),
+            ("ODIM", "RHOHV", "0.3l"),
+            ("ODIM", "RHOHV", "0.3"),
+            ("ODIM", "RHOHV", "8"),
+            ("ODIM", "Height", "0.3l"),
+            ("ODIM", "Height", "0.3"),
+            ("ODIM", "Height", "8"),
+            ("KNMI", "ZDR", "0.3l"),
+            ("KNMI", "ZDR", "0.3"),
+            ("KNMI", "ZDR", "8"),
+            ("KNMI", "KDP", "0.3l"),
+            ("KNMI", "KDP", "0.3"),
+            ("KNMI", "KDP", "8"),
+            ("KNMI", "RHOHV", "0.3l"),
+            ("KNMI", "RHOHV", "0.3"),
+            ("KNMI", "RHOHV", "8"),
+            ("KNMI", "Height", "0.3l"),
+            ("KNMI", "Height", "0.3"),
+            ("KNMI", "Height", "8"),
+        ],
+    )
+    def test_WMSGetMap_VolScan(self, file_type: str, layer: str, elevation: str):
         AdagucTestTools().cleanTempDir()
-        for file_type in ["ODIM", "KNMI"]:
-            for layer in ["ZDR", "KDP", "RHOHV", "Height"]:
-                for elev in ["0.3l", "0.3", "8"]:
-                    filename = f"test_WMSGetMap_VolScan_{layer}_{elev}.png"
-                    request_layer = layer
-                    if file_type == "KNMI" and layer == "RHOHV":
-                        request_layer = "RhoHV"
-                    wms_arg = f"source=test/volscan/{file_type}_RAD_NL62_VOL_NA_202106181850.h5&SERVICE=WMS&request=getmap&LAYERS={request_layer}&format=image/png&STYLES=&WMS=1.3.0&CRS=EPSG:4326&BBOX=46,0,58,12&WIDTH=400&HEIGHT=400&SHOWDIMS=true&DIM_scan_elevation={elev}"
-                    status, data, headers = AdagucTestTools().runADAGUCServer(
-                        wms_arg, env=self.env
-                    )
-                    AdagucTestTools().writetofile(
-                        self.testresultspath + f"{file_type}_{filename}",
-                        data.getvalue(),
-                    )
-                    self.assertEqual(status, 0)
-                    self.assertEqual(
-                        data.getvalue(),
-                        AdagucTestTools().readfromfile(
-                            self.expectedoutputsspath + f"{file_type}_{filename}",
-                        )
-                    )
+
+        filename = f"test_WMSGetMap_VolScan_{layer}_{elevation}.png"
+        request_layer = layer
+        if file_type == "KNMI" and layer == "RHOHV":
+            request_layer = "RhoHV"
+
+        wms_arg = f"source=test/volscan/{file_type}_RAD_NL62_VOL_NA_202106181850.h5&SERVICE=WMS&request=getmap&LAYERS={request_layer}&format=image/png&STYLES=&WMS=1.3.0&CRS=EPSG:4326&BBOX=46,0,58,12&WIDTH=400&HEIGHT=400&SHOWDIMS=true&DIM_scan_elevation={elevation}"
+        status, data, _ = AdagucTestTools().runADAGUCServer(wms_arg, env=self.env)
+        AdagucTestTools().writetofile(
+            self.testresultspath + f"{file_type}_{filename}",
+            data.getvalue(),
+        )
+        assert status == 0
+        assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + f"{file_type}_{filename}")

--- a/tests/AdagucTests/TestWMSVolScan.py
+++ b/tests/AdagucTests/TestWMSVolScan.py
@@ -1,19 +1,13 @@
-import datetime
-import json
 import os
 import os.path
-import re
-import shutil
-import subprocess
 import unittest
-from io import BytesIO
 
 from adaguc.AdagucTestTools import AdagucTestTools
-from lxml import etree, objectify
 
 ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 
+# TODO: Parametrize
 class TestWMSVolScan(unittest.TestCase):
     testresultspath = "testresults/TestWMSVolScan/"
     expectedoutputsspath = "expectedoutputs/TestWMSVolScan/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,16 +90,18 @@ def make_adaguc_env(dataset: str = "") -> dict:
     return {"ADAGUC_CONFIG": config}
 
 
-def update_db(adaguc_env: dict):
+def update_db(adaguc_env: dict, force_update: bool = False):
     """
-    Runs `--updatedb` if it hasn't been ran before. When executed multiple times with the same env, no extra calls will take place.
+    Run `--updatedb` if it has not been run before for the given environment. When executed multiple times
+    with the same environment, no additional `--updatedb` calls will be made, unless `force_update` is enabled.
 
-    Expects an `adaguc_env`, which is a dictionary with `ADAGUC_CONFIG` as key.
+    - `adaguc_env`: Environment configuration with `ADAGUC_CONFIG` as key.
+    - `force_update`: Always execute `force_update`, even if it has run before.
     """
 
     adaguc_config = adaguc_env.get("ADAGUC_CONFIG")
 
-    if adaguc_config in DATASETS_LOADED:
+    if not force_update and adaguc_config in DATASETS_LOADED:
         return
 
     from adaguc.AdagucTestTools import AdagucTestTools

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 import resource
 
+import pytest
+
 
 def determine_db_host():
     test_env = getenv("TEST_IN_CONTAINER", "").strip()
@@ -43,9 +45,7 @@ def set_env_vars():
 
 def ensure_adaguc_test_db():
     # We can only drop/recreate adaguc_test when connected to a different dbname
-    maintenance_db = (
-        f"user=adaguc password=adaguc host={DB_HOST} dbname=postgres port=54321"
-    )
+    maintenance_db = f"user=adaguc password=adaguc host={DB_HOST} dbname=postgres port=54321"
 
     # Verify testing db is running
     try:
@@ -68,6 +68,47 @@ set_env_vars()
 ensure_adaguc_test_db()
 
 # Set coredump size to unlimited, equivalent of `ulimit -c unlimited`
-resource.setrlimit(
-    resource.RLIMIT_CORE, (resource.RLIM_INFINITY, resource.RLIM_INFINITY)
-)
+resource.setrlimit(resource.RLIMIT_CORE, (resource.RLIM_INFINITY, resource.RLIM_INFINITY))
+
+
+DATASETS_LOADED = set()
+
+
+def make_adaguc_env(dataset: str = "") -> dict:
+    """
+    Return a dictionary with ADAGUC_CONFIG as key, and the value set to a default dataset + a given dataset.
+    Format is ready to pass into update_db() and runADAGUCServer().
+    """
+
+    ADAGUC_PATH = environ["ADAGUC_PATH"]
+
+    config = f"{ADAGUC_PATH}/data/config/adaguc.tests.dataset.xml"
+
+    if dataset:
+        config = f"{config},{dataset}"
+
+    return {"ADAGUC_CONFIG": config}
+
+
+def update_db(adaguc_env: dict):
+    """
+    Runs `--updatedb` if it hasn't been ran before. When executed multiple times with the same env, no extra calls will take place.
+
+    Expects an `adaguc_env`, which is a dictionary with `ADAGUC_CONFIG` as key.
+    """
+
+    adaguc_config = adaguc_env.get("ADAGUC_CONFIG")
+
+    if adaguc_config in DATASETS_LOADED:
+        return
+
+    from adaguc.AdagucTestTools import AdagucTestTools
+
+    args = ["--updatedb"]
+    if adaguc_env:
+        args += ["--config", adaguc_config]
+
+    status, *_ = AdagucTestTools().runADAGUCServer(args=args, env=adaguc_env, isCGI=False)
+    assert status == 0
+
+    DATASETS_LOADED.add(adaguc_config)


### PR DESCRIPTION
Fixes: https://github.com/KNMI/adaguc-server/issues/560

Parametrize tests using pytest.

Because `unittest.TestCase` and pytest `parametrize` do not work together, I've converted all the `self.assertTrue` to regular python `assert x == y` calls.

I've added the following helper methods to `conftest.py`:
```python
env = make_adaguc_env("/path/to/testcase_config.xml")
update_db(env)
```

- `make_adaguc_env` gives `{"ADAGUC_CONFIG": "/path/to/default_config.xml,/path/to/testcase_config.xml"}`.
- `update_db` calls `--updatedb` once per given dataset/env. This means we don't needlessly update the database.

If we're happy with the helper functions and the new asserts, we could refactor all other test files (in a new PR). I think it will reduce testing boiler plate by quite a bit.