### PR TITLE
Add pre-commit hooks and format python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  # black ~ Formats Python code
+  - repo: https://github.com/psf/black
+    rev: 26.1.0
+    hooks:
+      - id: black
+        args: ["--config", "./pyproject.toml"]
+        files: ^tests/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -108,5 +108,5 @@
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "python.testing.cwd": "${workspaceFolder}/tests",
-  "black-formatter.args" : ["--config", "${workspaceFolder}/pyproject.toml"],
+  "black-formatter.args": ["--config", "${workspaceFolder}/pyproject.toml"],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -108,4 +108,5 @@
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "python.testing.cwd": "${workspaceFolder}/tests",
+  "black-formatter.args" : ["--config", "${workspaceFolder}/pyproject.toml"],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -108,5 +108,4 @@
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "python.testing.cwd": "${workspaceFolder}/tests",
-  "black-formatter.args": ["--line-length", "140"],
 }

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -156,7 +156,7 @@ bash runtests_psql.sh
 
 # 8. Setup pre-commit hooks for formatting
 
-You need to do the steps _once_ to setup the pre-commit hooks:
+You need to do these steps _once_ to setup the pre-commit hooks:
 
 1. Install the python dependencies:
 ```bash

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -142,7 +142,7 @@ Copy a test netcdf file and display:
 
 # 7. Run tests
 
-First start the docker used for testing: 
+First start the docker used for testing:
 
 ```
 docker compose -f Docker/docker-compose-test.yml up -Vd
@@ -153,6 +153,32 @@ Then run the tests by doing:
 ```
 bash runtests_psql.sh
 ```
+
+# 8. Setup pre-commit hooks for formatting
+
+You need to do the steps _once_ to setup the pre-commit hooks:
+
+1. Install the python dependencies:
+```bash
+pip-sync requirements.txt requirements-dev.txt
+cd ./python/lib/ && python3 setup.py develop && cd ../../
+```
+
+2. Setup pre-commit hooks
+```bash
+git init
+pre-commit install
+```
+
+From then, `git commit` will automatically run the python formatting tools.
+
+To skip the pre-commit hook, run `git commit -m "A message" --no-verify`.
+
+To manually execute the pre-commit hooks on all files, run: `pre-commit run --all-files`.
+
+Important files:
+- `pyproject.toml` for configuration of python formatting
+- `.pre-commit-config.yaml` for pre-commit configuration
 
 ## To scan datasets
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -7,6 +7,7 @@
 black~=24.3
 deepdiff~=8.6
 isort~=5.12
+pre-commit~=4.5
 pylint~=2.17
 pytest~=7.4
 pytest-asyncio~=0.23.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,11 +4,12 @@
 #
 #    pip-compile --no-emit-index-url requirements-dev.in
 #
-# Upgrade via: pip-compile --upgrade --no-emit-index-url
 astroid==2.15.8
     # via pylint
 black==24.10.0
     # via -r requirements-dev.in
+cfgv==3.5.0
+    # via pre-commit
 click==8.1.8
     # via
     #   -c requirements.txt
@@ -17,10 +18,16 @@ deepdiff==8.6.1
     # via -r requirements-dev.in
 dill==0.4.1
     # via pylint
+distlib==0.4.0
+    # via virtualenv
 exceptiongroup==1.3.1
     # via
     #   -c requirements.txt
     #   pytest
+filelock==3.20.3
+    # via virtualenv
+identify==2.6.16
+    # via pre-commit
 iniconfig==2.3.0
     # via pytest
 isort==5.13.2
@@ -33,6 +40,8 @@ mccabe==0.7.0
     # via pylint
 mypy-extensions==1.1.0
     # via black
+nodeenv==1.10.0
+    # via pre-commit
 orderly-set==5.5.0
     # via deepdiff
 packaging==26.0
@@ -46,8 +55,11 @@ platformdirs==4.5.1
     # via
     #   black
     #   pylint
+    #   virtualenv
 pluggy==1.6.0
     # via pytest
+pre-commit==4.5.1
+    # via -r requirements-dev.in
 psycopg2==2.9.11
     # via -r requirements-dev.in
 pylint==2.17.7
@@ -58,6 +70,10 @@ pytest==7.4.4
     #   pytest-asyncio
 pytest-asyncio==0.23.8
     # via -r requirements-dev.in
+pyyaml==6.0.3
+    # via
+    #   -c requirements.txt
+    #   pre-commit
 tomli==2.4.0
     # via
     #   black
@@ -71,5 +87,8 @@ typing-extensions==4.15.0
     #   astroid
     #   black
     #   exceptiongroup
+    #   virtualenv
+virtualenv==20.36.1
+    # via pre-commit
 wrapt==1.17.3
     # via astroid

--- a/tests/AdagucTests/TestADAGUCFeatureFunctions.py
+++ b/tests/AdagucTests/TestADAGUCFeatureFunctions.py
@@ -4,28 +4,28 @@
 # pylint: disable=unused-argument
 
 """
- Run test for ADAGUC Feature functions
+Run test for ADAGUC Feature functions
 """
+
 import unittest
 import os
 from adaguc.ADAGUCFeatureFunctions import ADAGUCFeatureCombineNuts
 
 from adaguc.AdagucTestTools import AdagucTestTools
 
-ADAGUC_PATH = os.environ['ADAGUC_PATH']
+ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 
 class TestADAGUCFeatureFunctions(unittest.TestCase):
     """
     Run test for ADAGUC Feature functions
     """
+
     testresultspath = "{ADAGUC_PATH}/tests/testresults/TestADAGUCFeatureFunctions/"
     expectedoutputsspath = "{ADAGUC_PATH}/tests/expectedoutputs/TestADAGUCFeatureFunctions/"
-    env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-           "/data/config/adaguc.autoresource.xml"}
+    env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
     testresultspath = testresultspath.replace("{ADAGUC_PATH}/", ADAGUC_PATH)
-    expectedoutputsspath = expectedoutputsspath.replace(
-        "{ADAGUC_PATH}/", ADAGUC_PATH)
+    expectedoutputsspath = expectedoutputsspath.replace("{ADAGUC_PATH}/", ADAGUC_PATH)
 
     AdagucTestTools().mkdir_p(testresultspath)
 
@@ -44,7 +44,7 @@ class TestADAGUCFeatureFunctions(unittest.TestCase):
 
         ADAGUCFeatureCombineNuts(
             featureNCFile="countries.geojson",
-            #dataNCFile = "myfile.nc",
+            # dataNCFile = "myfile.nc",
             dataNCFile="testdata.nc",
             bbox="0,50,10,55",
             time=None,
@@ -56,10 +56,13 @@ class TestADAGUCFeatureFunctions(unittest.TestCase):
             outncpointfile=self.testresultspath + filenamencpoint,
             outcsvfile=self.testresultspath + filenamecsv,
             tmpFolderPath="/tmp",
-            callback=progressCallback)
-        #AdagucTestTools().writetofile(self.testresultspath + filename,data.getvalue())
+            callback=progressCallback,
+        )
+        # AdagucTestTools().writetofile(self.testresultspath + filename,data.getvalue())
         # Comparing binary NetCDF is difficult
         # self.assertEqual(
         # AdagucTestTools().readfromfile(self.testresultspath + filenamencraster), AdagucTestTools().readfromfile(self.expectedoutputsspath + filenamencraster))
         self.assertEqual(
-            AdagucTestTools().readfromfile(self.testresultspath + filenamecsv), AdagucTestTools().readfromfile(self.expectedoutputsspath + filenamecsv))
+            AdagucTestTools().readfromfile(self.testresultspath + filenamecsv),
+            AdagucTestTools().readfromfile(self.expectedoutputsspath + filenamecsv),
+        )

--- a/tests/AdagucTests/TestConvertLatLonBnds.py
+++ b/tests/AdagucTests/TestConvertLatLonBnds.py
@@ -2,6 +2,7 @@
 """
 This class contains tests to test the adaguc-server binary executable file. This is similar to black box testing, it tests the behaviour of the server software. It configures the server and checks if the response is OK.
 """
+
 import os
 import os.path
 import unittest
@@ -36,11 +37,7 @@ class TestConvertLatLonBnds(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_ConvertLatLonBnds_getMap(self):
         AdagucTestTools().cleanTempDir()
@@ -59,11 +56,7 @@ class TestConvertLatLonBnds(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareImage(
-                self.expectedoutputsspath + filename, self.testresultspath + filename, 8
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareImage(self.expectedoutputsspath + filename, self.testresultspath + filename, 8))
 
     def test_ConvertLatLonBnds_getFeatureInfo(self):
         AdagucTestTools().cleanTempDir()
@@ -83,7 +76,5 @@ class TestConvertLatLonBnds(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertEqual(
             json.loads(data.getvalue()),
-            json.loads(
-                AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
-            ),
+            json.loads(AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)),
         )

--- a/tests/AdagucTests/TestDataPostProcessor.py
+++ b/tests/AdagucTests/TestDataPostProcessor.py
@@ -11,235 +11,187 @@ from adaguc.AdagucTestTools import AdagucTestTools
 from lxml import etree, objectify
 import datetime
 
-ADAGUC_PATH = os.environ['ADAGUC_PATH']
+ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 
 class TestDataPostProcessor(unittest.TestCase):
     testresultspath = "testresults/TestDataPostProcessor/"
     expectedoutputsspath = "expectedoutputs/TestDataPostProcessor/"
-    env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-            "/data/config/adaguc.tests.dataset.xml"}
+    env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml"}
 
     AdagucTestTools().mkdir_p(testresultspath)
 
-  
-
     def test_DataPostProcessor_SubstractLevels_GetCapabilities(self):
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-            ADAGUC_PATH + '/data/config/datasets/adaguc.tests.datapostproc.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env=self.env, isCGI=False)
+        config = (
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.datapostproc.xml"
+        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
         filename = "test_DataPostProcessor_SubstractLevels_GetCapabilities.xml"
-        
+
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "dataset=adaguc.tests.datapostproc&SERVICE=WMS&request=getcapabilities",
-            {
-                'ADAGUC_CONFIG':
-                ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml'
-            })
+            {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml"},
+        )
 
-        AdagucTestTools().writetofile(self.testresultspath + filename,
-                                      data.getvalue())
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(
-            self.testresultspath + filename,
-            self.expectedoutputsspath + filename))
-
-
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_DataPostProcessor_SubstractLevels_GetMap(self):
         """
-        The input data for this set is a NetCDF file where textmessages are printed in the grid. 
-        This test checks if the correct dimensions are chosen and verifies if the result is as expected. 
+        The input data for this set is a NetCDF file where textmessages are printed in the grid.
+        This test checks if the correct dimensions are chosen and verifies if the result is as expected.
         The result does not look pretty, it is purely functional.
         """
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-            ADAGUC_PATH + '/data/config/datasets/adaguc.tests.datapostproc.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env=self.env, isCGI=False)
+        config = (
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.datapostproc.xml"
+        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
         filename = "test_DataPostProcessor_SubstractLevels_GetMap.png"
-        
+
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "dataset=adaguc.tests.datapostproc&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=output&WIDTH=256&CRS=EPSG:4326&HEIGHT=256&STYLES=default&FORMAT=image/png&TRANSPARENT=FALSE&showlegend=false",
-            {
-                'ADAGUC_CONFIG':
-                ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml'
-            })
+            {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml"},
+        )
 
-        AdagucTestTools().writetofile(self.testresultspath + filename,
-                                      data.getvalue())
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
 
-        self.assertEqual(
-            data.getvalue(),
-            AdagucTestTools().readfromfile(self.expectedoutputsspath +
-                                           filename))
-        
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
     def test_datapostprocessor_windshear_getmap(self):
         """
         Test for the windshear post processor
         """
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-            ADAGUC_PATH + '/data/config/datasets/adaguc.tests.datapostproc-windshear.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env=self.env, isCGI=False)
+        config = (
+            ADAGUC_PATH
+            + "/data/config/adaguc.tests.dataset.xml,"
+            + ADAGUC_PATH
+            + "/data/config/datasets/adaguc.tests.datapostproc-windshear.xml"
+        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_DataPostProcessor_WindShear_GetMap.png"
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "dataset=adaguc.tests.datapostproc-windshear&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=output&WIDTH=256&CRS=EPSG:4326&HEIGHT=256&STYLES=default&FORMAT=image/png&TRANSPARENT=FALSE&showlegend=false",
-            {
-                'ADAGUC_CONFIG':
-                ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml'
-            })
+            {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml"},
+        )
 
-        AdagucTestTools().writetofile(self.testresultspath + filename,
-                                      data.getvalue())
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertEqual(
-            data.getvalue(),
-            AdagucTestTools().readfromfile(self.expectedoutputsspath +
-                                           filename))
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
     def test_datapostprocessor_windshear_getmetadata(self):
         """
         Test for the windshear post processor
         """
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-            ADAGUC_PATH + '/data/config/datasets/adaguc.tests.datapostproc-windshear.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env=self.env, isCGI=False)
+        config = (
+            ADAGUC_PATH
+            + "/data/config/adaguc.tests.dataset.xml,"
+            + ADAGUC_PATH
+            + "/data/config/datasets/adaguc.tests.datapostproc-windshear.xml"
+        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
         filename = "test_DataPostProcessor_WindShear_GetMetaData.txt"
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "dataset=adaguc.tests.datapostproc-windshear&service=wms&request=getmetadata&format=image/png&srs=EPSG:4326&layer=output",
-            {
-                'ADAGUC_CONFIG':
-                ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml'
-            })
+            {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml"},
+        )
 
-        AdagucTestTools().writetofile(self.testresultspath + filename,
-                                      data.getvalue())
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertEqual(
-            data.getvalue(),
-            AdagucTestTools().readfromfile(self.expectedoutputsspath +
-                                           filename))
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
     def test_datapostprocessor_windshear_getfeatureinfo(self):
         """
         Test for the windshear post processor
         """
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-            ADAGUC_PATH + '/data/config/datasets/adaguc.tests.datapostproc-windshear.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env=self.env, isCGI=False)
+        config = (
+            ADAGUC_PATH
+            + "/data/config/adaguc.tests.dataset.xml,"
+            + ADAGUC_PATH
+            + "/data/config/datasets/adaguc.tests.datapostproc-windshear.xml"
+        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
         filename = "test_DataPostProcessor_WindShear_GetFeatureInfo.json"
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "dataset=adaguc.tests.datapostproc-windshear&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS=output&QUERY_LAYERS=output&CRS=EPSG%3A3857&BBOX=-1084594.00339733,5299085.702520586,2054668.3733940602,8244166.9013661165&WIDTH=1358&HEIGHT=1274&I=626&J=578&INFO_FORMAT=application/json&STYLES=&&time=2019-01-01T22%3A00%3A00Z",
-            {
-                'ADAGUC_CONFIG':
-                ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml'
-            })
+            {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml"},
+        )
 
-        AdagucTestTools().writetofile(self.testresultspath + filename,
-                                      data.getvalue())
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertEqual(
-            data.getvalue(),
-            AdagucTestTools().readfromfile(self.expectedoutputsspath +
-                                           filename))
-
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
     def test_datapostprocessor_windshear_gettimeseries(self):
         """
         Test for the windshear post processor
         """
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-            ADAGUC_PATH + '/data/config/datasets/adaguc.tests.datapostproc-windshear.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env=self.env, isCGI=False)
+        config = (
+            ADAGUC_PATH
+            + "/data/config/adaguc.tests.dataset.xml,"
+            + ADAGUC_PATH
+            + "/data/config/datasets/adaguc.tests.datapostproc-windshear.xml"
+        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
         filename = "test_DataPostProcessor_WindShear_GetTimeSeries.json"
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "dataset=adaguc.tests.datapostproc-windshear&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS=output&QUERY_LAYERS=output&CRS=EPSG%3A3857&BBOX=-1084594.00339733,5299085.702520586,2054668.3733940602,8244166.9013661165&WIDTH=1358&HEIGHT=1274&I=626&J=578&INFO_FORMAT=application/json&STYLES=&&time=*",
-            {
-                'ADAGUC_CONFIG':
-                ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml'
-            })
+            {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml"},
+        )
 
-        AdagucTestTools().writetofile(self.testresultspath + filename,
-                                      data.getvalue())
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertEqual(
-            data.getvalue(),
-            AdagucTestTools().readfromfile(self.expectedoutputsspath +
-                                           filename))
-
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
     def test_datapostprocessor_dbztorr_getmap(self):
         """
         Test for the dbztorr post processor
         """
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-            ADAGUC_PATH + '/data/config/datasets/adaguc.tests.datapostproc.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env=self.env, isCGI=False)
+        config = (
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.datapostproc.xml"
+        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
         filename = "test_DataPostProcessor_DBZ_GetMap.png"
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "DATASET=adaguc.tests.datapostproc&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=RAD_NL25_PCP_CM&WIDTH=256IGHT=256&CRS=EPSG%3A3857&BBOX=562267.2546644434,6568919.974681269,797831.9309681491,6869137.726056894&STYLES=radar%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&&time=2021-06-22T20%3A00%3A00Z",
-            {
-                'ADAGUC_CONFIG':
-                ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml'
-            })
+            {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml"},
+        )
 
-        AdagucTestTools().writetofile(self.testresultspath + filename,
-                                      data.getvalue())
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertEqual(
-            data.getvalue(),
-            AdagucTestTools().readfromfile(self.expectedoutputsspath +
-                                           filename))
-
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
     def test_datapostprocessor_axplusb_getmap(self):
         """
         Test for the axplusb post processor
         """
         AdagucTestTools().cleanTempDir()
-        config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-            ADAGUC_PATH + '/data/config/datasets/adaguc.tests.datapostproc.xml'
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=['--updatedb', '--config', config], env=self.env, isCGI=False)
+        config = (
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.datapostproc.xml"
+        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
         filename = "test_DataPostProcessor_axplusb_GetMap.png"
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "DATASET=adaguc.tests.datapostproc&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=testdata&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=-1841640.561188397,4434884.178327009,2446462.937192397,9899900.45389999&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&",
-            {
-                'ADAGUC_CONFIG':
-                ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml'
-            })
+            {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml"},
+        )
 
-        AdagucTestTools().writetofile(self.testresultspath + filename,
-                                      data.getvalue())
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertEqual(
-            data.getvalue(),
-            AdagucTestTools().readfromfile(self.expectedoutputsspath +
-                                           filename))
-        
-
-
-        
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))

--- a/tests/AdagucTests/TestEWCLocalClimateInfo.py
+++ b/tests/AdagucTests/TestEWCLocalClimateInfo.py
@@ -2,6 +2,7 @@
 """
 This class contains tests to test the adaguc-server binary executable file. This is similar to black box testing, it tests the behaviour of the server software. It configures the server and checks if the response is OK.
 """
+
 import os
 import json
 import unittest
@@ -25,8 +26,7 @@ class TestEWCLocalClimateInfo(unittest.TestCase):
             args=[
                 "--updatedb",
                 "--config",
-                self.adaguc_path
-                + "/data/config/adaguc.tests.dataset.xml,adaguc_ewclocalclimateinfo_test.xml",
+                self.adaguc_path + "/data/config/adaguc.tests.dataset.xml,adaguc_ewclocalclimateinfo_test.xml",
             ],
             env=self.env,
             isCGI=False,
@@ -60,7 +60,9 @@ class TestEWCLocalClimateInfo(unittest.TestCase):
             env=self.env,
         )
         self.assertEqual(status, 0)
-        AdagucTestTools().writetofile(self.testresultspath + filename, json.dumps( json.loads(data.getvalue().decode("utf-8")), indent=2).encode('utf-8'))
+        AdagucTestTools().writetofile(
+            self.testresultspath + filename, json.dumps(json.loads(data.getvalue().decode("utf-8")), indent=2).encode("utf-8")
+        )
         self.assertEqual(
             AdagucTestTools().readfromfile(self.testresultspath + filename),
             AdagucTestTools().readfromfile(self.expectedoutputsspath + filename),
@@ -74,7 +76,9 @@ class TestEWCLocalClimateInfo(unittest.TestCase):
             env=self.env,
         )
         self.assertEqual(status, 0)
-        AdagucTestTools().writetofile(self.testresultspath + filename, json.dumps( json.loads(data.getvalue().decode("utf-8")), indent=2).encode('utf-8'))
+        AdagucTestTools().writetofile(
+            self.testresultspath + filename, json.dumps(json.loads(data.getvalue().decode("utf-8")), indent=2).encode("utf-8")
+        )
         self.assertEqual(
             AdagucTestTools().readfromfile(self.testresultspath + filename),
             AdagucTestTools().readfromfile(self.expectedoutputsspath + filename),

--- a/tests/AdagucTests/TestFileScanner.py
+++ b/tests/AdagucTests/TestFileScanner.py
@@ -2,6 +2,7 @@
 """
 This class contains tests to test the adaguc-server binary executable file. This is similar to black box testing, it tests the behaviour of the server software. It configures the server and checks if the response is OK.
 """
+
 import os
 import shutil
 import time

--- a/tests/AdagucTests/TestGenericImageWarper.py
+++ b/tests/AdagucTests/TestGenericImageWarper.py
@@ -54,8 +54,16 @@ class TestGenericImageWarper:
                 "ahn_utrechtseheuvelrug_500m",
                 "style_colormapped_bilinear_multicolor_contours_extrasmooth_discretized",
             ),
