### PR TITLE
Compiles under clang without warnings

### DIFF
--- a/CCDFDataModel/CCDFTypes.h
+++ b/CCDFDataModel/CCDFTypes.h
@@ -59,6 +59,8 @@ typedef int CDFType;
 #define CDF_INT64 12   /* signed 8 byte integer */
 #define CDF_UINT64 13  /* unsigned 8 byte integer */
 
+typedef unsigned long ulong;
+
 // This is an X-Macro to automatically enumerate all template type mappings used in CDF
 #define ENUMERATE_OVER_CDFTYPES(DO)                                                                                                                                                                    \
   DO(CDF_CHAR, char)                                                                                                                                                                                   \

--- a/adagucserverEC/CDBFileScannerCleanFiles.cpp
+++ b/adagucserverEC/CDBFileScannerCleanFiles.cpp
@@ -72,7 +72,7 @@ std::pair<int, std::set<std::string>> CDBFileScanner::cleanFiles(CDataSource *da
   if (hasTimeDim == dataSource->requiredDims.end()) {
     // time is not part of this dimension set. Take something which looks like a time dim.
     CDBWarning("time dimension does not seem to exist in this layer");
-    auto isTypeTime = std::find_if(dataSource->requiredDims.begin(), dataSource->requiredDims.end(), [&colName](const COGCDims &ogcdim) { return ogcdim.isATimeDimension; });
+    auto isTypeTime = std::find_if(dataSource->requiredDims.begin(), dataSource->requiredDims.end(), [](const COGCDims &ogcdim) { return ogcdim.isATimeDimension; });
     if (isTypeTime != dataSource->requiredDims.end()) {
       CDBDebug("Using %s instead.", (*isTypeTime).netCDFDimName.c_str());
       colName = (*isTypeTime).netCDFDimName.c_str();

--- a/adagucserverEC/utils/minMax.h
+++ b/adagucserverEC/utils/minMax.h
@@ -11,7 +11,7 @@
 
 // TODO THIS NEEDS refactoring, e.g. combine MinMax and Statistics into one and dont use pointers.
 // The calculate routine should be a standalone function
-class DataObject;
+struct DataObject;
 
 struct MinMax {
   bool isSet = false;


### PR DESCRIPTION
- `ulong` was not declared (might be macbook/arm64 issue?)
- `colName` was unused in capture
- `DataObject` is not a class anymore but a struct, so forward decleration must be `struct DataObject`

Code compiles without warnings.