### PR TITLE
677 add user agent back to logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ USER root
 LABEL maintainer="adaguc@knmi.nl"
 
 # Version should be same as in Definitions.h
-LABEL version="7.1.2"
+LABEL version="7.2.0"
 
 # Try to update image packages
 RUN apt-get -q -y update \

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+**Version 7.2.0 TBD***
+
+- Revert remove of user agent logging [#677](https://github.com/KNMI/adaguc-server/issues/677)
+
 **Version 7.1.2 - 2026-03-30***
 
 - Refactored dataobject and datasource properties - no heap data is owned anymore.

--- a/adagucserverEC/Definitions.h
+++ b/adagucserverEC/Definitions.h
@@ -28,7 +28,7 @@
 #ifndef Definitions_H
 #define Definitions_H
 
-#define ADAGUCSERVER_VERSION "7.1.2" // Please also update in the Dockerfile to the same version
+#define ADAGUCSERVER_VERSION "7.2.0" // Please also update in the Dockerfile to the same version
 
 // CConfigReaderLayerType
 #define CConfigReaderLayerTypeUnknown 0

--- a/python/python_fastapi_server/main.py
+++ b/python/python_fastapi_server/main.py
@@ -28,9 +28,9 @@ logger = logging.getLogger(__name__)
 app = FastAPI(redirect_slashes=False)
 
 # Set uvicorn access log format using middleware
-ACCESS_LOG_FORMAT = (
-    'accesslog %(h)s ; %(t)s ; %(H)s ; %(m)s ; %(U)s ; %(q)s ; %(s)s ; %(M)s"'
-)
+ACCESS_LOG_FORMAT = 'accesslog %(h)s ; %(t)s ; %(H)s ; %(m)s ; %(U)s ; %(q)s ; %(s)s ; %(M)s ; "%(a)s"'
+
+
 logging.getLogger("uvicorn.access").handlers.clear()
 app.add_middleware(AccessLoggerMiddleware, format=ACCESS_LOG_FORMAT)
 logging.getLogger("access").propagate = False
@@ -44,9 +44,7 @@ async def add_hsts_header(request: Request, call_next):
         external_address = os.environ["EXTERNALADDRESS"]
         scheme = urlsplit(external_address).scheme
         if scheme == "https":
-            response.headers["Strict-Transport-Security"] = (
-                "max-age=31536000; includeSubDomains"
-            )
+            response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
             response.headers["X-Content-Type-Options"] = "nosniff"
             response.headers["Content-Security-Policy"] = "default-src 'self'"
 
@@ -67,7 +65,7 @@ async def add_process_time_header(request: Request, call_next):
     response = await call_next(request)
     # Log the X-Trace-Timings so we can monitor timings of the server
     if "X-Trace-Timings" in response.headers:
-        logger.log(35, str(request.query_params)+ response.headers["X-Trace-Timings"])
+        logger.log(35, str(request.query_params) + response.headers["X-Trace-Timings"])
     process_time = time.time() - start_time
     response.headers["X-Process-Time"] = str(process_time)
     return response
@@ -86,9 +84,7 @@ app.add_middleware(
 @app.get("/")
 async def root():
     """Root page"""
-    return {
-        "message": "ADAGUC server base URL, use /wms, /wcs, /autowms, /adagucopendap or /ogcapi"
-    }
+    return {"message": "ADAGUC server base URL, use /wms, /wcs, /autowms, /adagucopendap or /ogcapi"}
 
 
 app.mount("/ogcapi", ogcApiApp)


### PR DESCRIPTION
Logging changes from
```
applicationlog 2026-04-10 11:07:49,977 - main - TRACE - dataset=adaguc.tests.wikgeneric&service=WMS&request=GetCapabilities&random0.6487553885915154=[DBCONNECT 12.7/1/0],[DB 0.1/13/0],[total 27.2ms] {27}
accesslog 127.0.0.1:42618 ; [10/Apr/2026:11:07:49 +0200] ; HTTP/1.1 ; GET ; /adagucserver ; dataset=adaguc.tests.wikgeneric&&service=WMS&request=GetCapabilities&random0.6487553885915154 ; 200 ; 55 
```
to -->
```
applicationlog 2026-04-10 11:07:49,977 - main - TRACE - dataset=adaguc.tests.wikgeneric&service=WMS&request=GetCapabilities&random0.6487553885915154=[DBCONNECT 12.7/1/0],[DB 0.1/13/0],[total 27.2ms] {27}
accesslog 127.0.0.1:42618 ; [10/Apr/2026:11:07:49 +0200] ; HTTP/1.1 ; GET ; /adagucserver ; dataset=adaguc.tests.wikgeneric&&service=WMS&request=GetCapabilities&random0.6487553885915154 ; 200 ; 55 ; "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"
```

The user agent string is added back (`"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"`)

This is used in the monitoring of the KNMI Data Platform.