-            ("ahn_utrechtseheuvelrug_500m_style_hillshaded_opaque.png", "ahn_utrechtseheuvelrug_500m", "style_hillshaded_opaque/hillshaded"),
-            ("ahn_utrechtseheuvelrug_500m_style_hillshaded_transparent.png", "ahn_utrechtseheuvelrug_500m", "style_hillshaded_transparent/hillshaded"),
+            (
+                "ahn_utrechtseheuvelrug_500m_style_hillshaded_opaque.png",
+                "ahn_utrechtseheuvelrug_500m",
+                "style_hillshaded_opaque/hillshaded",
+            ),
+            (
+                "ahn_utrechtseheuvelrug_500m_style_hillshaded_transparent.png",
+                "ahn_utrechtseheuvelrug_500m",
+                "style_hillshaded_transparent/hillshaded",
+            ),
             (
                 "ahn_utrechtseheuvelrug_500m_hillshaded_style_colormapped_bilinear_elevation.png",
                 "ahn_utrechtseheuvelrug_500m_hillshaded",
@@ -66,7 +74,11 @@ class TestGenericImageWarper:
                 "ahn_utrechtseheuvelrug_500m_hillshaded",
                 "style_colormapped_bilinear_multicolor_contours",
             ),
-            ("ahn_utrechtseheuvelrug_500m_hillshaded_style_dutch_mountains.png", "ahn_utrechtseheuvelrug_500m_hillshaded", "style_dutch_mountains"),
+            (
+                "ahn_utrechtseheuvelrug_500m_hillshaded_style_dutch_mountains.png",
+                "ahn_utrechtseheuvelrug_500m_hillshaded",
+                "style_dutch_mountains",
+            ),
         ],
     )
     def test_GenericImageWarperOnAHNDataset(self, filetocheck: str, layers: str, styles: str):

--- a/tests/AdagucTests/TestGeoJSONFeatures.py
+++ b/tests/AdagucTests/TestGeoJSONFeatures.py
@@ -17,60 +17,72 @@ ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 @pytest.mark.skip("These tests are never called")
 class TestGeoJSONFeatures(unittest.TestCase):
-  testresultspath = "testresults/TestGeoJSONFeatures/"
-  expectedoutputsspath = "expectedoutputs/TestGeoJSONFeatures/"
-  env = {'ADAGUC_CONFIG': ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," +
-         ADAGUC_PATH + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"}
+    testresultspath = "testresults/TestGeoJSONFeatures/"
+    expectedoutputsspath = "expectedoutputs/TestGeoJSONFeatures/"
+    env = {
+        "ADAGUC_CONFIG": ADAGUC_PATH
+        + "/data/config/adaguc.tests.dataset.xml,"
+        + ADAGUC_PATH
+        + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"
+    }
 
-  AdagucTestTools().mkdir_p(testresultspath)
+    AdagucTestTools().mkdir_p(testresultspath)
 
-  def test_GeoJSONFeatures_non_thin(self):
-    AdagucTestTools().cleanTempDir()
-    filename = "test_GeoJSONFeatures_non_thin.png"
-    env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-           "/data/config/adaguc.tests.dataset.xml,"+
-           ADAGUC_PATH +
-           "/data/config/adaguc.testGeoJSONFeatures.xml"}
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "source=countries.geojson&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=features&WIDTH=256&HEIGHT=128&CRS=EPSG%3A4326&BBOX=50,2,54,10&STYLES=auto&FORMAT=image/png&TRANSPARENT=TRUE", env=env, showLog=False)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue(), AdagucTestTools(
-    ).readfromfile(self.expectedoutputsspath + filename))
+    def test_GeoJSONFeatures_non_thin(self):
+        AdagucTestTools().cleanTempDir()
+        filename = "test_GeoJSONFeatures_non_thin.png"
+        env = {
+            "ADAGUC_CONFIG": ADAGUC_PATH
+            + "/data/config/adaguc.tests.dataset.xml,"
+            + ADAGUC_PATH
+            + "/data/config/adaguc.testGeoJSONFeatures.xml"
+        }
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=countries.geojson&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=features&WIDTH=256&HEIGHT=128&CRS=EPSG%3A4326&BBOX=50,2,54,10&STYLES=auto&FORMAT=image/png&TRANSPARENT=TRUE",
+            env=env,
+            showLog=False,
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
-  def test_GeoJSON_time_GetCapabilities(self):
-    AdagucTestTools().cleanTempDir()
-    config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-        ADAGUC_PATH + '/data/config/datasets/adaguc.testGeoJSONReader_time.xml'
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        args=['--updatedb', '--config', config], env={'ADAGUC_CONFIG': config}, isCGI=False, showLog=False)
-    self.assertEqual(status, 0)
-    # Test GetCapabilities
-    filename = "test_GeoJSON_time_GetCapabilities.xml"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities", env={'ADAGUC_CONFIG': config})
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(
-        self.testresultspath + filename, self.expectedoutputsspath + filename))
+    def test_GeoJSON_time_GetCapabilities(self):
+        AdagucTestTools().cleanTempDir()
+        config = (
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"
+        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
+        )
+        self.assertEqual(status, 0)
+        # Test GetCapabilities
+        filename = "test_GeoJSON_time_GetCapabilities.xml"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities", env={"ADAGUC_CONFIG": config}
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
-  def test_GeoJSON_3timesteps(self):
-    AdagucTestTools().cleanTempDir()
-    config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-        ADAGUC_PATH + '/data/config/datasets/adaguc.testGeoJSONReader_time.xml'
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        args=['--updatedb', '--config', config], env={'ADAGUC_CONFIG': config}, isCGI=False, showLog=False)
-    self.assertEqual(status, 0)
+    def test_GeoJSON_3timesteps(self):
+        AdagucTestTools().cleanTempDir()
+        config = (
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testGeoJSONReader_time.xml"
+        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", config], env={"ADAGUC_CONFIG": config}, isCGI=False, showLog=False
+        )
+        self.assertEqual(status, 0)
 
-    dates = ['2018-12-04T12:00:00Z',
-             '2018-12-04T12:05:00Z',
-             '2018-12-04T12:10:00Z']
+        dates = ["2018-12-04T12:00:00Z", "2018-12-04T12:05:00Z", "2018-12-04T12:10:00Z"]
 
-    for date in dates:
-      filename = ("test_GeoJSON_timesupport"+date+".png").replace(":","_")
-      status, data, headers = AdagucTestTools().runADAGUCServer(
-          "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=features&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=40,-10,60,40&STYLES=features&FORMAT=image/png&TRANSPARENT=TRUE&TIME=" + date, env={'ADAGUC_CONFIG': config})
-      AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-      self.assertEqual(status, 0)
-      self.assertEqual(data.getvalue(), AdagucTestTools(
-      ).readfromfile(self.expectedoutputsspath + filename))
+        for date in dates:
+            filename = ("test_GeoJSON_timesupport" + date + ".png").replace(":", "_")
+            status, data, headers = AdagucTestTools().runADAGUCServer(
+                "&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=features&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=40,-10,60,40&STYLES=features&FORMAT=image/png&TRANSPARENT=TRUE&TIME="
+                + date,
+                env={"ADAGUC_CONFIG": config},
+            )
+            AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+            self.assertEqual(status, 0)
+            self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))

--- a/tests/AdagucTests/TestGraticules.py
+++ b/tests/AdagucTests/TestGraticules.py
@@ -2,6 +2,7 @@
 """
 This class contains tests to test the adaguc-server binary executable file. This is similar to black box testing, it tests the behaviour of the server software. It configures the server and checks if the response is OK.
 """
+
 import os
 from adaguc.AdagucTestTools import AdagucTestTools
 import pytest
@@ -25,7 +26,7 @@ class TestGraticules:
         [
             ("grid1"),
             ("grid10"),
-        ]
+        ],
     )
     def test_Graticules(self, layer_name: str):
         AdagucTestTools().cleanTempDir()

--- a/tests/AdagucTests/TestMetadataRequest.py
+++ b/tests/AdagucTests/TestMetadataRequest.py
@@ -2,6 +2,7 @@
 """
 This class contains tests to test the adaguc-server binary executable file. This is similar to black box testing, it tests the behaviour of the server software. It configures the server and checks if the response is OK.
 """
+
 import os
 import unittest
 from adaguc.AdagucTestTools import AdagucTestTools
@@ -22,15 +23,8 @@ class TestMetadataRequest(unittest.TestCase):
 
     def test_timeseries_adaguc_tests_arcus_uwcw_air_temperature_hagl(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.arcus_uwcw.xml"
-        )
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.arcus_uwcw.xml"
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_GetMetadataRequest_arcus_uwcw.json"
@@ -41,8 +35,4 @@ class TestMetadataRequest(unittest.TestCase):
         )
         AdagucTestTools().writetojson(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(AdagucTestTools().compareFile(
-            self.testresultspath + filename, self.expectedoutputsspath + filename)
-        )
-
-
+        self.assertTrue(AdagucTestTools().compareFile(self.testresultspath + filename, self.expectedoutputsspath + filename))

--- a/tests/AdagucTests/TestMetadataService.py
+++ b/tests/AdagucTests/TestMetadataService.py
@@ -12,24 +12,25 @@ import re
 from adaguc.AdagucTestTools import AdagucTestTools
 
 import sys
-sys.path.append('../../adaguc')
 
-ADAGUC_PATH = os.environ['ADAGUC_PATH']
+sys.path.append("../../adaguc")
+
+ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 
 class TestMetadataService(unittest.TestCase):
-  testresultspath = "testresults/TestMetadataService/"
-  expectedoutputsspath = "expectedoutputs/TestMetadataService/"
-  env = {'ADAGUC_CONFIG': ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
+    testresultspath = "testresults/TestMetadataService/"
+    expectedoutputsspath = "expectedoutputs/TestMetadataService/"
+    env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
 
-  AdagucTestTools().mkdir_p(testresultspath)
+    AdagucTestTools().mkdir_p(testresultspath)
 
-  def test_MetadataGetMetadata(self):
-    AdagucTestTools().cleanTempDir()
-    filename = "test_MetadataGetMetadata.json"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "source=test/testdata_timedim.nc&SERVICE=metadata&request=getmetadata&", env=self.env)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue(), AdagucTestTools(
-    ).readfromfile(self.expectedoutputsspath + filename))
+    def test_MetadataGetMetadata(self):
+        AdagucTestTools().cleanTempDir()
+        filename = "test_MetadataGetMetadata.json"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=test/testdata_timedim.nc&SERVICE=metadata&request=getmetadata&", env=self.env
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))

--- a/tests/AdagucTests/TestOpenDAPServer.py
+++ b/tests/AdagucTests/TestOpenDAPServer.py
@@ -3,127 +3,113 @@
 # pylint: disable=invalid-name
 
 """
-  Run test for OpenDap Server system of adaguc-server
+Run test for OpenDap Server system of adaguc-server
 """
 
 import os
 import unittest
 from adaguc.AdagucTestTools import AdagucTestTools
 
-ADAGUC_PATH = os.environ['ADAGUC_PATH']
+ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 
 class TestOpenDAPServer(unittest.TestCase):
-  """
-  Run test for OpenDap Server system of adaguc-server
-  """
-  testresultspath = "testresults/TestOpenDAP/"
-  expectedoutputsspath = "expectedoutputs/TestOpenDAP/"
-  env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-         "/data/config/adaguc.opendapserver.xml"}
+    """
+    Run test for OpenDap Server system of adaguc-server
+    """
 
-  AdagucTestTools().mkdir_p(testresultspath)
+    testresultspath = "testresults/TestOpenDAP/"
+    expectedoutputsspath = "expectedoutputs/TestOpenDAP/"
+    env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.opendapserver.xml"}
 
-  def test_OpenDAPServer_testdatanc_DDS(self):
-    """
-    Check if Data Description Service works
-    """
-    AdagucTestTools().cleanTempDir()
-    filename = "test_OpenDAPServer_testdatanc_DDS.txt"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        path="opendap/testdata.nc.dds", env=self.env)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue(), AdagucTestTools(
-    ).readfromfile(self.expectedoutputsspath + filename))
+    AdagucTestTools().mkdir_p(testresultspath)
 
-  def test_OpenDAPServer_testdatanc_DDS_headers(self):
-    """
-    Check if OpenDAP headers for DDS are OK
-    """
-    AdagucTestTools().cleanTempDir()
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        path="opendap/testdata.nc.dds", env=self.env)
-    self.assertEqual(status, 0)
+    def test_OpenDAPServer_testdatanc_DDS(self):
+        """
+        Check if Data Description Service works
+        """
+        AdagucTestTools().cleanTempDir()
+        filename = "test_OpenDAPServer_testdatanc_DDS.txt"
+        status, data, headers = AdagucTestTools().runADAGUCServer(path="opendap/testdata.nc.dds", env=self.env)
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
-    #print("\nHEADERS\n" + str(headers) + "\n")
-    self.assertEqual(headers, [
-                     "XDAP: 2.0 ", "Content-Description: dods-dds ", "Content-Type: text/plain; charset=utf-8"])
+    def test_OpenDAPServer_testdatanc_DDS_headers(self):
+        """
+        Check if OpenDAP headers for DDS are OK
+        """
+        AdagucTestTools().cleanTempDir()
+        status, data, headers = AdagucTestTools().runADAGUCServer(path="opendap/testdata.nc.dds", env=self.env)
+        self.assertEqual(status, 0)
 
-  def test_OpenDAPServer_testdatanc_DAS(self):
-    """
-    Check if OpenDAP DAS Data Attribute Service has correct response
-    """
-    AdagucTestTools().cleanTempDir()
-    filename = "test_OpenDAPServer_testdatanc_DAS.txt"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        path="opendap/testdata.nc.das", env=self.env)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue(), AdagucTestTools(
-    ).readfromfile(self.expectedoutputsspath + filename))
+        # print("\nHEADERS\n" + str(headers) + "\n")
+        self.assertEqual(headers, ["XDAP: 2.0 ", "Content-Description: dods-dds ", "Content-Type: text/plain; charset=utf-8"])
 
-  def test_OpenDAPServer_testdatanc_DODS(self):
-    """
-    Check if OpenDAP DODS Data Service has correct response
-    """
-    AdagucTestTools().cleanTempDir()
-    filename = "test_OpenDAPServer_testdatanc_DODS.txt"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        path="opendap/testdata.nc.dods", env=self.env)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue(), AdagucTestTools(
-    ).readfromfile(self.expectedoutputsspath + filename))
+    def test_OpenDAPServer_testdatanc_DAS(self):
+        """
+        Check if OpenDAP DAS Data Attribute Service has correct response
+        """
+        AdagucTestTools().cleanTempDir()
+        filename = "test_OpenDAPServer_testdatanc_DAS.txt"
+        status, data, headers = AdagucTestTools().runADAGUCServer(path="opendap/testdata.nc.das", env=self.env)
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
-  def test_OpenDAPServer_testdatanc_DODS_Query_testdatayxtimeprojection(self):
-    """
-    Check if OpenDAP DODS Data Service has correct response when querying
-    """
-    AdagucTestTools().cleanTempDir()
-    filename = "test_OpenDAPServer_testdatanc_DODS_Query_testdatayxtimeprojection.txt"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        path="opendap/testdata.nc.dods", url="testdata,y,x,time,projection", env=self.env)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue(), AdagucTestTools(
-    ).readfromfile(self.expectedoutputsspath + filename))
+    def test_OpenDAPServer_testdatanc_DODS(self):
+        """
+        Check if OpenDAP DODS Data Service has correct response
+        """
+        AdagucTestTools().cleanTempDir()
+        filename = "test_OpenDAPServer_testdatanc_DODS.txt"
+        status, data, headers = AdagucTestTools().runADAGUCServer(path="opendap/testdata.nc.dods", env=self.env)
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
-  def test_OpenDAPServer_testdatanc_DODS_Query_testdatay(self):
-    """
-    Check if OpenDAP DODS Data Service has correct response when querying testdatay
-    """
-    AdagucTestTools().cleanTempDir()
-    filename = "test_OpenDAPServer_testdatanc_DODS_Query_testdatay.txt"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        path="opendap/testdata.nc.dods", url="testdata,y", env=self.env)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue(), AdagucTestTools(
-    ).readfromfile(self.expectedoutputsspath + filename))
+    def test_OpenDAPServer_testdatanc_DODS_Query_testdatayxtimeprojection(self):
+        """
+        Check if OpenDAP DODS Data Service has correct response when querying
+        """
+        AdagucTestTools().cleanTempDir()
+        filename = "test_OpenDAPServer_testdatanc_DODS_Query_testdatayxtimeprojection.txt"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            path="opendap/testdata.nc.dods", url="testdata,y,x,time,projection", env=self.env
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
-  def test_OpenDAPServer_testdatanc_DODS_Query_projection(self):
-    """
-    Check if OpenDAP DODS Data Service has correct response when querying projection
-    """
-    AdagucTestTools().cleanTempDir()
-    filename = "test_OpenDAPServer_testdatanc_DODS_Query_projection.txt"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        path="opendap/testdata.nc.dods", url="projection", env=self.env)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue(), AdagucTestTools(
-    ).readfromfile(self.expectedoutputsspath + filename))
+    def test_OpenDAPServer_testdatanc_DODS_Query_testdatay(self):
+        """
+        Check if OpenDAP DODS Data Service has correct response when querying testdatay
+        """
+        AdagucTestTools().cleanTempDir()
+        filename = "test_OpenDAPServer_testdatanc_DODS_Query_testdatay.txt"
+        status, data, headers = AdagucTestTools().runADAGUCServer(path="opendap/testdata.nc.dods", url="testdata,y", env=self.env)
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
-  def test_OpenDAPServer_testdatanc_DODS_Query_testdata_subset(self):
-    """
-    Check if OpenDAP DODS Data Service has correct response when getting a subset of the data
-    """
-    AdagucTestTools().cleanTempDir()
-    filename = "test_OpenDAPServer_testdatanc_DODS_Query_testdata_subset.txt"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        path="opendap/testdata.nc.dods", url="testdata[1:5][8:17]", env=self.env)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue(), AdagucTestTools(
-    ).readfromfile(self.expectedoutputsspath + filename))
+    def test_OpenDAPServer_testdatanc_DODS_Query_projection(self):
+        """
+        Check if OpenDAP DODS Data Service has correct response when querying projection
+        """
+        AdagucTestTools().cleanTempDir()
+        filename = "test_OpenDAPServer_testdatanc_DODS_Query_projection.txt"
+        status, data, headers = AdagucTestTools().runADAGUCServer(path="opendap/testdata.nc.dods", url="projection", env=self.env)
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
+
+    def test_OpenDAPServer_testdatanc_DODS_Query_testdata_subset(self):
+        """
+        Check if OpenDAP DODS Data Service has correct response when getting a subset of the data
+        """
+        AdagucTestTools().cleanTempDir()
+        filename = "test_OpenDAPServer_testdatanc_DODS_Query_testdata_subset.txt"
+        status, data, headers = AdagucTestTools().runADAGUCServer(path="opendap/testdata.nc.dods", url="testdata[1:5][8:17]", env=self.env)
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))

--- a/tests/AdagucTests/TestWCS.py
+++ b/tests/AdagucTests/TestWCS.py
@@ -3,9 +3,8 @@
 # pylint: disable=invalid-name
 
 """
-  Run test for WCS Server system of adaguc-server
+Run test for WCS Server system of adaguc-server
 """
-
 
 import os
 import os.path
@@ -17,568 +16,553 @@ import tempfile
 from adaguc.AdagucTestTools import AdagucTestTools
 import difflib
 
-ADAGUC_PATH = os.environ['ADAGUC_PATH']
+ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 
 class TestWCS(unittest.TestCase):
-  """
-  Run test for WCS Server system of adaguc-server
-  """
-  testresultspath = "testresults/TestWCS/"
-  expectedoutputsspath = "expectedoutputs/TestWCS/"
-  env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-         "/data/config/adaguc.autoresource.xml"}
-
-  AdagucTestTools().mkdir_p(testresultspath)
-
-  def test_WCSGetCapabilities_testdatanc(self):
     """
-    Check if WCS GetCapabilities for testdata.nc file is OK
+    Run test for WCS Server system of adaguc-server
     """
-    AdagucTestTools().cleanTempDir()
-    filename = "test_WCSGetCapabilities_testdatanc.xml"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "source=testdata.nc&SERVICE=WCS&request=getcapabilities", env=self.env)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(
-        self.testresultspath + filename, self.expectedoutputsspath + filename))
 
-  def test_WCSDescribeCoverage_Actuele10mindata(self):
-    """
-    Check if WCS DescribeCoverage for Actuele10mindataKNMIstations_20201220123000.nc file is OK
-    """
-    AdagucTestTools().cleanTempDir()
-    filename = "test_WCSDescribeCoverage_testdatanc.xml"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      "source=test/netcdfpointtimeseries/Actuele10mindataKNMIstations_20201220123000.nc&SERVICE=WCS&request=describecoverage&coverage=ff,dd,ta",
-      env=self.env, maxLogFileSize=16384)  # Silence log flood warning, datafile has lots of variables, each giving log output
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(
-      self.testresultspath + filename, self.expectedoutputsspath + filename))
+    testresultspath = "testresults/TestWCS/"
+    expectedoutputsspath = "expectedoutputs/TestWCS/"
+    env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
 
+    AdagucTestTools().mkdir_p(testresultspath)
 
-  def test_WCSDescribeCoverage_Multidimdata(self):
-    """
-    Check if WCS DescribeCoverage shows information for multidimensional data
-    """
-    AdagucTestTools().cleanTempDir()
-    # This file has the following dimensions: lon,lat,member,height, and time.
-    filename = "test_WCSDescribeCoverage_Multidimdata.xml"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "source=netcdf_5dims/netcdf_5dims_seq2/nc_5D_20170101001500-20170101002500.nc&SERVICE=WCS&request=describecoverage&coverage=data",
-        env=self.env,
-        maxLogFileSize=16384
-    )  # Silence log flood warning, datafile has lots of variables, each giving log output
-    AdagucTestTools().writetofile(self.testresultspath + filename,
-                                  data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(
-        self.testresultspath + filename,
-        self.expectedoutputsspath + filename))
+    def test_WCSGetCapabilities_testdatanc(self):
+        """
+        Check if WCS GetCapabilities for testdata.nc file is OK
+        """
+        AdagucTestTools().cleanTempDir()
+        filename = "test_WCSGetCapabilities_testdatanc.xml"
+        status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WCS&request=getcapabilities", env=self.env)
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
-  def test_WCSDescribeCoverage_Multidimdata_large_daily(self):
-    """
-    Check if WCS DescribeCoverage shows information for multidimensional data, with more than 200 equally spaced timestamps
-    """
-    AdagucTestTools().cleanTempDir()
-    # This file has the following dimensions: lon,lat,member,height, and time.
-    filename = "test_WCSDescribeCoverage_Multidimdata_large_daily.xml"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "source=large_number_timesteps/210_daily_timesteps.nc&SERVICE=WCS&request=describecoverage&coverage=data",
-        env=self.env,
-        maxLogFileSize=16384
-    )  # Silence log flood warning, datafile has lots of variables, each giving log output
-    AdagucTestTools().writetofile(self.testresultspath + filename,
-                                  data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(
-        self.testresultspath + filename,
-        self.expectedoutputsspath + filename))
+    def test_WCSDescribeCoverage_Actuele10mindata(self):
+        """
+        Check if WCS DescribeCoverage for Actuele10mindataKNMIstations_20201220123000.nc file is OK
+        """
+        AdagucTestTools().cleanTempDir()
+        filename = "test_WCSDescribeCoverage_testdatanc.xml"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=test/netcdfpointtimeseries/Actuele10mindataKNMIstations_20201220123000.nc&SERVICE=WCS&request=describecoverage&coverage=ff,dd,ta",
+            env=self.env,
+            maxLogFileSize=16384,
+        )  # Silence log flood warning, datafile has lots of variables, each giving log output
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
-  def test_WCSDescribeCoverage_Multidimdata_large_2day_height(self):
-    """
-    Check if WCS DescribeCoverage shows information for multidimensional data, with more than 200  equally spaced timestamps
-    and one extra dimension (height)
-    """
-    AdagucTestTools().cleanTempDir()
-    # This file has the following dimensions: lon,lat,member,height, and time.
-    filename = "test_WCSDescribeCoverage_Multidimdata_large_2day_height.xml"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "source=large_number_timesteps/210_2day_timesteps_5_heights.nc&SERVICE=WCS&request=describecoverage&coverage=data",
-        env=self.env,
-        maxLogFileSize=16384
-    )  # Silence log flood warning, datafile has lots of variables, each giving log output
-    AdagucTestTools().writetofile(self.testresultspath + filename,
-                                  data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(
-        self.testresultspath + filename,
-        self.expectedoutputsspath + filename))
+    def test_WCSDescribeCoverage_Multidimdata(self):
+        """
+        Check if WCS DescribeCoverage shows information for multidimensional data
+        """
+        AdagucTestTools().cleanTempDir()
+        # This file has the following dimensions: lon,lat,member,height, and time.
+        filename = "test_WCSDescribeCoverage_Multidimdata.xml"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=netcdf_5dims/netcdf_5dims_seq2/nc_5D_20170101001500-20170101002500.nc&SERVICE=WCS&request=describecoverage&coverage=data",
+            env=self.env,
+            maxLogFileSize=16384,
+        )  # Silence log flood warning, datafile has lots of variables, each giving log output
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
-  def test_WCSDescribeCoverage_Multidimdata_99_timesteps(self):
-    """
-    Check if WCS DescribeCoverage shows information for multidimensional data, with 190 equally spaced timestamps
-    """
-    AdagucTestTools().cleanTempDir()
-    # This file has the following dimensions: lon,lat,member,height, and time.
-    filename = "test_WCSDescribeCoverage_Multidimdata_99_timesteps.xml"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "source=large_number_timesteps/99_2day_timesteps.nc&SERVICE=WCS&request=describecoverage&coverage=data",
-        env=self.env,
-        maxLogFileSize=16384
-    )  # Silence log flood warning, datafile has lots of variables, each giving log output
-    AdagucTestTools().writetofile(self.testresultspath + filename,
-                                  data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(
-        self.testresultspath + filename,
-        self.expectedoutputsspath + filename))
+    def test_WCSDescribeCoverage_Multidimdata_large_daily(self):
+        """
+        Check if WCS DescribeCoverage shows information for multidimensional data, with more than 200 equally spaced timestamps
+        """
+        AdagucTestTools().cleanTempDir()
+        # This file has the following dimensions: lon,lat,member,height, and time.
+        filename = "test_WCSDescribeCoverage_Multidimdata_large_daily.xml"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=large_number_timesteps/210_daily_timesteps.nc&SERVICE=WCS&request=describecoverage&coverage=data",
+            env=self.env,
+            maxLogFileSize=16384,
+        )  # Silence log flood warning, datafile has lots of variables, each giving log output
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
-  def test_WCSDescribeCoverage_Multidimdata_large_random(self):
-    """
-    Check if WCS DescribeCoverage shows information for multidimensional data, with more than 200 randomly spaced timestamps
-    """
-    AdagucTestTools().cleanTempDir()
-    # This file has the following dimensions: lon,lat,member,height, and time.
-    filename = "test_WCSDescribeCoverage_Multidimdata_large_random.xml"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "source=large_number_timesteps%2F210_random_timesteps.nc&&service=WCS&REQUEST=DescribeCoverage&COVERAGE=data",
-        env=self.env,
-        maxLogFileSize=16384,
-        showLog=True
-    )  # Silence log flood warning, datafile has lots of variables, each giving log output
-    AdagucTestTools().writetofile(self.testresultspath + filename,
-                                  data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(
-        self.testresultspath + filename,
-        self.expectedoutputsspath + filename))
+    def test_WCSDescribeCoverage_Multidimdata_large_2day_height(self):
+        """
+        Check if WCS DescribeCoverage shows information for multidimensional data, with more than 200  equally spaced timestamps
+        and one extra dimension (height)
+        """
+        AdagucTestTools().cleanTempDir()
+        # This file has the following dimensions: lon,lat,member,height, and time.
+        filename = "test_WCSDescribeCoverage_Multidimdata_large_2day_height.xml"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=large_number_timesteps/210_2day_timesteps_5_heights.nc&SERVICE=WCS&request=describecoverage&coverage=data",
+            env=self.env,
+            maxLogFileSize=16384,
+        )  # Silence log flood warning, datafile has lots of variables, each giving log output
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
-  def test_WCSGetCoverageAAIGRID_testdatanc(self):
-    """
-    Check if WCS GetCoverage for testdata.nc as AAIGRID file is OK
-    """
-    AdagucTestTools().cleanTempDir()
-    filename = "test_WCSGetCoverageAAIGRID_testdatanc.grd"
-    status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=aaigrid&BBOX=-180,-90,180,90&RESX=1&RESY=1",
-                                                              env=self.env, args=["--report"])
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    # Different gdal versions give different spaces in the output.
-    # Compare in a way where any sequence of whitespace characters is equivalent
-    # This means that newlines (which are important?) are not compared
-    test_output = data.getvalue()
-    expected_output = AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
-    test_output = ' '.join(test_output.decode("utf-8").split())
-    expected_output = ' '.join(expected_output.decode("utf-8").split())
-    self.assertEqual(test_output, expected_output)
+    def test_WCSDescribeCoverage_Multidimdata_99_timesteps(self):
+        """
+        Check if WCS DescribeCoverage shows information for multidimensional data, with 190 equally spaced timestamps
+        """
+        AdagucTestTools().cleanTempDir()
+        # This file has the following dimensions: lon,lat,member,height, and time.
+        filename = "test_WCSDescribeCoverage_Multidimdata_99_timesteps.xml"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=large_number_timesteps/99_2day_timesteps.nc&SERVICE=WCS&request=describecoverage&coverage=data",
+            env=self.env,
+            maxLogFileSize=16384,
+        )  # Silence log flood warning, datafile has lots of variables, each giving log output
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
-  def test_WCSGetCoverageNetCDF3_testdatanc(self):
-    """
-    Check if WCS GetCoverage for testdata.nc as NetCDF3 file is OK
-    """
-    AdagucTestTools().cleanTempDir()
-    status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=NetCDF3&BBOX=-180,-90,180,90&RESX=1&RESY=1",
-                                                              env=self.env, args=["--report"])
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue()[0:10],
-                     b'CDF\x02\x00\x00\x00\x00\x00\x00')
+    def test_WCSDescribeCoverage_Multidimdata_large_random(self):
+        """
+        Check if WCS DescribeCoverage shows information for multidimensional data, with more than 200 randomly spaced timestamps
+        """
+        AdagucTestTools().cleanTempDir()
+        # This file has the following dimensions: lon,lat,member,height, and time.
+        filename = "test_WCSDescribeCoverage_Multidimdata_large_random.xml"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=large_number_timesteps%2F210_random_timesteps.nc&&service=WCS&REQUEST=DescribeCoverage&COVERAGE=data",
+            env=self.env,
+            maxLogFileSize=16384,
+            showLog=True,
+        )  # Silence log flood warning, datafile has lots of variables, each giving log output
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
-  def test_WCSGetCoverageNetCDF4_testdatanc(self):
-    """
-    Check if WCS GetCoverage for testdata.nc as NetCDF4 file is OK
-    """
-    AdagucTestTools().cleanTempDir()
-    status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=NetCDF4&BBOX=-180,-90,180,90&RESX=1&RESY=1",
-                                                              env=self.env, args=["--report"])
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue()[0:6], b'\x89HDF\r\n')
+    def test_WCSGetCoverageAAIGRID_testdatanc(self):
+        """
+        Check if WCS GetCoverage for testdata.nc as AAIGRID file is OK
+        """
+        AdagucTestTools().cleanTempDir()
+        filename = "test_WCSGetCoverageAAIGRID_testdatanc.grd"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=aaigrid&BBOX=-180,-90,180,90&RESX=1&RESY=1",
+            env=self.env,
+            args=["--report"],
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        # Different gdal versions give different spaces in the output.
+        # Compare in a way where any sequence of whitespace characters is equivalent
+        # This means that newlines (which are important?) are not compared
+        test_output = data.getvalue()
+        expected_output = AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
+        test_output = " ".join(test_output.decode("utf-8").split())
+        expected_output = " ".join(expected_output.decode("utf-8").split())
+        self.assertEqual(test_output, expected_output)
 
-  def test_WCSGetCoverageGeoTiff_testdatanc(self):
-    """
-    Check if WCS GetCoverage for testdata.nc as TIFF file is OK
-    """
-    AdagucTestTools().cleanTempDir()
-    filename = "test_WCSGetCoverageGeoTiff_testdatanc.tiff"
-    status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=geotiff&BBOX=-180,-90,180,90&RESX=1&RESY=1",
-                                                              env=self.env, args=["--report"])
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue()[0:10],
-                     b'II*\x00\x08\x00\x00\x00\x12\x00')
+    def test_WCSGetCoverageNetCDF3_testdatanc(self):
+        """
+        Check if WCS GetCoverage for testdata.nc as NetCDF3 file is OK
+        """
+        AdagucTestTools().cleanTempDir()
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=NetCDF3&BBOX=-180,-90,180,90&RESX=1&RESY=1",
+            env=self.env,
+            args=["--report"],
+        )
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue()[0:10], b"CDF\x02\x00\x00\x00\x00\x00\x00")
 
-  # TODO: This test (which uses GDAL) produces incorrect results. Made a ticket in backlog.
-  def test_WCSGetCoverageAAIGRID_NATIVE_testdatanc(self):
-    """
-    Check if WCS GetCoverage for testdata.nc as Native grid is OK
-    """
-    AdagucTestTools().cleanTempDir()
-    filename = "test_WCSGetCoverageAAIGRID_NATIVE_testdatanc.grd"
-    status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&FORMAT=aaigrid&",
-                                                              env=self.env, args=["--report"])
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    lines = str(data.getvalue().decode('UTF-8')).splitlines()[0:6]
-    parsed = [re.split(r'\s+', line) for line in lines]
-    aaigrid_header_items = [(p[0], round(float(p[1]), 3)) for p in parsed]
+    def test_WCSGetCoverageNetCDF4_testdatanc(self):
+        """
+        Check if WCS GetCoverage for testdata.nc as NetCDF4 file is OK
+        """
+        AdagucTestTools().cleanTempDir()
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=NetCDF4&BBOX=-180,-90,180,90&RESX=1&RESY=1",
+            env=self.env,
+            args=["--report"],
+        )
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue()[0:6], b"\x89HDF\r\n")
 
-    self.assertEqual([('ncols', 29.0),
-                      ('nrows', 31.0),
-                      ('xllcorner', -1500000.013),
-                      ('yllcorner', -999999.971),
-                      ('dx', 103448.277),
-                      ('dy', 96774.192)],
-                    aaigrid_header_items)
+    def test_WCSGetCoverageGeoTiff_testdatanc(self):
+        """
+        Check if WCS GetCoverage for testdata.nc as TIFF file is OK
+        """
+        AdagucTestTools().cleanTempDir()
+        filename = "test_WCSGetCoverageGeoTiff_testdatanc.tiff"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=geotiff&BBOX=-180,-90,180,90&RESX=1&RESY=1",
+            env=self.env,
+            args=["--report"],
+        )
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue()[0:10], b"II*\x00\x08\x00\x00\x00\x12\x00")
 
-    
+    # TODO: This test (which uses GDAL) produces incorrect results. Made a ticket in backlog.
+    def test_WCSGetCoverageAAIGRID_NATIVE_testdatanc(self):
+        """
+        Check if WCS GetCoverage for testdata.nc as Native grid is OK
+        """
+        AdagucTestTools().cleanTempDir()
+        filename = "test_WCSGetCoverageAAIGRID_NATIVE_testdatanc.grd"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&FORMAT=aaigrid&", env=self.env, args=["--report"]
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        lines = str(data.getvalue().decode("UTF-8")).splitlines()[0:6]
+        parsed = [re.split(r"\s+", line) for line in lines]
+        aaigrid_header_items = [(p[0], round(float(p[1]), 3)) for p in parsed]
 
-  def test_WCSGetCoverageNetCDF4_testdatanc_adaguc_wcs_destgridspec_specifiedgridresxresy(self):
-    """
-    Check if WCS GetCoverage for specified settings returns correct grid spec
-    """
-    AdagucTestTools().cleanTempDir()
-    status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=NetCDF4&BBOX=-180,-90,180,90&RESX=1&RESY=1",
-                                                              env=self.env, args=["--report"])
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue()[0:6], b'\x89HDF\r\n')
+        self.assertEqual(
+            [
+                ("ncols", 29.0),
+                ("nrows", 31.0),
+                ("xllcorner", -1500000.013),
+                ("yllcorner", -999999.971),
+                ("dx", 103448.277),
+                ("dy", 96774.192),
+            ],
+            aaigrid_header_items,
+        )
 
-    ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
+    def test_WCSGetCoverageNetCDF4_testdatanc_adaguc_wcs_destgridspec_specifiedgridresxresy(self):
+        """
+        Check if WCS GetCoverage for specified settings returns correct grid spec
+        """
+        AdagucTestTools().cleanTempDir()
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=NetCDF4&BBOX=-180,-90,180,90&RESX=1&RESY=1",
+            env=self.env,
+            args=["--report"],
+        )
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue()[0:6], b"\x89HDF\r\n")
 
-    expectedgridspec="width=360&height=180&resx=1.000000&resy=1.000000&bbox=-180.000000,-90.000000,180.000000,90.000000&crs=EPSG:4326"
-    foundgridspec = ds.getncattr("adaguc_wcs_destgridspec")
-    self.assertEqual(foundgridspec, expectedgridspec)
-    projectionid = ds.variables["crs"].getncattr("id")
-    self.assertEqual("EPSG:4326", projectionid)
+        ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
 
-  def test_WCSGetCoverageNetCDF4_testdatanc_adaguc_wcs_destgridspec_specifiedgridwidthheight(self):
-    """
-    Check if WCS GetCoverage for specified settings returns correct grid spec
-    """
-    AdagucTestTools().cleanTempDir()
-    status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=NetCDF4&BBOX=-180,-90,180,90&width=360&height=180",
-                                                              env=self.env, args=["--report"])
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue()[0:6], b'\x89HDF\r\n')
+        expectedgridspec = "width=360&height=180&resx=1.000000&resy=1.000000&bbox=-180.000000,-90.000000,180.000000,90.000000&crs=EPSG:4326"
+        foundgridspec = ds.getncattr("adaguc_wcs_destgridspec")
+        self.assertEqual(foundgridspec, expectedgridspec)
+        projectionid = ds.variables["crs"].getncattr("id")
+        self.assertEqual("EPSG:4326", projectionid)
 
-    ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
+    def test_WCSGetCoverageNetCDF4_testdatanc_adaguc_wcs_destgridspec_specifiedgridwidthheight(self):
+        """
+        Check if WCS GetCoverage for specified settings returns correct grid spec
+        """
+        AdagucTestTools().cleanTempDir()
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=NetCDF4&BBOX=-180,-90,180,90&width=360&height=180",
+            env=self.env,
+            args=["--report"],
+        )
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue()[0:6], b"\x89HDF\r\n")
 
-    expectedgridspec="width=360&height=180&resx=1.000000&resy=1.000000&bbox=-180.000000,-90.000000,180.000000,90.000000&crs=EPSG:4326"
-    foundgridspec = ds.getncattr("adaguc_wcs_destgridspec")
-    self.assertEqual(foundgridspec, expectedgridspec)
-    projectionid = ds.variables["crs"].getncattr("id")
-    self.assertEqual("EPSG:4326", projectionid)
+        ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
 
-  def test_WCSGetCoverageNetCDF4_testdatanc_adaguc_wcs_destgridspec_native(self):
-    """
-    Check if WCS GetCoverage for specified settings returns correct grid spec
-    """
-    AdagucTestTools().cleanTempDir()
-    status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&FORMAT=NetCDF4",
-                                                              env=self.env, args=["--report"])
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue()[0:6], b'\x89HDF\r\n')
+        expectedgridspec = "width=360&height=180&resx=1.000000&resy=1.000000&bbox=-180.000000,-90.000000,180.000000,90.000000&crs=EPSG:4326"
+        foundgridspec = ds.getncattr("adaguc_wcs_destgridspec")
+        self.assertEqual(foundgridspec, expectedgridspec)
+        projectionid = ds.variables["crs"].getncattr("id")
+        self.assertEqual("EPSG:4326", projectionid)
 
-    ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
+    def test_WCSGetCoverageNetCDF4_testdatanc_adaguc_wcs_destgridspec_native(self):
+        """
+        Check if WCS GetCoverage for specified settings returns correct grid spec
+        """
+        AdagucTestTools().cleanTempDir()
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&FORMAT=NetCDF4", env=self.env, args=["--report"]
+        )
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue()[0:6], b"\x89HDF\r\n")
 
-    expectedgridspec="width=29&height=31&resx=103448.276786&resy=96774.191667&bbox=-1500000.013393,-999999.970833,1500000.013393,1999999.970833&crs=+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +towgs84=565.417,50.3319,465.552,-0.398957,0.343988,-1.8774,4.0725 +units=m +no_defs"
-    foundgridspec = ds.getncattr("adaguc_wcs_destgridspec")
-    self.assertEqual(foundgridspec, expectedgridspec)
-    projectionid = ds.variables["crs"].getncattr("id")
-    self.assertEqual("unknown", projectionid)
+        ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
 
-  def test_WCSGetCoverageNetCDF4_testdatanc_adaguc_wcs_destgridspec_specifiedgrid_noresxnoresy_fullglobe(self):
-    """
-    Check if WCS GetCoverage for specified settings returns correct grid spec
-    """
-    AdagucTestTools().cleanTempDir()
-    status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=NetCDF4&BBOX=-180,-90,180,90",
-                                                              env=self.env, args=["--report"])
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue()[0:6], b'\x89HDF\r\n')
+        expectedgridspec = "width=29&height=31&resx=103448.276786&resy=96774.191667&bbox=-1500000.013393,-999999.970833,1500000.013393,1999999.970833&crs=+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +towgs84=565.417,50.3319,465.552,-0.398957,0.343988,-1.8774,4.0725 +units=m +no_defs"
+        foundgridspec = ds.getncattr("adaguc_wcs_destgridspec")
+        self.assertEqual(foundgridspec, expectedgridspec)
+        projectionid = ds.variables["crs"].getncattr("id")
+        self.assertEqual("unknown", projectionid)
 
-    ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
+    def test_WCSGetCoverageNetCDF4_testdatanc_adaguc_wcs_destgridspec_specifiedgrid_noresxnoresy_fullglobe(self):
+        """
+        Check if WCS GetCoverage for specified settings returns correct grid spec
+        """
+        AdagucTestTools().cleanTempDir()
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=NetCDF4&BBOX=-180,-90,180,90",
+            env=self.env,
+            args=["--report"],
+        )
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue()[0:6], b"\x89HDF\r\n")
 
-    expectedgridspec="width=174&height=196&resx=2.068966&resy=0.918367&bbox=-180.000000,-90.000000,180.000000,90.000000&crs=EPSG:4326"
-    foundgridspec = ds.getncattr("adaguc_wcs_destgridspec")
-    self.assertEqual(foundgridspec, expectedgridspec)
-    projectionid = ds.variables["crs"].getncattr("id")
-    self.assertEqual("EPSG:4326", projectionid)
+        ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
 
-  def test_WCSGetCoverageNetCDF4_testdatanc_adaguc_wcs_destgridspec_specifiedgrid_noresxnoresy_nl(self):
-    """
-    Check if WCS GetCoverage for specified settings returns correct grid spec
-    """
-    AdagucTestTools().cleanTempDir()
-    status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=NetCDF4&BBOX=-10,40,20,60",
-                                                              env=self.env, args=["--report"])
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue()[0:6], b'\x89HDF\r\n')
-    ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
+        expectedgridspec = "width=174&height=196&resx=2.068966&resy=0.918367&bbox=-180.000000,-90.000000,180.000000,90.000000&crs=EPSG:4326"
+        foundgridspec = ds.getncattr("adaguc_wcs_destgridspec")
+        self.assertEqual(foundgridspec, expectedgridspec)
+        projectionid = ds.variables["crs"].getncattr("id")
+        self.assertEqual("EPSG:4326", projectionid)
 
-    expectedgridspec="width=15&height=22&resx=2.000000&resy=0.909091&bbox=-10.000000,40.000000,20.000000,60.000000&crs=EPSG:4326"
-    foundgridspec = ds.getncattr("adaguc_wcs_destgridspec")
-    self.assertEqual(foundgridspec, expectedgridspec)
-    projectionid = ds.variables["crs"].getncattr("id")
-    self.assertEqual("EPSG:4326", projectionid)
+    def test_WCSGetCoverageNetCDF4_testdatanc_adaguc_wcs_destgridspec_specifiedgrid_noresxnoresy_nl(self):
+        """
+        Check if WCS GetCoverage for specified settings returns correct grid spec
+        """
+        AdagucTestTools().cleanTempDir()
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=NetCDF4&BBOX=-10,40,20,60",
+            env=self.env,
+            args=["--report"],
+        )
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue()[0:6], b"\x89HDF\r\n")
+        ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
 
+        expectedgridspec = "width=15&height=22&resx=2.000000&resy=0.909091&bbox=-10.000000,40.000000,20.000000,60.000000&crs=EPSG:4326"
+        foundgridspec = ds.getncattr("adaguc_wcs_destgridspec")
+        self.assertEqual(foundgridspec, expectedgridspec)
+        projectionid = ds.variables["crs"].getncattr("id")
+        self.assertEqual("EPSG:4326", projectionid)
 
-  def test_WCSGetCoverageNetCDF4_testdatanc_adaguc_wcs_destgridspec_specifiedgridwidthheight_responsecrs(self):
-    """
-    Check if WCS GetCoverage for specified settings returns correct grid spec
-    """
-    AdagucTestTools().cleanTempDir()
-    status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=NetCDF4&BBOX=0,50,10,60&width=100&height=100&RESPONSE_CRS=EPSG:28992&",
-                                                              env=self.env, args=["--report"])
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue()[0:6], b'\x89HDF\r\n')
+    def test_WCSGetCoverageNetCDF4_testdatanc_adaguc_wcs_destgridspec_specifiedgridwidthheight_responsecrs(self):
+        """
+        Check if WCS GetCoverage for specified settings returns correct grid spec
+        """
+        AdagucTestTools().cleanTempDir()
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=NetCDF4&BBOX=0,50,10,60&width=100&height=100&RESPONSE_CRS=EPSG:28992&",
+            env=self.env,
+            args=["--report"],
+        )
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue()[0:6], b"\x89HDF\r\n")
 
-    ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
+        ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
 
-    expectedgridspec="width=100&height=100&resx=7167.687040&resy=11262.730534&bbox=-231108.757898,223282.967525,485659.946091,1349556.020954&crs=EPSG:28992"
-    foundgridspec = ds.getncattr("adaguc_wcs_destgridspec")
-    self.assertEqual(foundgridspec, expectedgridspec)
-    projectionid = ds.variables["crs"].getncattr("id")
-    self.assertEqual("EPSG:28992", projectionid)
+        expectedgridspec = "width=100&height=100&resx=7167.687040&resy=11262.730534&bbox=-231108.757898,223282.967525,485659.946091,1349556.020954&crs=EPSG:28992"
+        foundgridspec = ds.getncattr("adaguc_wcs_destgridspec")
+        self.assertEqual(foundgridspec, expectedgridspec)
+        projectionid = ds.variables["crs"].getncattr("id")
+        self.assertEqual("EPSG:28992", projectionid)
 
+    def test_WCS_WithCaching(self):
+        AdagucTestTools().cleanTempDir()
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.cacheheader.xml"
 
-  def test_WCS_WithCaching(self):
-    AdagucTestTools().cleanTempDir()
-    config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.cacheheader.xml"
-    )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
+        self.assertEqual(status, 0)
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      args=["--updatedb", "--config", config], env=self.env, isCGI=False
-    )
-    self.assertEqual(status, 0)
+        status, data, headers = AdagucTestTools().runADAGUCServer("SERVICE=WCS&request=GetCapabilities", {"ADAGUC_CONFIG": config})
+        self.assertEqual(status, 0)
+        self.assertEqual(headers, ["Content-Type:text/xml", "Cache-Control:max-age=60"])
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      "SERVICE=WCS&request=GetCapabilities", {"ADAGUC_CONFIG": config}
-    )
-    self.assertEqual(status, 0)
-    self.assertEqual(headers, ["Content-Type:text/xml", "Cache-Control:max-age=60"])
+        status, data, headers = AdagucTestTools().runADAGUCServer("SERVICE=WCS&request=DescribeCoverage", {"ADAGUC_CONFIG": config})
+        self.assertEqual(status, 0)
+        self.assertEqual(headers, ["Content-Type:text/xml", "Cache-Control:max-age=60"])
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      "SERVICE=WCS&request=DescribeCoverage", {"ADAGUC_CONFIG": config}
-    )
-    self.assertEqual(status, 0)
-    self.assertEqual(headers, ["Content-Type:text/xml", "Cache-Control:max-age=60"])
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "SERVICE=WCS&request=DescribeCoverage&coverage=data", {"ADAGUC_CONFIG": config}
+        )
+        # print(data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(headers, ["Content-Type:text/xml", "Cache-Control:max-age=60"])
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      "SERVICE=WCS&request=DescribeCoverage&coverage=data", {"ADAGUC_CONFIG": config}
-    )
-    # print(data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertEqual(headers, ["Content-Type:text/xml", "Cache-Control:max-age=60"])
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "SERVICE=WCS&request=GetCoverage&coverage=data&crs=EPSG%3A4326&format=NetCDF4&bbox=0,50,10,60&width=100&height=100",
+            {"ADAGUC_CONFIG": config},
+        )
+        self.assertEqual(status, 0)
+        self.assertTrue("Content-Type:application/netcdf" in headers)
+        self.assertTrue("Cache-Control:max-age=60" in headers)
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      "SERVICE=WCS&request=GetCoverage&coverage=data&crs=EPSG%3A4326&format=NetCDF4&bbox=0,50,10,60&width=100&height=100",
-      {"ADAGUC_CONFIG": config}
-    )
-    self.assertEqual(status, 0)
-    self.assertTrue("Content-Type:application/netcdf" in headers)
-    self.assertTrue("Cache-Control:max-age=60" in headers)
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "SERVICE=WCS&request=GetCoverage&coverage=data&crs=EPSG%3A4326&format=NetCDF4&bbox=0,50,10,60&width=100&height=100&time=2017-01-01T00:05:00Z&DIM_member=member3&elevation=5000",
+            {"ADAGUC_CONFIG": config},
+        )
+        self.assertEqual(status, 0)
+        self.assertTrue("Content-Type:application/netcdf" in headers)
+        self.assertTrue("Cache-Control:max-age=7200" in headers)
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      "SERVICE=WCS&request=GetCoverage&coverage=data&crs=EPSG%3A4326&format=NetCDF4&bbox=0,50,10,60&width=100&height=100&time=2017-01-01T00:05:00Z&DIM_member=member3&elevation=5000",
-      {"ADAGUC_CONFIG": config},
-    )
-    self.assertEqual(status, 0)
-    self.assertTrue("Content-Type:application/netcdf" in headers)
-    self.assertTrue("Cache-Control:max-age=7200" in headers)
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "SERVICE=WCS&request=GetCoverage&coverage=data&crs=EPSG%3A4326&format=NetCDF4&bbox=0,50,10,60&width=100&height=100&time=2017-01-01T00:05:00Z&DIM_member=member3",
+            {"ADAGUC_CONFIG": config},
+        )
+        self.assertEqual(status, 0)
+        self.assertTrue("Content-Type:application/netcdf" in headers)
+        self.assertTrue("Cache-Control:max-age=60" in headers)
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      "SERVICE=WCS&request=GetCoverage&coverage=data&crs=EPSG%3A4326&format=NetCDF4&bbox=0,50,10,60&width=100&height=100&time=2017-01-01T00:05:00Z&DIM_member=member3",
-      {"ADAGUC_CONFIG": config},
-    )
-    self.assertEqual(status, 0)
-    self.assertTrue("Content-Type:application/netcdf" in headers)
-    self.assertTrue("Cache-Control:max-age=60" in headers)
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "SERVICE=WCS&request=GetCoverage&coverage=data&crs=EPSG%3A4326&format=NetCDF4&bbox=0,50,10,60&width=100&height=100&time=2017-01-01T00:05:00Z&elevation=5000",
+            {"ADAGUC_CONFIG": config},
+        )
+        self.assertEqual(status, 0)
+        self.assertTrue("Content-Type:application/netcdf" in headers)
+        self.assertTrue("Cache-Control:max-age=60" in headers)
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      "SERVICE=WCS&request=GetCoverage&coverage=data&crs=EPSG%3A4326&format=NetCDF4&bbox=0,50,10,60&width=100&height=100&time=2017-01-01T00:05:00Z&elevation=5000",
-      {"ADAGUC_CONFIG": config},
-    )
-    self.assertEqual(status, 0)
-    self.assertTrue("Content-Type:application/netcdf" in headers)
-    self.assertTrue("Cache-Control:max-age=60" in headers)
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "SERVICE=WCS&request=GetCoverage&coverage=data&crs=EPSG%3A4326&format=NetCDF4&bbox=0,50,10,60&width=100&height=100&elevation=5000",
+            {"ADAGUC_CONFIG": config},
+        )
+        self.assertEqual(status, 0)
+        self.assertTrue("Content-Type:application/netcdf" in headers)
+        self.assertTrue("Cache-Control:max-age=60" in headers)
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      "SERVICE=WCS&request=GetCoverage&coverage=data&crs=EPSG%3A4326&format=NetCDF4&bbox=0,50,10,60&width=100&height=100&elevation=5000",
-      {"ADAGUC_CONFIG": config},
-    )
-    self.assertEqual(status, 0)
-    self.assertTrue("Content-Type:application/netcdf" in headers)
-    self.assertTrue("Cache-Control:max-age=60" in headers)
+        with tempfile.NamedTemporaryFile() as tmp:
+            tmp.write(data.getvalue())
+            dataset = Dataset(tmp.name, mode="r")
+            self.assertEqual(dataset.variables["member"][0], "member6")  # Largest value (default)
+            self.assertEqual(dataset.variables["height"][0], 5000)
 
-    with tempfile.NamedTemporaryFile() as tmp:
-      tmp.write(data.getvalue())
-      dataset = Dataset(tmp.name, mode='r')
-      self.assertEqual(dataset.variables["member"][0], "member6")  # Largest value (default)
-      self.assertEqual(dataset.variables["height"][0], 5000)
+        # Make sure the correct value ends up in the NetCDF when a dimension is fixed
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "SERVICE=WCS&request=GetCoverage&coverage=data_with_fixed&crs=EPSG%3A4326&format=NetCDF4&bbox=0,50,10,60&width=100&height=100&time=2017-01-01T00:05:00Z&elevation=2000",
+            {"ADAGUC_CONFIG": config},
+        )
+        self.assertEqual(status, 0)
+        self.assertTrue("Content-Type:application/netcdf" in headers)
+        self.assertTrue("Cache-Control:max-age=7200" in headers)  # Fully specified with the fixed dimension and the query
 
+        with tempfile.NamedTemporaryFile() as tmp:
+            tmp.write(data.getvalue())
+            dataset = Dataset(tmp.name, mode="r")
+            self.assertEqual(dataset.variables["member"][0], "member4")  # Fixed dimension
+            self.assertEqual(dataset.variables["height"][0], 2000)
 
-    # Make sure the correct value ends up in the NetCDF when a dimension is fixed
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      "SERVICE=WCS&request=GetCoverage&coverage=data_with_fixed&crs=EPSG%3A4326&format=NetCDF4&bbox=0,50,10,60&width=100&height=100&time=2017-01-01T00:05:00Z&elevation=2000",
-      {"ADAGUC_CONFIG": config},
-    )
-    self.assertEqual(status, 0)
-    self.assertTrue("Content-Type:application/netcdf" in headers)
-    self.assertTrue("Cache-Control:max-age=7200" in headers)  # Fully specified with the fixed dimension and the query
+        # Test AAIgrid response format
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "SERVICE=WCS&request=GetCoverage&coverage=data&crs=EPSG%3A4326&format=aaigrid&bbox=0,50,10,60&width=100&height=100",
+            {"ADAGUC_CONFIG": config},
+        )
+        self.assertEqual(status, 0)
+        self.assertTrue("Content-Type:text/plain" in headers)
+        self.assertTrue("Cache-Control:max-age=60" in headers)
 
-    with tempfile.NamedTemporaryFile() as tmp:
-      tmp.write(data.getvalue())
-      dataset = Dataset(tmp.name, mode='r')
-      self.assertEqual(dataset.variables["member"][0], "member4")  # Fixed dimension
-      self.assertEqual(dataset.variables["height"][0], 2000)
+        # Test AAIgrid response format
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "SERVICE=WCS&request=GetCoverage&coverage=data&crs=EPSG%3A4326&format=aaigrid&bbox=0,50,10,60&width=100&height=100&time=2017-01-01T00:05:00Z&DIM_member=member3&elevation=5000",
+            {"ADAGUC_CONFIG": config},
+        )
+        self.assertEqual(status, 0)
+        self.assertTrue("Content-Type:text/plain" in headers)
+        self.assertTrue("Cache-Control:max-age=7200" in headers)
 
+    def test_WCSGetCoverage_error_on_wrong_coverage(self):
+        """
+        Check if WCS GetCoverage for specified settings returns corresponding error when wrong coverage is provided
+        """
+        AdagucTestTools().cleanTempDir()
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=nonexisting&CRS=EPSG%3A4326&FORMAT=NetCDF4&BBOX=-10,40,20,60",
+            env=self.env,
+            args=["--report"],
+        )
 
-    # Test AAIgrid response format
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      "SERVICE=WCS&request=GetCoverage&coverage=data&crs=EPSG%3A4326&format=aaigrid&bbox=0,50,10,60&width=100&height=100",
-      {"ADAGUC_CONFIG": config}
-    )
-    self.assertEqual(status, 0)
-    self.assertTrue("Content-Type:text/plain" in headers)
-    self.assertTrue("Cache-Control:max-age=60" in headers)
+        # Should return 404 Not Found
+        self.assertEqual(status, 404)
 
-    # Test AAIgrid response format
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      "SERVICE=WCS&request=GetCoverage&coverage=data&crs=EPSG%3A4326&format=aaigrid&bbox=0,50,10,60&width=100&height=100&time=2017-01-01T00:05:00Z&DIM_member=member3&elevation=5000",
-      {"ADAGUC_CONFIG": config}
-    )
-    self.assertEqual(status, 0)
-    self.assertTrue("Content-Type:text/plain" in headers)
-    self.assertTrue("Cache-Control:max-age=7200" in headers)
+    def test_WCSGetCoverage_error_on_wrong_time(self):
+        AdagucTestTools().cleanTempDir()
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.cacheheader.xml"
 
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
+        self.assertEqual(status, 0)
 
-  def test_WCSGetCoverage_error_on_wrong_coverage(self):
-    """
-    Check if WCS GetCoverage for specified settings returns corresponding error when wrong coverage is provided
-    """
-    AdagucTestTools().cleanTempDir()
-    status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WCS&REQUEST=GetCoverage&COVERAGE=nonexisting&CRS=EPSG%3A4326&FORMAT=NetCDF4&BBOX=-10,40,20,60",
-                                                              env=self.env, args=["--report"])
-    
-    # Should return 404 Not Found
-    self.assertEqual(status, 404)
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "SERVICE=WCS&request=GetCoverage&coverage=data_with_fixed&crs=EPSG%3A4326&format=NetCDF4&bbox=0,50,10,60&width=100&height=100&time=2022-sdfsd-22T00:00:00Z/2022-07-23T00:00:00Z&elevation=2000",
+            {"ADAGUC_CONFIG": config},
+        )
+        self.assertEqual(status, 404)
 
+    def test_WCSGetCoverage_no_error_on_correct_time(self):
+        AdagucTestTools().cleanTempDir()
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.cacheheader.xml"
 
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
+        self.assertEqual(status, 0)
 
-  def test_WCSGetCoverage_error_on_wrong_time(self):
-    AdagucTestTools().cleanTempDir()
-    config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.cacheheader.xml"
-    )
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "SERVICE=WCS&request=GetCoverage&coverage=data_with_fixed&crs=EPSG%3A4326&format=NetCDF4&bbox=0,50,10,60&width=100&height=100&time=2017-01-01T00:00:00Z/2017-01-01T00:00:00Z&elevation=2000",
+            {"ADAGUC_CONFIG": config},
+        )
+        self.assertEqual(status, 0)
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      args=["--updatedb", "--config", config], env=self.env, isCGI=False
-    )
-    self.assertEqual(status, 0)
+    def test_WCSGetCoverage_error_on_wrong_service(self):
+        """
+        Check if WCS GetCoverage returns an error status code when Service is wrong
+        """
+        AdagucTestTools().cleanTempDir()
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=testdata.nc&SERVICE=WCCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=geotiff&BBOX=-180,-90,180,90&RESX=1&RESY=1",
+            env=self.env,
+            args=["--report"],
+        )
+        self.assertEqual(status, 422)
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      "SERVICE=WCS&request=GetCoverage&coverage=data_with_fixed&crs=EPSG%3A4326&format=NetCDF4&bbox=0,50,10,60&width=100&height=100&time=2022-sdfsd-22T00:00:00Z/2022-07-23T00:00:00Z&elevation=2000",
-      {"ADAGUC_CONFIG": config},
-    )
-    self.assertEqual(status, 404)
-    
-  def test_WCSGetCoverage_no_error_on_correct_time(self):
-    AdagucTestTools().cleanTempDir()
-    config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.cacheheader.xml"
-    )
-
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      args=["--updatedb", "--config", config], env=self.env, isCGI=False
-    )
-    self.assertEqual(status, 0)
-
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      "SERVICE=WCS&request=GetCoverage&coverage=data_with_fixed&crs=EPSG%3A4326&format=NetCDF4&bbox=0,50,10,60&width=100&height=100&time=2017-01-01T00:00:00Z/2017-01-01T00:00:00Z&elevation=2000",
-      {"ADAGUC_CONFIG": config},
-    )
-    self.assertEqual(status, 0)    
-
-
-  def test_WCSGetCoverage_error_on_wrong_service(self):
-    """
-    Check if WCS GetCoverage returns an error status code when Service is wrong
-    """
-    AdagucTestTools().cleanTempDir()
-    status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WCCS&REQUEST=GetCoverage&COVERAGE=testdata&CRS=EPSG%3A4326&FORMAT=geotiff&BBOX=-180,-90,180,90&RESX=1&RESY=1",
-                                                              env=self.env, args=["--report"])
-    self.assertEqual(status, 422)
-    
-
-  def test_WCSGetCoverage_error_on_wrong_request(self):
-    """
+    def test_WCSGetCoverage_error_on_wrong_request(self):
+        """
         Check if WCS GetCoverage returns an error status code when Request is wrong
-    """
-    AdagucTestTools().cleanTempDir()
-    status, data, headers = AdagucTestTools().runADAGUCServer("source=test/netcdfpointtimeseries/Actuele10mindataKNMIstations_20201220123000.nc&SERVICE=WCS&request=nonexisting&coverage=ff,dd,ta",
-                                                              env=self.env, args=["--report"])
-    self.assertEqual(status, 422)
-    
-    
-  def test_WCSGetCoverageNetCDF4_testdatanc_native_subset(self):
-    """
-    Check if WCS GetCoverage for specified settings returns correct grid spec
-    """
-    AdagucTestTools().cleanTempDir()
-    status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&service=wcs&version=1.1.1&request=getcoverage&format=NetCDF4&crs=EPSG:4326&coverage=testdata&bbox=5.5,52.5,6.5,53.5&time=2024-06-01T01:00:00Z&dim_reference_time=2024-06-01T00:00:00Z&DIM_height=40",
-                                                              env=self.env, args=["--report"])
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue()[0:6], b'\x89HDF\r\n')
+        """
+        AdagucTestTools().cleanTempDir()
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=test/netcdfpointtimeseries/Actuele10mindataKNMIstations_20201220123000.nc&SERVICE=WCS&request=nonexisting&coverage=ff,dd,ta",
+            env=self.env,
+            args=["--report"],
+        )
+        self.assertEqual(status, 422)
 
-    ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
+    def test_WCSGetCoverageNetCDF4_testdatanc_native_subset(self):
+        """
+        Check if WCS GetCoverage for specified settings returns correct grid spec
+        """
+        AdagucTestTools().cleanTempDir()
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "source=testdata.nc&service=wcs&version=1.1.1&request=getcoverage&format=NetCDF4&crs=EPSG:4326&coverage=testdata&bbox=5.5,52.5,6.5,53.5&time=2024-06-01T01:00:00Z&dim_reference_time=2024-06-01T00:00:00Z&DIM_height=40",
+            env=self.env,
+            args=["--report"],
+        )
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue()[0:6], b"\x89HDF\r\n")
 
-    expectedgridspec="width=0&height=1&resx=inf&resy=1.000000&bbox=5.500000,52.500000,6.500000,53.500000&crs=EPSG:4326"
-    foundgridspec = ds.getncattr("adaguc_wcs_destgridspec")
-    self.assertEqual(foundgridspec, expectedgridspec)
-    projectionid = ds.variables["crs"].getncattr("id")
-    self.assertEqual("EPSG:4326", projectionid)
-    
-    
-  def test_WCSGetCoverageNetCDF4_dataset_testcollection_native_subset(self):
-    """
-    Check if WCS GetCoverage for specified settings returns correct grid spec
-    """
-    AdagucTestTools().cleanTempDir()
+        ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-      args=["--updatedb", "--config", ADAGUC_PATH+ "/data/config/adaguc.tests.dataset.xml,testcollection"], env=self.env, isCGI=False
-    )
-    self.assertEqual(status, 0)
+        expectedgridspec = "width=0&height=1&resx=inf&resy=1.000000&bbox=5.500000,52.500000,6.500000,53.500000&crs=EPSG:4326"
+        foundgridspec = ds.getncattr("adaguc_wcs_destgridspec")
+        self.assertEqual(foundgridspec, expectedgridspec)
+        projectionid = ds.variables["crs"].getncattr("id")
+        self.assertEqual("EPSG:4326", projectionid)
 
-    env = {
-        "ADAGUC_CONFIG": ADAGUC_PATH
-        + "/data/config/adaguc.tests.dataset.xml,testcollection"
+    def test_WCSGetCoverageNetCDF4_dataset_testcollection_native_subset(self):
+        """
+        Check if WCS GetCoverage for specified settings returns correct grid spec
+        """
+        AdagucTestTools().cleanTempDir()
 
-    }
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,testcollection"], env=self.env, isCGI=False
+        )
+        self.assertEqual(status, 0)
 
-    status, data, headers = AdagucTestTools().runADAGUCServer("dataset=testcollection&service=wcs&version=1.1.1&request=getcoverage&format=NetCDF4&crs=EPSG:4326&coverage=testdata&bbox=5.5,52.5,6.5,53.5&time=2024-06-01T01:00:00Z&dim_reference_time=2024-06-01T00:00:00Z&DIM_height=40",
-                                                              env={"ADAGUC_CONFIG": ADAGUC_PATH  + "/data/config/adaguc.tests.dataset.xml,testcollection" }, args=["--report"])
-    self.assertEqual(status, 0)
-    
-    self.assertEqual(data.getvalue()[0:6], b'\x89HDF\r\n')
+        env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,testcollection"}
 
-    ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "dataset=testcollection&service=wcs&version=1.1.1&request=getcoverage&format=NetCDF4&crs=EPSG:4326&coverage=testdata&bbox=5.5,52.5,6.5,53.5&time=2024-06-01T01:00:00Z&dim_reference_time=2024-06-01T00:00:00Z&DIM_height=40",
+            env={"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,testcollection"},
+            args=["--report"],
+        )
+        self.assertEqual(status, 0)
 
-    expectedgridspec="width=1&height=1&resx=1.000000&resy=1.000000&bbox=5.500000,52.500000,6.500000,53.500000&crs=EPSG:4326"
-    foundgridspec = ds.getncattr("adaguc_wcs_destgridspec")
-    self.assertEqual(foundgridspec, expectedgridspec)
-    projectionid = ds.variables["crs"].getncattr("id")
-    self.assertEqual("EPSG:4326", projectionid)
-        
-    
+        self.assertEqual(data.getvalue()[0:6], b"\x89HDF\r\n")
+
+        ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
+
+        expectedgridspec = "width=1&height=1&resx=1.000000&resy=1.000000&bbox=5.500000,52.500000,6.500000,53.500000&crs=EPSG:4326"
+        foundgridspec = ds.getncattr("adaguc_wcs_destgridspec")
+        self.assertEqual(foundgridspec, expectedgridspec)
+        projectionid = ds.variables["crs"].getncattr("id")
+        self.assertEqual("EPSG:4326", projectionid)

--- a/tests/AdagucTests/TestWMS.py
+++ b/tests/AdagucTests/TestWMS.py
@@ -2,6 +2,7 @@
 """
 This class contains tests to test the adaguc-server binary executable file. This is similar to black box testing, it tests the behaviour of the server software. It configures the server and checks if the response is OK.
 """
+
 import os
 import os.path
 import unittest
@@ -30,16 +31,10 @@ class TestWMS(unittest.TestCase):
         AdagucTestTools().cleanTempDir()
         filename = "test_WMSGetCapabilities_testdatanc.xml"
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            "source=testdata.nc&SERVICE=WMS&request=getcapabilities", env=self.env
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WMS&request=getcapabilities", env=self.env)
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_WMSGetMap_testdatanc(self):
         AdagucTestTools().cleanTempDir()
@@ -176,20 +171,12 @@ class TestWMS(unittest.TestCase):
 
     def test_WMSGetCapabilitiesGetMap_testdatanc(self):
         AdagucTestTools().cleanTempDir()
-        filename = (
-            "test_WMSGetCapabilitiesGetMap_testdatanc_WMSGetCapabilities_testdatanc.xml"
-        )
+        filename = "test_WMSGetCapabilitiesGetMap_testdatanc_WMSGetCapabilities_testdatanc.xml"
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            "source=testdata.nc&SERVICE=WMS&request=getcapabilities", env=self.env
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WMS&request=getcapabilities", env=self.env)
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
         filename = "test_WMSGetCapabilitiesGetMap_testdatanc.png"
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "source=testdata.nc&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=testdata&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=30,-30,75,30&STYLES=testdata%2Fnearest&FORMAT=image/png&TRANSPARENT=FALSE&",
@@ -216,19 +203,11 @@ class TestWMS(unittest.TestCase):
             data.getvalue(),
             AdagucTestTools().readfromfile(self.expectedoutputsspath + filename),
         )
-        filename = (
-            "test_WMSGetMapGetCapabilities_testdatanc_WMSGetCapabilities_testdatanc.xml"
-        )
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            "source=testdata.nc&SERVICE=WMS&request=getcapabilities", env=self.env
-        )
+        filename = "test_WMSGetMapGetCapabilities_testdatanc_WMSGetCapabilities_testdatanc.xml"
+        status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WMS&request=getcapabilities", env=self.env)
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_WMSGetMap_getmap_3dims_singlefile(self):
         dims = {
@@ -274,25 +253,17 @@ class TestWMS(unittest.TestCase):
                         kvps += "&" + key + "=" + str(value)
                     # print("Checking dims" + kvps)
                     filename = "test_WMSGetMap_getmap_3dims_" + kvps + ".png"
-                    filename = (
-                        filename.replace("&", "_").replace(":", "_").replace("=", "_")
-                    )
+                    filename = filename.replace("&", "_").replace(":", "_").replace("=", "_")
                     # print filename
                     url = "source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000-20170101001000.nc&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&"
                     url += kvps
                     # pylint: disable=unused-variable
-                    status, data, headers = AdagucTestTools().runADAGUCServer(
-                        url, env=self.env
-                    )
-                    AdagucTestTools().writetofile(
-                        self.testresultspath + filename, data.getvalue()
-                    )
+                    status, data, headers = AdagucTestTools().runADAGUCServer(url, env=self.env)
+                    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
                     self.assertEqual(status, 0)
                     self.assertEqual(
                         data.getvalue(),
-                        AdagucTestTools().readfromfile(
-                            self.expectedoutputsspath + filename
-                        ),
+                        AdagucTestTools().readfromfile(self.expectedoutputsspath + filename),
                     )
 
         l = []
@@ -305,9 +276,7 @@ class TestWMS(unittest.TestCase):
     def test_WMSCMDUpdateDBNoConfig(self):
         AdagucTestTools().cleanTempDir()
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb"], env=self.env, isCGI=False, showLogOnError=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb"], env=self.env, isCGI=False, showLogOnError=False)
         self.assertEqual(status, 1)
 
     def test_WMSCMDUpdateDB(self):
@@ -331,11 +300,7 @@ class TestWMS(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_WMSCMDUpdateDBTailPath(self):
         AdagucTestTools().cleanTempDir()
@@ -361,11 +326,7 @@ class TestWMS(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
         status, data, headers = AdagucTestTools().runADAGUCServer(
             args=[
@@ -387,11 +348,7 @@ class TestWMS(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_WMSCMDUpdateDBPath(self):
         AdagucTestTools().cleanTempDir()
@@ -403,8 +360,7 @@ class TestWMS(unittest.TestCase):
                 "--config",
                 ADAGUC_PATH + "/data/config/adaguc.timeseries.xml",
                 "--path",
-                ADAGUC_PATH
-                + "/data/datasets/netcdf_5dims/netcdf_5dims_seq1/nc_5D_20170101000000-20170101001000.nc",
+                ADAGUC_PATH + "/data/datasets/netcdf_5dims/netcdf_5dims_seq1/nc_5D_20170101000000-20170101001000.nc",
             ],
             isCGI=False,
             showLogOnError=False,
@@ -419,11 +375,7 @@ class TestWMS(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
         status, data, headers = AdagucTestTools().runADAGUCServer(
             args=[
@@ -431,8 +383,7 @@ class TestWMS(unittest.TestCase):
                 "--config",
                 ADAGUC_PATH + "/data/config/adaguc.timeseries.xml",
                 "--path",
-                ADAGUC_PATH
-                + "/data/datasets/netcdf_5dims/netcdf_5dims_seq2/nc_5D_20170101001500-20170101002500.nc",
+                ADAGUC_PATH + "/data/datasets/netcdf_5dims/netcdf_5dims_seq2/nc_5D_20170101001500-20170101002500.nc",
             ],
             isCGI=False,
             showLogOnError=False,
@@ -446,11 +397,7 @@ class TestWMS(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_WMSGetFeatureInfo_forecastreferencetime_texthtml(self):
         AdagucTestTools().cleanTempDir()
@@ -467,16 +414,10 @@ class TestWMS(unittest.TestCase):
             AdagucTestTools().readfromfile(self.expectedoutputsspath + filename),
         )
         filename = "test_WMSGetFeatureInfo_forecastreferencetime_texthtml_TestDataGetCapabilities.xml"
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            "source=testdata.nc&SERVICE=WMS&request=getcapabilities", env=self.env
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WMS&request=getcapabilities", env=self.env)
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_WMSGetMap_Report_nounits(self):
         AdagucTestTools().cleanTempDir()
@@ -600,11 +541,7 @@ class TestWMS(unittest.TestCase):
 
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_WMSGetCapabilities_multidimnc_autostyle(self):
         AdagucTestTools().cleanTempDir()
@@ -617,24 +554,15 @@ class TestWMS(unittest.TestCase):
 
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_WMSGetCapabilities_multidimncdataset_autostyle(self):
         AdagucTestTools().cleanTempDir()
         config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.testmultidimautostyle.xml"
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testmultidimautostyle.xml"
         )
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetCapabilities_multidimncdataset_autostyle.xml"
@@ -645,11 +573,7 @@ class TestWMS(unittest.TestCase):
 
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_WMSGetMapWithShowLegendTrue_testdatanc(self):
         AdagucTestTools().cleanTempDir()
@@ -694,10 +618,7 @@ class TestWMS(unittest.TestCase):
 
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "source=testdata.nc&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=testdata&WIDTH=256&HEIGHT=256&CRS=EPSG%3A4326&BBOX=30,-30,75,30&STYLES=testdata_style_manycontours/contour&FORMAT=image/png&TRANSPARENT=FALSE&",
-            {
-                "ADAGUC_CONFIG": ADAGUC_PATH
-                + "/data/config/adaguc.tests.manycontours.xml"
-            },
+            {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.tests.manycontours.xml"},
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
@@ -784,11 +705,7 @@ class TestWMS(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareImage(
-                self.expectedoutputsspath + filename, self.testresultspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareImage(self.expectedoutputsspath + filename, self.testresultspath + filename))
 
     def test_WMSGetMapWithShowLegendAllLayers_testdatanc(self):
         AdagucTestTools().cleanTempDir()
@@ -865,11 +782,7 @@ class TestWMS(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareImage(
-                self.expectedoutputsspath + filename, self.testresultspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareImage(self.expectedoutputsspath + filename, self.testresultspath + filename))
 
     def test_WMSGetMapCustomCRSEPSG3413Projection_sample_tas_cmip6_ssp585_preIndustrial_warming2_year(
         self,
@@ -893,17 +806,11 @@ class TestWMS(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareImage(
-                self.expectedoutputsspath + filename, self.testresultspath + filename, 8
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareImage(self.expectedoutputsspath + filename, self.testresultspath + filename, 8))
 
     def test_WMSGetMapRobinsonProjection_ipcc_cmip5_tas_historical_subset_nc(self):
         AdagucTestTools().cleanTempDir()
-        filename = (
-            "test_WMSGetMapRobinsonProjection_ipcc_cmip5_tas_historical_subset.nc.png"
-        )
+        filename = "test_WMSGetMapRobinsonProjection_ipcc_cmip5_tas_historical_subset.nc.png"
         # pylint: disable=unused-variable
         status, data, headers = AdagucTestTools().runADAGUCServer(
             args=[
@@ -948,11 +855,7 @@ class TestWMS(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareImage(
-                self.expectedoutputsspath + filename, self.testresultspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareImage(self.expectedoutputsspath + filename, self.testresultspath + filename))
 
     def test_WMSGetMapCustomCRSEPSG3413Projection_ipcc_cmip5_tas_historical_subset_nc(
         self,
@@ -976,11 +879,7 @@ class TestWMS(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareImage(
-                self.expectedoutputsspath + filename, self.testresultspath + filename, 8
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareImage(self.expectedoutputsspath + filename, self.testresultspath + filename, 8))
 
     # def test_WMSGetMapCustomCRSClippedRobinsonProjection_ipcc_cmip5_tas_historical_subset_nc(self):
     #     AdagucTestTools().cleanTempDir()
@@ -1002,16 +901,9 @@ class TestWMS(unittest.TestCase):
             + ADAGUC_PATH
             + "/data/config/datasets/adaguc.KNMIHDF5.test.xml"
         }
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.KNMIHDF5.test.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.KNMIHDF5.test.xml"
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetFeatureInfo_timeseries_KNMIHDF5_json.json"
@@ -1043,17 +935,10 @@ class TestWMS(unittest.TestCase):
 
     def test_WMSGetMap_KNMIHDF5_echotops_RAD_NL25_ETH_NA_GRID(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.KNMIHDF5.test.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.KNMIHDF5.test.xml"
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_KNMIHDF5_echotops_RAD_NL25_ETH_NA_GRID.png"
@@ -1071,17 +956,10 @@ class TestWMS(unittest.TestCase):
     # FIXME: these tests all use style=auto, they fail without <RenderMethod>point</RenderMethod>
     def test_WMSGetMap_KNMIHDF5_echotops_RAD_NL25_ETH_NA_TOPS(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.KNMIHDF5.test.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.KNMIHDF5.test.xml"
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_KNMIHDF5_echotops_RAD_NL25_ETH_NA_TOPS.png"
@@ -1109,9 +987,7 @@ class TestWMS(unittest.TestCase):
         )
 
         # Tops Outline
-        filename = (
-            "test_WMSGetMap_KNMIHDF5_echotops_RAD_NL25_ETH_NA_TOPS_MAX_OUTLINE.png"
-        )
+        filename = "test_WMSGetMap_KNMIHDF5_echotops_RAD_NL25_ETH_NA_TOPS_MAX_OUTLINE.png"
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "dataset=adaguc.KNMIHDF5.test&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=RAD_NL25_ETH_NA_TOPS_MAX&WIDTH=300&HEIGHT=300&CRS=EPSG%3A3857&BBOX=180000,6300000,1000000,7200000&STYLES=echotopsmax_outline&FORMAT=image/png&TRANSPARENT=TRUE&time=2020-04-30T13%3A15%3A00Z&",
             env=env,
@@ -1126,16 +1002,11 @@ class TestWMS(unittest.TestCase):
     def test_WMSGetCapabilities_KMDS_PointNetCDF_pointstylepoint(self):
         AdagucTestTools().cleanTempDir()
         config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.testKMDS_PointNetCDF.xml"
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testKMDS_PointNetCDF.xml"
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetCapabilities_KMDS_PointNetCDF_pointstylepoint.xml"
@@ -1146,25 +1017,16 @@ class TestWMS(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_WMSGetMap_KMDS_PointNetCDF_pointstylepoint(self):
         AdagucTestTools().cleanTempDir()
         config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.testKMDS_PointNetCDF.xml"
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testKMDS_PointNetCDF.xml"
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_KMDS_PointNetCDF_pointstylepoint.png"
@@ -1206,9 +1068,7 @@ class TestWMS(unittest.TestCase):
         )
 
         # Test no outline
-        filename = (
-            "test_WMSGetMap_KMDS_PointNetCDF_ffdd_windspeed_barb_barb_no_outline.png"
-        )
+        filename = "test_WMSGetMap_KMDS_PointNetCDF_ffdd_windspeed_barb_barb_no_outline.png"
 
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "dataset=adaguc.testKMDS_PointNetCDF.xml&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=ff_dd&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX=294179.7001580532,6411290.650918596,901204.9572071509,7199735.637765654&STYLES=windspeed_barb_no_outline%2Fbarb&FORMAT=image/png&TRANSPARENT=FALSE&BGCOLOR=0xFFFFFF&",
@@ -1257,24 +1117,18 @@ class TestWMS(unittest.TestCase):
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "dataset=adaguc.testKMDS_PointNetCDF_filetimedate.xml&SERVICE=WMS&request=getcapabilities",
             env=env,
         )
-        obj1 = objectify.fromstring(
-            re.sub(b' xmlns="[^"]+"', b"", data.getvalue(), count=1)
-        )
+        obj1 = objectify.fromstring(re.sub(b' xmlns="[^"]+"', b"", data.getvalue(), count=1))
         foundTimeFromXML = obj1.findall("Capability/Layer/Layer/Dimension")[0]
 
         fileToCheck = f"{ADAGUC_PATH}/data/datasets/test/netcdfpointtimeseries/Actuele10mindataKNMIstations_20201220123000.nc"
-        foundTimeFromFile = datetime.datetime.utcfromtimestamp(
-            os.path.getmtime(fileToCheck)
-        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        foundTimeFromFile = datetime.datetime.utcfromtimestamp(os.path.getmtime(fileToCheck)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
         self.assertEqual(foundTimeFromXML, foundTimeFromFile)
 
@@ -1293,17 +1147,10 @@ class TestWMS(unittest.TestCase):
 
     def test_WMSGetLegendGraphic_adaguc_scaling_dataset_scaling1x(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.scaling.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.scaling.xml"
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetLegendGraphic_adaguc_scaling_dataset_scaling1x.png"
@@ -1321,22 +1168,13 @@ class TestWMS(unittest.TestCase):
 
     def test_WMSGetMapWithGetLegendGraphic_adaguc_scaling_dataset_scaling1x(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.scaling.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.scaling.xml"
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
-        filename = (
-            "test_WMSGetMapWithGetLegendGraphic_adaguc_scaling_dataset_scaling1x.png"
-        )
+        filename = "test_WMSGetMapWithGetLegendGraphic_adaguc_scaling_dataset_scaling1x.png"
 
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "DATASET=adaguc.tests.scaling&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=testdata&WIDTH=1024&HEIGHT=1024&CRS=EPSG%3A3857&BBOX=-3099408.36963744,3701316.1668297593,3704230.74564144,10633468.46539724&STYLES=testdata%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&showlegend=true",
@@ -1351,22 +1189,13 @@ class TestWMS(unittest.TestCase):
 
     def test_WMSGetMapWithGetLegendGraphic_adaguc_scaling_dataset_scaling4x(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.scaling.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.scaling.xml"
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
-        filename = (
-            "test_WMSGetMapWithGetLegendGraphic_adaguc_scaling_dataset_scaling4x.png"
-        )
+        filename = "test_WMSGetMapWithGetLegendGraphic_adaguc_scaling_dataset_scaling4x.png"
 
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "DATASET=adaguc.tests.scaling&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=testdata&WIDTH=1024&HEIGHT=1024&CRS=EPSG%3A3857&BBOX=-3099408.36963744,3701316.1668297593,3704230.74564144,10633468.46539724&STYLES=testdatascaling4x%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&showlegend=true",
@@ -1383,16 +1212,11 @@ class TestWMS(unittest.TestCase):
         AdagucTestTools().cleanTempDir()
         ADAGUC_PATH = os.environ["ADAGUC_PATH"]
         config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.invertedlegend.xml"
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.invertedlegend.xml"
         )
         env = {"ADAGUC_CONFIG": config}
 
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetLegendGraphic_inverted_min_max.png"
@@ -1411,16 +1235,11 @@ class TestWMS(unittest.TestCase):
         AdagucTestTools().cleanTempDir()
         ADAGUC_PATH = os.environ["ADAGUC_PATH"]
         config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.invertedlegend.xml"
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.invertedlegend.xml"
         )
         env = {"ADAGUC_CONFIG": config}
 
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetLegendGraphic_log10.png"
@@ -1438,17 +1257,10 @@ class TestWMS(unittest.TestCase):
     def test_WMSGetMapQuantizeLow(self):
         AdagucTestTools().cleanTempDir()
         ADAGUC_PATH = os.environ["ADAGUC_PATH"]
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.quantizelow.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.quantizelow.xml"
         env = {"ADAGUC_CONFIG": config}
 
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "testWMSGetCapabilities_quantizelow.xml"
@@ -1457,27 +1269,18 @@ class TestWMS(unittest.TestCase):
             env=env,
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
         self.assertEqual(status, 0)
 
     def test_WMSGetMapQuantizeHigh(self):
         AdagucTestTools().cleanTempDir()
         ADAGUC_PATH = os.environ["ADAGUC_PATH"]
         config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.quantizehigh.xml"
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.quantizehigh.xml"
         )
         env = {"ADAGUC_CONFIG": config}
 
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "testWMSGetCapabilities_quantizehigh.xml"
@@ -1486,27 +1289,18 @@ class TestWMS(unittest.TestCase):
             env=env,
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
         self.assertEqual(status, 0)
 
     def test_WMSGetMapQuantizeRound(self):
         AdagucTestTools().cleanTempDir()
         ADAGUC_PATH = os.environ["ADAGUC_PATH"]
         config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.quantizeround.xml"
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.quantizeround.xml"
         )
         env = {"ADAGUC_CONFIG": config}
 
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "testWMSGetCapabilities_quantizeround.xml"
@@ -1515,26 +1309,15 @@ class TestWMS(unittest.TestCase):
             env=env,
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
         self.assertEqual(status, 0)
 
     def test_WMSGetMap_ODIMHDF5_RAD_CU21_PPZ_E05(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.ODIMHDF5.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.ODIMHDF5.xml"
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_ODIMHDF5_RAD_CU21_PPZ_E05.png"
@@ -1568,9 +1351,7 @@ class TestWMS(unittest.TestCase):
             newDateTime = newDateTime.replace(second=0)
             return newDateTime.replace(microsecond=0)
 
-        recenttimesteptowrite = (
-            roundSeconds(datetime.datetime.utcnow()).isoformat() + "Z"
-        )
+        recenttimesteptowrite = roundSeconds(datetime.datetime.utcnow()).isoformat() + "Z"
 
         # Make the three filenames
         oldfile1 = f"{ADAGUC_TMP}/cleandb/csv-20200601T000000.csv"
@@ -1586,17 +1367,11 @@ class TestWMS(unittest.TestCase):
 
         # Write files to disk ready to scan without cleanup
         with open(oldfile1, "w") as f:
-            f.write(
-                '# time=2020-06-01T00:00:00Z\nlat,lon,Name,test\n48.1,0.25,"Station",60'
-            )
+            f.write('# time=2020-06-01T00:00:00Z\nlat,lon,Name,test\n48.1,0.25,"Station",60')
         with open(oldfile2, "w") as f:
-            f.write(
-                '# time=2020-06-02T00:00:00Z\nlat,lon,Name,test\n48.1,0.25,"Station",60'
-            )
+            f.write('# time=2020-06-02T00:00:00Z\nlat,lon,Name,test\n48.1,0.25,"Station",60')
         with open(newfile1, "w") as f:
-            f.write(
-                f'# time={recenttimesteptowrite}\nlat,lon,Name,test\n48.1,0.25,"Station",60'
-            )
+            f.write(f'# time={recenttimesteptowrite}\nlat,lon,Name,test\n48.1,0.25,"Station",60')
 
         ### Step 1 ###
 
@@ -1623,15 +1398,9 @@ class TestWMS(unittest.TestCase):
             f"DATASET={DATASET}&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities",
             env=env,
         )
-        xslt_root = etree.XML(
-            re.sub(
-                ' xmlns="[^"]+"', "", data.getvalue().decode("UTF-8"), count=1
-            ).encode("ascii")
-        )
+        xslt_root = etree.XML(re.sub(' xmlns="[^"]+"', "", data.getvalue().decode("UTF-8"), count=1).encode("ascii"))
         dimvalues = xslt_root.findall("Capability/Layer/Layer/Dimension")[0].text
-        expecteddimensionvalues = (
-            f"2020-06-01T00:00:00Z,2020-06-02T00:00:00Z,{recenttimesteptowrite}"
-        )
+        expecteddimensionvalues = f"2020-06-01T00:00:00Z,2020-06-02T00:00:00Z,{recenttimesteptowrite}"
         self.assertEqual(expecteddimensionvalues, dimvalues)
 
         ### Step 2 ###
@@ -1659,11 +1428,7 @@ class TestWMS(unittest.TestCase):
             f"DATASET={DATASET}&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities",
             env=env,
         )
-        xslt_root = etree.XML(
-            re.sub(
-                ' xmlns="[^"]+"', "", data.getvalue().decode("UTF-8"), count=1
-            ).encode("ascii")
-        )
+        xslt_root = etree.XML(re.sub(' xmlns="[^"]+"', "", data.getvalue().decode("UTF-8"), count=1).encode("ascii"))
         dimvalues = xslt_root.findall("Capability/Layer/Layer/Dimension")[0].text
         self.assertEqual(recenttimesteptowrite, dimvalues)
 
@@ -1789,9 +1554,7 @@ class TestWMS(unittest.TestCase):
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_NearestRenderWithShadeIntervalFast.png"
@@ -1816,9 +1579,7 @@ class TestWMS(unittest.TestCase):
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_NearestRenderWithShadeIntervalPrecise.png"
@@ -1843,9 +1604,7 @@ class TestWMS(unittest.TestCase):
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetLegendGraphic_NearestRenderWithShadeInterval.png"
@@ -1870,11 +1629,7 @@ class TestWMS(unittest.TestCase):
             f"SOURCE=pngfile_with_time_dim.png&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities",
             env=self.env,
         )
-        xslt_root = etree.XML(
-            re.sub(
-                ' xmlns="[^"]+"', "", data.getvalue().decode("UTF-8"), count=1
-            ).encode("ascii")
-        )
+        xslt_root = etree.XML(re.sub(' xmlns="[^"]+"', "", data.getvalue().decode("UTF-8"), count=1).encode("ascii"))
         dimvalues = xslt_root.findall("Capability/Layer/Layer/Dimension")[0].text
         self.assertEqual("2023-10-27T06:00:00Z", dimvalues)
 
@@ -1887,15 +1642,9 @@ class TestWMS(unittest.TestCase):
             f"SOURCE=pngfile_with_time_and_reftime_dim.png&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities",
             env=self.env,
         )
-        xslt_root = etree.XML(
-            re.sub(
-                ' xmlns="[^"]+"', "", data.getvalue().decode("UTF-8"), count=1
-            ).encode("ascii")
-        )
+        xslt_root = etree.XML(re.sub(' xmlns="[^"]+"', "", data.getvalue().decode("UTF-8"), count=1).encode("ascii"))
         dimvalues = xslt_root.findall("Capability/Layer/Layer/Dimension")[0].text
-        reftime_dimvalues = xslt_root.findall("Capability/Layer/Layer/Dimension")[
-            1
-        ].text
+        reftime_dimvalues = xslt_root.findall("Capability/Layer/Layer/Dimension")[1].text
 
         self.assertEqual("2023-10-28T00:00:00Z", dimvalues)
         self.assertEqual("2023-10-27T12:00:00Z", reftime_dimvalues)
@@ -1958,9 +1707,7 @@ class TestWMS(unittest.TestCase):
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
         filename = "test_WMSGetMap_dashed_contour_lines.png"
         status, data, headers = AdagucTestTools().runADAGUCServer(
@@ -1988,9 +1735,7 @@ class TestWMS(unittest.TestCase):
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
         filename = "test_WMSGetMap_dashed_contour_lines_arial.png"
         status, data, headers = AdagucTestTools().runADAGUCServer(
@@ -2045,9 +1790,7 @@ class TestWMS(unittest.TestCase):
         ]
         print(args)
         env = {"ADAGUC_CONFIG": config}
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=args, env=env, isCGI=False, showLogOnError=True, showLog=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=args, env=env, isCGI=False, showLogOnError=True, showLog=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSCMDUpdateDBPathFileInSubfoldersGetCapabilities.xml"
@@ -2058,11 +1801,7 @@ class TestWMS(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_WMSCMDUpdateDBPathFileWithNonMatchingPath(self):
         """
@@ -2080,14 +1819,11 @@ class TestWMS(unittest.TestCase):
             "--config",
             config,
             "--path",
-            ADAGUC_PATH
-            + "data/datasets/test_suffix/RAD_NL25_PCP_CM_202106222000_suffix.h5",
+            ADAGUC_PATH + "data/datasets/test_suffix/RAD_NL25_PCP_CM_202106222000_suffix.h5",
         ]
         print(args)
         env = {"ADAGUC_CONFIG": config}
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=args, env=env, isCGI=False, showLogOnError=True, showLog=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=args, env=env, isCGI=False, showLogOnError=True, showLog=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSCMDUpdateDBPathFileWithNonMatchingPathGetCapabilities.xml"
@@ -2098,11 +1834,7 @@ class TestWMS(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_WMSGetMapWithHarmWindBarbs(self):
         AdagucTestTools().cleanTempDir()
@@ -2289,9 +2021,7 @@ class TestWMS(unittest.TestCase):
             + "/data/config/datasets/adaguc.tests.311-getcapabilities-dimension-units.xml"
         )
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetCapabilities_DimensionUnits.xml"
@@ -2302,135 +2032,98 @@ class TestWMS(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_WMSGetMap_WithCaching(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.cacheheader.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.cacheheader.xml"
 
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            "SERVICE=WMS&request=getcapabilities", {"ADAGUC_CONFIG": config}
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer("SERVICE=WMS&request=getcapabilities", {"ADAGUC_CONFIG": config})
         self.assertEqual(headers, ["Content-Type:text/xml", "Cache-Control:max-age=60"])
 
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&",
             {"ADAGUC_CONFIG": config},
         )
-        self.assertEqual(
-            headers, ["Content-Type:image/png", "Cache-Control:max-age=60"]
-        )
+        self.assertEqual(headers, ["Content-Type:image/png", "Cache-Control:max-age=60"])
 
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=2017-01-01T00:05:00",
             {"ADAGUC_CONFIG": config},
         )
-        self.assertEqual(
-            headers, ["Content-Type:image/png", "Cache-Control:max-age=60"]
-        )
+        self.assertEqual(headers, ["Content-Type:image/png", "Cache-Control:max-age=60"])
 
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=2017-01-01T00:05:00&DIM_member=member3",
             {"ADAGUC_CONFIG": config},
         )
-        self.assertEqual(
-            headers, ["Content-Type:image/png", "Cache-Control:max-age=60"]
-        )
+        self.assertEqual(headers, ["Content-Type:image/png", "Cache-Control:max-age=60"])
 
         # If some dims are specfied with current, we expect a shorter caching interval.
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=current&DIM_member=member3&elevation=5000",
             {"ADAGUC_CONFIG": config},
         )
-        self.assertEqual(
-            headers, ["Content-Type:image/png", "Cache-Control:max-age=60"]
-        )
+        self.assertEqual(headers, ["Content-Type:image/png", "Cache-Control:max-age=60"])
 
         # If some dims are specfied incorrectly, we expect a shorter caching interval.
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=2017-01-01T00:05:00.000Z&DIM_member=member3&elevation=5000",
             {"ADAGUC_CONFIG": config},
         )
-        self.assertEqual(
-            headers, ["Content-Type:image/png", "Cache-Control:max-age=60"]
-        )
+        self.assertEqual(headers, ["Content-Type:image/png", "Cache-Control:max-age=60"])
 
         # If all dims are specfied, we expect a longer caching interval.
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=2017-01-01T00:05:00Z&DIM_member=member3&elevation=5000",
             {"ADAGUC_CONFIG": config},
         )
-        self.assertEqual(
-            headers, ["Content-Type:image/png", "Cache-Control:max-age=7200"]
-        )
+        self.assertEqual(headers, ["Content-Type:image/png", "Cache-Control:max-age=7200"])
 
         # If all dims are specfied, but time is without zulue, we expect a shorter caching interval.
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=2017-01-01T00:05:00&DIM_member=member3&elevation=5000",
             {"ADAGUC_CONFIG": config},
         )
-        self.assertEqual(
-            headers, ["Content-Type:image/png", "Cache-Control:max-age=60"]
-        )
+        self.assertEqual(headers, ["Content-Type:image/png", "Cache-Control:max-age=60"])
 
         # If all dims are specfied, but time contains millieseconds, we expect a shorter caching interval.
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=2017-01-01T00:05:00.000Z&DIM_member=member3&elevation=5000",
             {"ADAGUC_CONFIG": config},
         )
-        self.assertEqual(
-            headers, ["Content-Type:image/png", "Cache-Control:max-age=60"]
-        )
+        self.assertEqual(headers, ["Content-Type:image/png", "Cache-Control:max-age=60"])
 
         # If all dims are specfied, but time is current, we expect a shorter caching interval.
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=current&DIM_member=member3&elevation=5000",
             {"ADAGUC_CONFIG": config},
         )
-        self.assertEqual(
-            headers, ["Content-Type:image/png", "Cache-Control:max-age=60"]
-        )
+        self.assertEqual(headers, ["Content-Type:image/png", "Cache-Control:max-age=60"])
 
         # If all dims are specfied except time, we expect a shorter caching interval.
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&DIM_member=member3&elevation=5000",
             {"ADAGUC_CONFIG": config},
         )
-        self.assertEqual(
-            headers, ["Content-Type:image/png", "Cache-Control:max-age=60"]
-        )
+        self.assertEqual(headers, ["Content-Type:image/png", "Cache-Control:max-age=60"])
 
         # If all dims are specfied except member, we expect a shorter caching interval.
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=2017-01-01T00:05:00Z&elevation=5000",
             {"ADAGUC_CONFIG": config},
         )
-        self.assertEqual(
-            headers, ["Content-Type:image/png", "Cache-Control:max-age=60"]
-        )
+        self.assertEqual(headers, ["Content-Type:image/png", "Cache-Control:max-age=60"])
 
         # If all dims are specfied except height, we expect a shorter caching interval.
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=2017-01-01T00:05:00Z&DIM_member=member3&",
             {"ADAGUC_CONFIG": config},
         )
-        self.assertEqual(
-            headers, ["Content-Type:image/png", "Cache-Control:max-age=60"]
-        )
+        self.assertEqual(headers, ["Content-Type:image/png", "Cache-Control:max-age=60"])
 
         #### From here, dimension 'member' is fixed to 'member4'
         # If we query member with same value as what it is fixed to, we get long cache
@@ -2438,36 +2131,28 @@ class TestWMS(unittest.TestCase):
             "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data_with_fixed&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=2017-01-01T00:05:00Z&DIM_member=member4&elevation=5000",
             {"ADAGUC_CONFIG": config},
         )
-        self.assertEqual(
-            headers, ["Content-Type:image/png", "Cache-Control:max-age=7200"]
-        )
+        self.assertEqual(headers, ["Content-Type:image/png", "Cache-Control:max-age=7200"])
 
         # If we query member with different value as what it is fixed to, we get long cache. Fixed values wins from queried value.
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data_with_fixed&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=2017-01-01T00:05:00Z&DIM_member=member2&elevation=5000",
             {"ADAGUC_CONFIG": config},
         )
-        self.assertEqual(
-            headers, ["Content-Type:image/png", "Cache-Control:max-age=7200"]
-        )
+        self.assertEqual(headers, ["Content-Type:image/png", "Cache-Control:max-age=7200"])
 
         # If we don't provide query at all for member, we should get long cache
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data_with_fixed&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=2017-01-01T00:05:00Z&elevation=5000",
             {"ADAGUC_CONFIG": config},
         )
-        self.assertEqual(
-            headers, ["Content-Type:image/png", "Cache-Control:max-age=7200"]
-        )
+        self.assertEqual(headers, ["Content-Type:image/png", "Cache-Control:max-age=7200"])
 
         # Unfixed, unprovided dimension should still result in short cache
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=data_with_fixed&WIDTH=360&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&COLORSCALERANGE=0,1&time=2017-01-01T00:05:00Z",
             {"ADAGUC_CONFIG": config},
         )
-        self.assertEqual(
-            headers, ["Content-Type:image/png", "Cache-Control:max-age=60"]
-        )
+        self.assertEqual(headers, ["Content-Type:image/png", "Cache-Control:max-age=60"])
 
     def test_WMSGetMap_IrregularGrid_1Dimensional_latlon(self):
         """
@@ -2498,17 +2183,13 @@ class TestWMS(unittest.TestCase):
 
         filename_getcapabilities = "test_WMSGetMap_IrregularGrid_1Dimensional_latlon_nextdimensionstep_getcapabilities.xml"
 
-        filename = (
-            "test_WMSGetMap_IrregularGrid_1Dimensional_latlon_nextdimensionstep.png"
-        )
+        filename = "test_WMSGetMap_IrregularGrid_1Dimensional_latlon_nextdimensionstep.png"
 
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "source=example_file_irregular_1Dlat1Dlon_grid.nc&SERVICE=WMS&request=GetCapabilities",
             {"ADAGUC_CONFIG": config},
         )
-        AdagucTestTools().writetofile(
-            self.testresultspath + filename_getcapabilities, data.getvalue()
-        )
+        AdagucTestTools().writetofile(self.testresultspath + filename_getcapabilities, data.getvalue())
         self.assertEqual(status, 0)
         self.assertTrue(
             AdagucTestTools().compareGetCapabilitiesXML(
@@ -2538,17 +2219,13 @@ class TestWMS(unittest.TestCase):
 
         filename_getcapabilities = "test_WMSGetMap_IrregularGrid_2Dimensional_latlon_nextdimensionstep_getcapabilities.xml"
 
-        filename = (
-            "test_WMSGetMap_IrregularGrid_2Dimensional_latlon_nextdimensionstep.png"
-        )
+        filename = "test_WMSGetMap_IrregularGrid_2Dimensional_latlon_nextdimensionstep.png"
 
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "source=example_file_irregular_2Dlat2Dlon_grid.nc&SERVICE=WMS&request=GetCapabilities",
             {"ADAGUC_CONFIG": config},
         )
-        AdagucTestTools().writetofile(
-            self.testresultspath + filename_getcapabilities, data.getvalue()
-        )
+        AdagucTestTools().writetofile(self.testresultspath + filename_getcapabilities, data.getvalue())
         self.assertEqual(status, 0)
         self.assertTrue(
             AdagucTestTools().compareGetCapabilitiesXML(
@@ -2616,9 +2293,7 @@ class TestWMS(unittest.TestCase):
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         status, data, headers = AdagucTestTools().runADAGUCServer(
@@ -2663,26 +2338,17 @@ class TestWMS(unittest.TestCase):
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         # should return 0
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_WMSGetMap_SolarTerminatorEquinox(self):
         # Testing the solar terminator on March 21, 2023
         AdagucTestTools().cleanTempDir()
         config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.solarterminator.xml"
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.solarterminator.xml"
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_SolarTerminatorEquinox.png"
@@ -2701,16 +2367,11 @@ class TestWMS(unittest.TestCase):
         # Testing the solar terminator on December 21, 2022
         AdagucTestTools().cleanTempDir()
         config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.solarterminator.xml"
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.solarterminator.xml"
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_SolarTerminatorSolstice.png"
@@ -2729,16 +2390,11 @@ class TestWMS(unittest.TestCase):
         # Testing the solar terminator on August 7, 2000
         AdagucTestTools().cleanTempDir()
         config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.solarterminator.xml"
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.solarterminator.xml"
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_SolarTerminatorQuarterPoint.png"
@@ -2757,16 +2413,11 @@ class TestWMS(unittest.TestCase):
         # Testing the solar terminator legend
         AdagucTestTools().cleanTempDir()
         config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.solarterminator.xml"
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.solarterminator.xml"
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetLegendGraphic_SolarTerminator.png"
@@ -2785,16 +2436,11 @@ class TestWMS(unittest.TestCase):
         # Testing the solar terminator feature info
         AdagucTestTools().cleanTempDir()
         config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.solarterminator.xml"
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.solarterminator.xml"
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
 
         filename = "test_WMSGetFeatureInfo_SolarTerminator.html"
         status, data, headers = AdagucTestTools().runADAGUCServer(
@@ -2821,14 +2467,10 @@ class TestWMS(unittest.TestCase):
             + "/data/config/datasets/adaguc.tests.403_default_time_referenced_to_forecast_time.xml"
         )
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
-        filename = (
-            "test_WMSGetCapabilities_403_default_time_referenced_to_forecast_time.xml"
-        )
+        filename = "test_WMSGetCapabilities_403_default_time_referenced_to_forecast_time.xml"
         # pylint: disable=unused-variable
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "dataset=adaguc.tests.403_default_time_referenced_to_forecast_time&service=WMS&request=GetCapabilities",
@@ -2836,11 +2478,7 @@ class TestWMS(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_WMSGetLegendGraphic_LongTempLegend(self):
         """Skip some labels when legend is too long"""
@@ -2854,9 +2492,7 @@ class TestWMS(unittest.TestCase):
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetLegendGraphic_LongTempLegend.png"
@@ -2883,9 +2519,7 @@ class TestWMS(unittest.TestCase):
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetLegendGraphic_LongTempLegend_height260.png"
@@ -2939,9 +2573,7 @@ class TestWMS(unittest.TestCase):
         )
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetLegendGraphic_LongTempLegend2.png"
@@ -2960,16 +2592,9 @@ class TestWMS(unittest.TestCase):
         """A dataset configuration with multiple dimensions and a DataBaseTable should work"""
 
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/multi_dim.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/multi_dim.xml"
         env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMS_MultiDim_PreconfiguredDataBaseTable.png"
@@ -2987,9 +2612,7 @@ class TestWMS(unittest.TestCase):
     def test_WMSGetMap_PASCAL_probabilities_manydims_timewindow(self):
 
         AdagucTestTools().cleanTempDir()
-        filename_getcapabilities = (
-            "test_WMSGetCapabilities_PASCAL_probabilities_manydims_timewindow.xml"
-        )
+        filename_getcapabilities = "test_WMSGetCapabilities_PASCAL_probabilities_manydims_timewindow.xml"
         filename_getmap = "test_WMSGetMap_PASCAL_probabilities_manydims_timewindow.png"
 
         # pylint: disable=unused-variable
@@ -3013,9 +2636,7 @@ class TestWMS(unittest.TestCase):
             env=self.env,
             args=["--report"],
         )
-        AdagucTestTools().writetofile(
-            self.testresultspath + filename_getmap, data_getmap.getvalue()
-        )
+        AdagucTestTools().writetofile(self.testresultspath + filename_getmap, data_getmap.getvalue())
 
         self.assertEqual(status_getcapabilities, 0)
         self.assertTrue(
@@ -3033,14 +2654,9 @@ class TestWMS(unittest.TestCase):
 
     def test_WMSGetMap_Barbs_example_windbarbs_from_pointdata_csv(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.vectorrendering.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.vectorrendering.xml"
         env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_Barbs_example_windbarbs_from_pointdata_csv.png"
@@ -3060,14 +2676,9 @@ class TestWMS(unittest.TestCase):
 
     def test_WMSGetMap_Discs_example_windbarbs_from_pointdata_csv(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.vectorrendering.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.vectorrendering.xml"
         env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_Discs_example_windbarbs_from_pointdata_csv.png"
@@ -3089,14 +2700,9 @@ class TestWMS(unittest.TestCase):
         self,
     ):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.vectorrendering.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.vectorrendering.xml"
         env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_Barbs_example_windbarbs_from_pointdata_csv_different_style_options.png"
@@ -3113,14 +2719,9 @@ class TestWMS(unittest.TestCase):
 
     def test_WMSGetMap_Barbs_example_windbarbs_on_gridded_netcdf(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.vectorrendering.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.vectorrendering.xml"
         env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_Barbs_example_windbarbs_on_gridded_netcdf.png"
@@ -3141,14 +2742,9 @@ class TestWMS(unittest.TestCase):
 
     def test_WMSGetMap_Discs_example_windbarbs_on_gridded_netcdf(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.vectorrendering.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.vectorrendering.xml"
         env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_Discs_example_windbarbs_on_gridded_netcdf.png"
@@ -3168,14 +2764,9 @@ class TestWMS(unittest.TestCase):
 
     def test_WMSGetMap_Arrows_example_windbarbs_on_gridded_netcdf(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.vectorrendering.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.vectorrendering.xml"
         env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_Arrows_example_windbarbs_on_gridded_netcdf.png"
@@ -3190,25 +2781,18 @@ class TestWMS(unittest.TestCase):
                 self.expectedoutputsspath + filename,
                 self.testresultspath + filename,
                 maxAllowedColorDifference=56,
-                maxAllowedColorPercentage=0.05
+                maxAllowedColorPercentage=0.05,
             )
         )
 
     def test_WMSGetMap_KNMI_WebSite_AnimatedGifImagery_temperature_styledisc(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.pointrendering.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.pointrendering.xml"
         env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
-        filename = (
-            "test_WMSGetMap_KNMI_WebSite_AnimatedGifImagery_temperature_styledisc.png"
-        )
+        filename = "test_WMSGetMap_KNMI_WebSite_AnimatedGifImagery_temperature_styledisc.png"
         status, data, _ = AdagucTestTools().runADAGUCServer(
             "DATASET=adaguc.tests.pointrendering&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=overlaymask,ta&WIDTH=512&HEIGHT=512&CRS=EPSG%3A3857&BBOX=288069.7108512885,6471755.331201249,894206.0083504317,7141909.376801726&STYLES=filledcountries%2Fnearest,discs&FORMAT=image/png&TRANSPARENT=TRUE&&0.8777664780631963",
             env=env,
@@ -3224,14 +2808,9 @@ class TestWMS(unittest.TestCase):
         self,
     ):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.pointrendering.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.pointrendering.xml"
         env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_KNMI_WebSite_AnimatedGifImagery_temperature_style_temperature.png"
@@ -3250,14 +2829,9 @@ class TestWMS(unittest.TestCase):
         self,
     ):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.pointrendering.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.pointrendering.xml"
         env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_KNMI_WebSite_AnimatedGifImagery_temperature_style_temperature_thinned.png"
@@ -3274,14 +2848,9 @@ class TestWMS(unittest.TestCase):
 
     def test_WMSGetMap_select_temperature_as_point_from_grid(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.pointrendering.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.pointrendering.xml"
         env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_select_temperature_as_point_from_grid.png"
@@ -3299,14 +2868,9 @@ class TestWMS(unittest.TestCase):
 
     def test_WMSGetMap_windbarbs_on_gridded_netcdf_striding_offset(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.vectorrendering.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.vectorrendering.xml"
         env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_windbarbs_on_gridded_netcdf_striding_offset.png"
@@ -3325,20 +2889,16 @@ class TestWMS(unittest.TestCase):
 
     def test_WMSGetMap_windbarbs_kts_selectpoint_for_grids(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.pointrendering.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml,adaguc.tests.pointrendering.xml"
         env = {"ADAGUC_CONFIG": config}
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetMap_windbarbs_kts_selectpoint_for_grids.png"
         status, data, _ = AdagucTestTools().runADAGUCServer(
             "DATASET=adaguc.tests.pointrendering&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=windbarbs_kts_selectpoint_for_grids&WIDTH=654&HEIGHT=513&CRS=EPSG:3857&BBOX=-127880.43405139455,6311494.158487529,1447830.4566477134,7547487.563577196&STYLES=windbarbs_kts_selectpoint_for_grids&FORMAT=image/png&TRANSPARENT=TRUE&time=2023-09-30T06:00:00Z&DIM_reference_time=2023-09-28T06:00:00Z",
-            env=env,showLog=True
+            env=env,
+            showLog=True,
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)

--- a/tests/AdagucTests/TestWMSDocumentCache.py
+++ b/tests/AdagucTests/TestWMSDocumentCache.py
@@ -9,68 +9,70 @@ from lxml import objectify
 import re
 from adaguc.AdagucTestTools import AdagucTestTools
 
-ADAGUC_PATH = os.environ['ADAGUC_PATH']
+ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 
 class TestWMSDocumentCache(unittest.TestCase):
-  testresultspath = "testresults/TestWMSDocumentCache/"
-  expectedoutputsspath = "expectedoutputs/TestWMSDocumentCache/"
+    testresultspath = "testresults/TestWMSDocumentCache/"
+    expectedoutputsspath = "expectedoutputs/TestWMSDocumentCache/"
 
-  env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-         "/data/config/adaguc.tests.dataset.xml"}
+    env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml"}
 
-  AdagucTestTools().mkdir_p(testresultspath)
+    AdagucTestTools().mkdir_p(testresultspath)
 
-  def test_WMSCMDUpdateDB(self):
-    AdagucTestTools().cleanTempDir()
-    ADAGUC_PATH = os.environ['ADAGUC_PATH']
+    def test_WMSCMDUpdateDB(self):
+        AdagucTestTools().cleanTempDir()
+        ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
-    config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-        ADAGUC_PATH + '/data/config/datasets/adaguc.testtimeseriescached.xml'
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        args=['--updatedb', '--config', config], env=self.env, isCGI=False)
-    self.assertEqual(status, 0)
+        config = (
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testtimeseriescached.xml"
+        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
+        self.assertEqual(status, 0)
 
-    filename = "test_WMSGetCapabilities_timeseries_twofiles.xml"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "DATASET=adaguc.testtimeseriescached&SERVICE=WMS&request=getcapabilities", env=self.env)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(
-        self.testresultspath + filename, self.expectedoutputsspath + filename))
+        filename = "test_WMSGetCapabilities_timeseries_twofiles.xml"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "DATASET=adaguc.testtimeseriescached&SERVICE=WMS&request=getcapabilities", env=self.env
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
-  def test_WMSCMDUpdateDBTailPath(self):
-    AdagucTestTools().cleanTempDir()
-    AdagucTestTools().cleanPostgres()
+    def test_WMSCMDUpdateDBTailPath(self):
+        AdagucTestTools().cleanTempDir()
+        AdagucTestTools().cleanPostgres()
 
-    ADAGUC_PATH = os.environ['ADAGUC_PATH']
-    config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-        ADAGUC_PATH + '/data/config/datasets/adaguc.testtimeseriescached.xml'
+        ADAGUC_PATH = os.environ["ADAGUC_PATH"]
+        config = (
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testtimeseriescached.xml"
+        )
 
-    """ First insert one file """
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        args=['--updatedb', '--config', config, '--tailpath', 'netcdf_5dims_seq1'], env=self.env, isCGI=False)
-    self.assertEqual(status, 0)
+        """ First insert one file """
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", config, "--tailpath", "netcdf_5dims_seq1"], env=self.env, isCGI=False
+        )
+        self.assertEqual(status, 0)
 
-    """ Check getcap """
-    filename = "test_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1.xml"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "DATASET=adaguc.testtimeseriescached&SERVICE=WMS&request=getcapabilities", env=self.env)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(
-        self.testresultspath + filename, self.expectedoutputsspath + filename))
+        """ Check getcap """
+        filename = "test_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1.xml"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "DATASET=adaguc.testtimeseriescached&SERVICE=WMS&request=getcapabilities", env=self.env
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
-    """ Insert second file"""
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        args=['--updatedb', '--config', config, '--tailpath', 'netcdf_5dims_seq2'], env=self.env, isCGI=False)
-    self.assertEqual(status, 0)
+        """ Insert second file"""
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            args=["--updatedb", "--config", config, "--tailpath", "netcdf_5dims_seq2"], env=self.env, isCGI=False
+        )
+        self.assertEqual(status, 0)
 
-    """ And check if getcap was indeed updated """
-    filename = "test_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1_and_seq2.xml"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "DATASET=adaguc.testtimeseriescached&SERVICE=WMS&request=getcapabilities", env=self.env)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(
-        self.testresultspath + filename, self.expectedoutputsspath + filename))
+        """ And check if getcap was indeed updated """
+        filename = "test_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1_and_seq2.xml"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "DATASET=adaguc.testtimeseriescached&SERVICE=WMS&request=getcapabilities", env=self.env
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))

--- a/tests/AdagucTests/TestWMSPolylineLabel.py
+++ b/tests/AdagucTests/TestWMSPolylineLabel.py
@@ -24,14 +24,9 @@ class TestWMSPolylineLabel(unittest.TestCase):
         AdagucTestTools().cleanTempDir()
 
         config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.testwmspolylinelabels.xml"
+            ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testwmspolylinelabels.xml"
         )
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         sys.stdout.write("\ntest style %s " % stylename)

--- a/tests/AdagucTests/TestWMSPolylineRenderer.py
+++ b/tests/AdagucTests/TestWMSPolylineRenderer.py
@@ -117,8 +117,11 @@ class TestWMSPolylineRenderer:
     def test_WMSPointRenderer_usgs_earthquakes_geojson_GetFeatureInfoJSON(self):
         env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
 
-        filename="test_WMSPointRenderer_usgs_earthquakes_geojson_GetFeatureInfoJSON.json"
-        status, data, _ = AdagucTestTools().runADAGUCServer("source=usgs_earthquakes.geojson&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS=mag&QUERY_LAYERS=mag&CRS=EPSG%3A3857&BBOX=-23104664.410278287,-14378748.700871969,-3145013.1419883464,15878107.815369671&WIDTH=849&HEIGHT=1287&I=460&J=438&INFO_FORMAT=application/json&", env=env)
+        filename = "test_WMSPointRenderer_usgs_earthquakes_geojson_GetFeatureInfoJSON.json"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "source=usgs_earthquakes.geojson&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS=mag&QUERY_LAYERS=mag&CRS=EPSG%3A3857&BBOX=-23104664.410278287,-14378748.700871969,-3145013.1419883464,15878107.815369671&WIDTH=849&HEIGHT=1287&I=460&J=438&INFO_FORMAT=application/json&",
+            env=env,
+        )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         assert status == 0
         assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)
@@ -126,8 +129,11 @@ class TestWMSPolylineRenderer:
     def test_WMSPointRenderer_usgs_earthquakes_geojson_GetFeatureInfoJSONOutsidePoint(self):
         env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.autoresource.xml"}
 
-        filename="test_WMSPointRenderer_usgs_earthquakes_geojson_GetFeatureInfoJSONOutsidePoint.json"
-        status, data, _ = AdagucTestTools().runADAGUCServer("source=usgs_earthquakes.geojson&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS=mag&QUERY_LAYERS=mag&CRS=EPSG%3A3857&BBOX=-15726290.605935914,1725196.0890940144,-10964171.442404782,6983730.098762937&WIDTH=825&HEIGHT=911&I=248&J=368&INFO_FORMAT=application/json&STYLES=&", env=env)
+        filename = "test_WMSPointRenderer_usgs_earthquakes_geojson_GetFeatureInfoJSONOutsidePoint.json"
+        status, data, _ = AdagucTestTools().runADAGUCServer(
+            "source=usgs_earthquakes.geojson&&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&LAYERS=mag&QUERY_LAYERS=mag&CRS=EPSG%3A3857&BBOX=-15726290.605935914,1725196.0890940144,-10964171.442404782,6983730.098762937&WIDTH=825&HEIGHT=911&I=248&J=368&INFO_FORMAT=application/json&STYLES=&",
+            env=env,
+        )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         assert status == 0
         assert data.getvalue() == AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)

--- a/tests/AdagucTests/TestWMSSLD.py
+++ b/tests/AdagucTests/TestWMSSLD.py
@@ -42,9 +42,7 @@ class TestWMSSLD(unittest.TestCase):
         )
         self.assertEqual(status, 0)
 
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            DEFAULT_REQUEST_PARAMS, env=self.env
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(DEFAULT_REQUEST_PARAMS, env=self.env)
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
         self.assertEqual(
@@ -55,9 +53,7 @@ class TestWMSSLD(unittest.TestCase):
     def test_WMSGetMap_testdatanc_NOSLDURL(self):
         AdagucTestTools().cleanTempDir()
         filename = "test_WMSGetMap_testdatanc_NOSLDURL.xml"
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            DEFAULT_REQUEST_PARAMS + "&SLD=", env=self.env, showLogOnError=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(DEFAULT_REQUEST_PARAMS + "&SLD=", env=self.env, showLogOnError=False)
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 404)
 

--- a/tests/AdagucTests/TestWMSTiling.py
+++ b/tests/AdagucTests/TestWMSTiling.py
@@ -3,104 +3,109 @@
 # pylint: disable=invalid-name
 
 """
-  Run test for tiling system of adaguc-server
+Run test for tiling system of adaguc-server
 """
 
 import os
 import unittest
 from adaguc.AdagucTestTools import AdagucTestTools
 
-
-ADAGUC_PATH = os.environ['ADAGUC_PATH']
+ADAGUC_PATH = os.environ["ADAGUC_PATH"]
 
 
 class TestWMSTiling(unittest.TestCase):
-  """
-  The class for testing tiling
-  """
-  testresultspath = "testresults/TestWMSTiling/"
-  expectedoutputsspath = "expectedoutputs/TestWMSTiling/"
-  env = {'ADAGUC_CONFIG': ADAGUC_PATH +
-         "/data/config/adaguc.tests.dataset.xml"}
-  AdagucTestTools().mkdir_p(testresultspath)
-
-  def test_WMSGetMap_testdatanc_notiling(self):
     """
-    Testing standard functionality without tiling
+    The class for testing tiling
     """
-    AdagucTestTools().cleanTempDir()
 
-    config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-        ADAGUC_PATH + '/data/config/datasets/adaguc.testtiling.xml'
+    testresultspath = "testresults/TestWMSTiling/"
+    expectedoutputsspath = "expectedoutputs/TestWMSTiling/"
+    env = {"ADAGUC_CONFIG": ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml"}
+    AdagucTestTools().mkdir_p(testresultspath)
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        args=['--updatedb', '--config', config], env=self.env, isCGI=False)
-    self.assertEqual(status, 0)
+    def test_WMSGetMap_testdatanc_notiling(self):
+        """
+        Testing standard functionality without tiling
+        """
+        AdagucTestTools().cleanTempDir()
 
-    filename = "test_TestWMSTilingWMSGetMap_testdatanc-notiling.png"
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testtiling.xml"
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "dataset=adaguc.testtiling&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=testdatant&WIDTH=256&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=testdata%2Fnearest&FORMAT=image/png&TRANSPARENT=FALSE&", env=self.env, showLogOnError=True, showLog=False)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue(), AdagucTestTools(
-    ).readfromfile(self.expectedoutputsspath + filename))
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
+        self.assertEqual(status, 0)
 
-  def test_WMSGetMap_testdatanc_tiling(self):
-    """
-    Testing tiling using the createtiles command
-    """
-    AdagucTestTools().cleanTempDir()
+        filename = "test_TestWMSTilingWMSGetMap_testdatanc-notiling.png"
 
-    config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-        ADAGUC_PATH + '/data/config/datasets/adaguc.testtiling.xml'
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "dataset=adaguc.testtiling&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=testdatant&WIDTH=256&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=testdata%2Fnearest&FORMAT=image/png&TRANSPARENT=FALSE&",
+            env=self.env,
+            showLogOnError=True,
+            showLog=False,
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        args=['--updatedb', '--config', config], env=self.env, isCGI=False)
-    self.assertEqual(status, 0)
+    def test_WMSGetMap_testdatanc_tiling(self):
+        """
+        Testing tiling using the createtiles command
+        """
+        AdagucTestTools().cleanTempDir()
 
-    filename = "test_TestWMSTilingWMSGetMap_testdatanc-notiling.png"
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testtiling.xml"
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "dataset=adaguc.testtiling&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=testdatant&WIDTH=256&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=testdata%2Fnearest&FORMAT=image/png&TRANSPARENT=FALSE&", env=self.env, showLogOnError=True, showLog=False)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue(), AdagucTestTools(
-    ).readfromfile(self.expectedoutputsspath + filename))
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
+        self.assertEqual(status, 0)
 
-    AdagucTestTools().mkdir_p(os.environ['ADAGUC_TMP']+"/tiling/")
-    config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-        ADAGUC_PATH + '/data/config/datasets/adaguc.testtiling.xml'
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        args=['--createtiles', '--config', config], env=self.env, isCGI=False, showLogOnError=True, showLog=False)
-    self.assertEqual(status, 0)
+        filename = "test_TestWMSTilingWMSGetMap_testdatanc-notiling.png"
 
-    filename = "test_TestWMSTilingWMSGetMap_testdatanc.png"
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "dataset=adaguc.testtiling&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=testdata&WIDTH=256&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=testdata%2Fnearest&FORMAT=image/png&TRANSPARENT=FALSE&", env=self.env, showLogOnError=True, showLog=False)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue(), AdagucTestTools(
-    ).readfromfile(self.expectedoutputsspath + filename))
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "dataset=adaguc.testtiling&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=testdatant&WIDTH=256&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=testdata%2Fnearest&FORMAT=image/png&TRANSPARENT=FALSE&",
+            env=self.env,
+            showLogOnError=True,
+            showLog=False,
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
-  def test_WMSGetMap_testdatanc_autotiling(self):
-    """
-    Testing auto tiling, tiling done during --updatedb
-    """
-    AdagucTestTools().cleanTempDir()
+        AdagucTestTools().mkdir_p(os.environ["ADAGUC_TMP"] + "/tiling/")
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testtiling.xml"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            args=["--createtiles", "--config", config], env=self.env, isCGI=False, showLogOnError=True, showLog=False
+        )
+        self.assertEqual(status, 0)
 
-    config = ADAGUC_PATH + '/data/config/adaguc.tests.dataset.xml,' + \
-        ADAGUC_PATH + '/data/config/datasets/adaguc.testautotiling.xml'
+        filename = "test_TestWMSTilingWMSGetMap_testdatanc.png"
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "dataset=adaguc.testtiling&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=testdata&WIDTH=256&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=testdata%2Fnearest&FORMAT=image/png&TRANSPARENT=FALSE&",
+            env=self.env,
+            showLogOnError=True,
+            showLog=False,
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        args=['--updatedb', '--config', config], env=self.env, isCGI=False)
-    self.assertEqual(status, 0)
+    def test_WMSGetMap_testdatanc_autotiling(self):
+        """
+        Testing auto tiling, tiling done during --updatedb
+        """
+        AdagucTestTools().cleanTempDir()
 
-    filename = "test_TestWMSTilingWMSGetMap_testdatanc-autotiling.png"
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.testautotiling.xml"
 
-    status, data, headers = AdagucTestTools().runADAGUCServer(
-        "dataset=adaguc.testautotiling&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=testdata&WIDTH=256&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=testdata%2Fnearest&FORMAT=image/png&TRANSPARENT=FALSE&", env=self.env, showLogOnError=True, showLog=False)
-    AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
-    self.assertEqual(status, 0)
-    self.assertEqual(data.getvalue(), AdagucTestTools(
-    ).readfromfile(self.expectedoutputsspath + filename))
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
+        self.assertEqual(status, 0)
+
+        filename = "test_TestWMSTilingWMSGetMap_testdatanc-autotiling.png"
+
+        status, data, headers = AdagucTestTools().runADAGUCServer(
+            "dataset=adaguc.testautotiling&SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=testdata&WIDTH=256&HEIGHT=180&CRS=EPSG%3A4326&BBOX=-90,-180,90,180&STYLES=testdata%2Fnearest&FORMAT=image/png&TRANSPARENT=FALSE&",
+            env=self.env,
+            showLogOnError=True,
+            showLog=False,
+        )
+        AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(data.getvalue(), AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))

--- a/tests/AdagucTests/TestWMSTimeHeightProfiles.py
+++ b/tests/AdagucTests/TestWMSTimeHeightProfiles.py
@@ -36,11 +36,7 @@ class TestWMSTimeHeightProfiles(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_wms_getmap_timeheightprofiles(self):
         """
@@ -93,23 +89,15 @@ class TestWMSTimeHeightProfiles(unittest.TestCase):
         )
 
         # Update database, scan the file
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         # Check getcapabilities on dataset configuration
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            "SERVICE=WMS&request=getcapabilities", {"ADAGUC_CONFIG": config}
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer("SERVICE=WMS&request=getcapabilities", {"ADAGUC_CONFIG": config})
         filename = "test_wmsgetcapabilities_timeheightprofiles_as_dataset.xml"
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
         # Check getfeatureinfo as PNG on dataset configuration
         filename = "test_wmsgetfeatureinfo_png_timeheightprofiles_as_dataset.png"
@@ -143,23 +131,15 @@ class TestWMSTimeHeightProfiles(unittest.TestCase):
         )
 
         # Update database, scan the file
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         # Check getcapabilities on dataset configuration
-        status, data, _ = AdagucTestTools().runADAGUCServer(
-            "SERVICE=WMS&request=getcapabilities", {"ADAGUC_CONFIG": config}
-        )
+        status, data, _ = AdagucTestTools().runADAGUCServer("SERVICE=WMS&request=getcapabilities", {"ADAGUC_CONFIG": config})
         filename = "test_wmsgetcapabilities_timeheightprofiles_as_dataset.xml"
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
         # Check getfeatureinfo as PNG on dataset configuration
         filename = "test_wmsgetfeatureinfo_json_timeheightprofiles_as_dataset.json"

--- a/tests/AdagucTests/TestWMSTimeSeries.py
+++ b/tests/AdagucTests/TestWMSTimeSeries.py
@@ -2,6 +2,7 @@
 """
 This class contains tests to test the adaguc-server binary executable file. This is similar to black box testing, it tests the behaviour of the server software. It configures the server and checks if the response is OK.
 """
+
 import json
 import os
 import os.path
@@ -27,16 +28,9 @@ class TestWMSTimeSeries(unittest.TestCase):
     def test_timeseries_adaguc_tests_arcus_uwcw_air_temperature_hagl(self):
         AdagucTestTools().cleanTempDir()
 
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.arcus_uwcw.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.arcus_uwcw.xml"
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetFeatureInfoTimeSeries_arcus_uwcw_air_temperature_hagl.json"
@@ -51,8 +45,6 @@ class TestWMSTimeSeries(unittest.TestCase):
             data.getvalue(),
             AdagucTestTools().readfromfile(self.expectedoutputsspath + filename),
         )
-
-
 
     def test_WMSGetFeatureInfo_timeseries_5dims_json(self):
         AdagucTestTools().cleanTempDir()
@@ -81,7 +73,6 @@ class TestWMSTimeSeries(unittest.TestCase):
             AdagucTestTools().readfromfile(self.expectedoutputsspath + filename),
         )
 
-
     def test_WMSGetFeatureInfo_timeseries_forecastreferencetime_json(self):
         AdagucTestTools().cleanTempDir()
         filename = "test_WMSGetFeatureInfo_timeseries_forecastreferencetime.json"
@@ -97,31 +88,17 @@ class TestWMSTimeSeries(unittest.TestCase):
             AdagucTestTools().readfromfile(self.expectedoutputsspath + filename),
         )
         filename = "test_WMSGetFeatureInfo_timeseries_forecastreferencetime_json_WMSGetCapabilities_testdatanc.xml"
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            "source=testdata.nc&SERVICE=WMS&request=getcapabilities", env=self.env
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer("source=testdata.nc&SERVICE=WMS&request=getcapabilities", env=self.env)
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
-
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
 
     def test_WMSGetFeatureInfo_KNMIHDF5_echotops_RAD_NL25_ETH_NA_TOPS(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.KNMIHDF5.test.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.KNMIHDF5.test.xml"
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetFeatureInfo_KNMIHDF5_echotops_RAD_NL25_ETH_NA_TOPS.json"
@@ -136,20 +113,12 @@ class TestWMSTimeSeries(unittest.TestCase):
             AdagucTestTools().readfromfile(self.expectedoutputsspath + filename),
         )
 
-
     def test_WMSGetFeatureInfo_KNMIHDF5_echotops_RAD_NL25_ETH_NA_GRID(self):
         AdagucTestTools().cleanTempDir()
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.KNMIHDF5.test.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.KNMIHDF5.test.xml"
         env = {"ADAGUC_CONFIG": config}
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetFeatureInfo_KNMIHDF5_echotops_RAD_NL25_ETH_NA_GRID.json"
@@ -164,20 +133,12 @@ class TestWMSTimeSeries(unittest.TestCase):
             AdagucTestTools().readfromfile(self.expectedoutputsspath + filename),
         )
 
-
     def test_timeseries_adaguc_tests_arcus_uwcw_wind_kts(self):
         AdagucTestTools().cleanTempDir()
 
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.arcus_uwcw.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.arcus_uwcw.xml"
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetFeatureInfoTimeSeries_arcus_uwcw_wind_speed_hagl_convertedtokts.json"
@@ -196,16 +157,9 @@ class TestWMSTimeSeries(unittest.TestCase):
     def test_timeseries_adaguc_tests_arcus_uwcw_wind_kts_to_ms(self):
         AdagucTestTools().cleanTempDir()
 
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.arcus_uwcw.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.arcus_uwcw.xml"
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetFeatureInfoTimeSeries_arcus_uwcw_wind_speed_hagl_convertedtoms.json"
@@ -221,20 +175,12 @@ class TestWMSTimeSeries(unittest.TestCase):
             AdagucTestTools().readfromfile(self.expectedoutputsspath + filename),
         )
 
-
     def test_timeseries_adaguc_tests_arcus_uwcw_wind_kts_to_ms_wind_speed_hagl_ms_wrong_dim_order(self):
         AdagucTestTools().cleanTempDir()
 
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.arcus_uwcw.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.arcus_uwcw.xml"
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetFeatureInfoTimeSeries_arcus_uwcw_wind_speed_hagl_convertedtoms_wrong_order.json"
@@ -250,20 +196,12 @@ class TestWMSTimeSeries(unittest.TestCase):
             AdagucTestTools().readfromfile(self.expectedoutputsspath + filename),
         )
 
-
     def test_timeseries_adaguc_tests_arcus_uwcw_wind_kts_to_ms_member_3(self):
         AdagucTestTools().cleanTempDir()
 
-        config = (
-            ADAGUC_PATH
-            + "/data/config/adaguc.tests.dataset.xml,"
-            + ADAGUC_PATH
-            + "/data/config/datasets/adaguc.tests.arcus_uwcw.xml"
-        )
+        config = ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.tests.arcus_uwcw.xml"
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetFeatureInfoTimeSeries_arcus_uwcw_wind_speed_hagl_convertedtoms_member_3.json"
@@ -282,11 +220,10 @@ class TestWMSTimeSeries(unittest.TestCase):
         # Check if member_3 is the same as in the multidim file from previous test:
         data_file_member_3 = json.loads(data.getvalue())[0]["data"]["2024-06-05T03:00:00Z"]
         filename_many_members = "test_WMSGetFeatureInfoTimeSeries_arcus_uwcw_wind_speed_hagl_convertedtoms.json"
-        with open(self.expectedoutputsspath+filename_many_members, encoding = 'utf-8') as fp:
+        with open(self.expectedoutputsspath + filename_many_members, encoding="utf-8") as fp:
             filename_many_members_data = json.load(fp)
         data_file_all_members = filename_many_members_data[0]["data"]["2024-06-05T03:00:00Z"]
         assert data_file_member_3 == data_file_all_members["3"]
-
 
     def test_timeseries_adaguc_tests_arcus_uwcw_ha43_dini_5p5km_10x8_air_temperature_pl(self):
         AdagucTestTools().cleanTempDir()
@@ -298,9 +235,7 @@ class TestWMSTimeSeries(unittest.TestCase):
             + "/data/config/datasets/test.uwcw_ha43_dini_5p5km_10x8.xml"
         )
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetFeatureInfoTimeSeries_arcus_uwcw_ha43_dini_5p5km_10x8_air_temperature_pl.json"
@@ -312,7 +247,9 @@ class TestWMSTimeSeries(unittest.TestCase):
 
         # TODO Check why pressure levels sometimes have suffix .0 on different environments
         server_response = data.getvalue().decode("utf-8")
-        server_response = server_response.replace("500.0", "500").replace("700.0", "700").replace("850.0", "850").replace("925.0", "925").encode("utf-8")
+        server_response = (
+            server_response.replace("500.0", "500").replace("700.0", "700").replace("850.0", "850").replace("925.0", "925").encode("utf-8")
+        )
 
         AdagucTestTools().writetofile(self.testresultspath + filename, server_response)
         self.assertEqual(status, 0)
@@ -321,13 +258,10 @@ class TestWMSTimeSeries(unittest.TestCase):
         # print("---------------- 2 -----------------", file=sys.stderr)
         # print(json.loads(AdagucTestTools().readfromfile(self.expectedoutputsspath + filename)), file=sys.stderr)
         # print("---------------- 3 -----------------", file=sys.stderr)
-        assert  json.loads(server_response) == json.loads(AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
-        
-
-
+        assert json.loads(server_response) == json.loads(AdagucTestTools().readfromfile(self.expectedoutputsspath + filename))
 
     def test_wmsgetfeatureinfo_json_timeheight_profile_for_sorted_model_levels(self):
-      
+
         AdagucTestTools().cleanTempDir()
 
         config = (
@@ -337,9 +271,7 @@ class TestWMSTimeSeries(unittest.TestCase):
             + "/data/config/datasets/adaguc.tests.arcus_harmonie_sorted_model_levels.xml"
         )
         # pylint: disable=unused-variable
-        status, data, headers = AdagucTestTools().runADAGUCServer(
-            args=["--updatedb", "--config", config], env=self.env, isCGI=False
-        )
+        status, data, headers = AdagucTestTools().runADAGUCServer(args=["--updatedb", "--config", config], env=self.env, isCGI=False)
         self.assertEqual(status, 0)
 
         filename = "test_WMSGetCapabilities_adaguc_arcus_harmonie_sorted_model_levels.xml"
@@ -350,12 +282,8 @@ class TestWMSTimeSeries(unittest.TestCase):
         )
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        self.assertTrue(
-            AdagucTestTools().compareGetCapabilitiesXML(
-                self.testresultspath + filename, self.expectedoutputsspath + filename
-            )
-        )
-        
+        self.assertTrue(AdagucTestTools().compareGetCapabilitiesXML(self.testresultspath + filename, self.expectedoutputsspath + filename))
+
         filename = "test_WMSGetFeatureInfoTimeSeries_arcus_harmonie_sorted_model_levels.json"
 
         status, data, headers = AdagucTestTools().runADAGUCServer(
@@ -379,10 +307,7 @@ class TestWMSTimeSeries(unittest.TestCase):
             args=[
                 "--updatedb",
                 "--config",
-                ADAGUC_PATH
-                + "/data/config/adaguc.tests.dataset.xml,"
-                + ADAGUC_PATH
-                + "/data/config/datasets/adaguc.test.members.xml",
+                ADAGUC_PATH + "/data/config/adaguc.tests.dataset.xml," + ADAGUC_PATH + "/data/config/datasets/adaguc.test.members.xml",
             ],
             isCGI=False,
         )
@@ -410,11 +335,10 @@ class TestWMSTimeSeries(unittest.TestCase):
             AdagucTestTools().readfromfile(self.expectedoutputsspath + filename),
         )
 
-
     def test_UWCW_DINI_windcomponents_GetMetadata(self):
         AdagucTestTools().cleanTempDir()
         AdagucTestTools().cleanPostgres()
-        
+
         filename = "test_UWCW_DINI_windcomponents_GetMetadata.json"
         config = ADAGUC_PATH + "data/config/adaguc.tests.dataset.xml"
         # pylint: disable=unused-variable
@@ -433,18 +357,16 @@ class TestWMSTimeSeries(unittest.TestCase):
             "service=wms&request=getmetadata&format=application/json",
             {"ADAGUC_CONFIG": ADAGUC_PATH + "data/config/adaguc.tests.dataset.xml"},
         )
-        
+
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertEqual(status, 0)
-        
+
         metadata_json = json.loads(data.getvalue())
-        
-        self.assertEqual(len(metadata_json["adaguc_tests_uwcwdini_windcomponents"]["wind-hagl"]["layer"]["variables"]),6)
-        
-        self.assertEqual(metadata_json["adaguc_tests_uwcwdini_windcomponents"]["wind-hagl"]["layer"]["layername"],"wind-hagl")
 
+        self.assertEqual(len(metadata_json["adaguc_tests_uwcwdini_windcomponents"]["wind-hagl"]["layer"]["variables"]), 6)
 
-        
+        self.assertEqual(metadata_json["adaguc_tests_uwcwdini_windcomponents"]["wind-hagl"]["layer"]["layername"], "wind-hagl")
+
     def test_UWCW_DINI_windcomponents_xwind_ywind_WMSGetMapBarbs(self):
         AdagucTestTools().cleanTempDir()
         filename = "test_UWCW_DINI_windcomponents_xwind_ywind_WMSGetMapBarbs.png"
@@ -475,7 +397,7 @@ class TestWMSTimeSeries(unittest.TestCase):
                 0.1,
             )
         )
-        
+
     def test_UWCW_DINI_windcomponents_xwind_ywind_WMSGetFeatureInfoTimeSeries(self):
         AdagucTestTools().cleanTempDir()
         filename = "test_UWCW_DINI_windcomponents_xwind_ywind_WMSGetFeatureInfoTimeSeries.json"
@@ -530,8 +452,8 @@ class TestWMSTimeSeries(unittest.TestCase):
         self.assertEqual(
             data.getvalue(),
             AdagucTestTools().readfromfile(self.expectedoutputsspath + filename),
-        )        
-        
+        )
+
     def test_UWCW_DINI_windcomponents_xwind_ywind_WCSGetCoverage(self):
         AdagucTestTools().cleanTempDir()
         filename = "test_UWCW_DINI_windcomponents_xwind_ywind_WCSGetCoverage.nc"
@@ -555,20 +477,35 @@ class TestWMSTimeSeries(unittest.TestCase):
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
 
         self.assertEqual(status, 0)
-        
+
         # Check NetCDF file: Number of variables and global attribute
         ds = netCDF4.Dataset("filename.nc", memory=data.getvalue())
         self.assertEqual(ds.getncattr("convert_uv_components"), "metadata")
-        self.assertEqual(list(ds.variables), ['x', 'y', 'time', 'wind_at_10m', 'forecast_reference_time', 'crs', 'speed_component', 'direction_component', 'eastward_component', 'northward_component', 'x-wind-hagl', 'y-wind-hagl'])
+        self.assertEqual(
+            list(ds.variables),
+            [
+                "x",
+                "y",
+                "time",
+                "wind_at_10m",
+                "forecast_reference_time",
+                "crs",
+                "speed_component",
+                "direction_component",
+                "eastward_component",
+                "northward_component",
+                "x-wind-hagl",
+                "y-wind-hagl",
+            ],
+        )
 
-
-        
         # Do getmap request on the NetCDF file we just obtained via WCS, query the direction_component
         filename = "test_UWCW_DINI_windcomponents_xwind_ywind_GetMapOnWCSCoverage_direction_component.png"
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "source=TestWMSTimeSeries%2Ftest_UWCW_DINI_windcomponents_xwind_ywind_WCSGetCoverage%2Enc&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=direction_component&WIDTH=512HEIGHT=512&CRS=EPSG%3A3857&BBOX=-4787988.272387099,4425096.702571644,4348576.567740106,10946270.416926505&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&&DIM_wind_at_10m=10&time=2024-09-07T12%3A00%3A00Z&DIM_reference_time=2024-09-05T00%3A00%3A00Z&0.783935864573529",
-            {"ADAGUC_CONFIG": ADAGUC_PATH + "data/config/adaguc.autoresource.xml",
-             "ADAGUC_AUTOWMS_DIR":self.testresultspath},showLog=False)
+            {"ADAGUC_CONFIG": ADAGUC_PATH + "data/config/adaguc.autoresource.xml", "ADAGUC_AUTOWMS_DIR": self.testresultspath},
+            showLog=False,
+        )
         self.assertEqual(status, 0)
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertTrue(
@@ -579,13 +516,14 @@ class TestWMSTimeSeries(unittest.TestCase):
                 0.1,
             )
         )
-        
+
         # Do getmap request on the NetCDF file we just obtained via WCS, query the speed_component
         filename = "test_UWCW_DINI_windcomponents_xwind_ywind_GetMapOnWCSCoverage_speed_component.png"
         status, data, headers = AdagucTestTools().runADAGUCServer(
             "source=TestWMSTimeSeries%2Ftest_UWCW_DINI_windcomponents_xwind_ywind_WCSGetCoverage%2Enc&SERVICE=WMS&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=speed_component&WIDTH=512HEIGHT=512&CRS=EPSG%3A3857&BBOX=-4787988.272387099,4425096.702571644,4348576.567740106,10946270.416926505&STYLES=auto%2Fnearest&FORMAT=image/png&TRANSPARENT=TRUE&&DIM_wind_at_10m=10&time=2024-09-07T12%3A00%3A00Z&DIM_reference_time=2024-09-05T00%3A00%3A00Z&0.783935864573529",
-            {"ADAGUC_CONFIG": ADAGUC_PATH + "data/config/adaguc.autoresource.xml",
-             "ADAGUC_AUTOWMS_DIR":self.testresultspath},showLog=False)
+            {"ADAGUC_CONFIG": ADAGUC_PATH + "data/config/adaguc.autoresource.xml", "ADAGUC_AUTOWMS_DIR": self.testresultspath},
+            showLog=False,
+        )
         self.assertEqual(status, 0)
         AdagucTestTools().writetofile(self.testresultspath + filename, data.getvalue())
         self.assertTrue(


### PR DESCRIPTION
- Adds pre-commit hook that runs `black` formatter. Settings for formatter are in `pyproject.toml`, used by both pre-commit hook and VS Code settings, so we can all use the same formatting rules.
- I've picked line-length 140, it looks okay to me.
- I ran the formatter on everything in `tests/`. If we're happy with these settings, we can also include the paths `python/lib/adaguc` and `python/python_fastapi_server/`.
- All test changes are due to formatting, nothing else was changed.