### PR TITLE
Version 7.2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-**Version TBD**
+**Version 7.2.0 - 2026-04-17**
 
 - GetLayerMetadata can now return results for specific forecast_reference_time, like: `http://localhost:8080/adagucserver?dataset=adaguc.tests.arcus_uwcw&&service=wms&version=1.3.0&request=getmetadata&format=application/json&dim_reference_time=2024-05-23T00:00:00Z&layer=air_temperature_hagl`
 - Fixed [#614](https://github.com/KNMI/adaguc-server/issues/614) where generic renderer caused issues with linear transform

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,9 @@
 - EDR: When performing a position or cube query without selecting an instance (e.g. `/edr/collections/my_collection/position`), adaguc now returns the most recent instance.
 - WMS GetFeatureInfo for timeseries now sorts properly when * is used for the time dimension
 - Replaced CAIRO_LINE_JOIN_MITER with BEVEL for smoother line joins 
-- Brotli encoding is now done only for certain Content-Types.
+- Brotli encoding is now done only for certain Con'tent-Types.
 - Add EPSG:5041 as a supported projection
+- "Upgraded to python 3.14
 
 **Version 7.1.2 - 2026-03-30***
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 - WMS GetFeatureInfo for timeseries now sorts properly when * is used for the time dimension
 - Replaced CAIRO_LINE_JOIN_MITER with BEVEL for smoother line joins 
 - Brotli encoding is now done only for certain Content-Types.
+- Add EPSG:5041 as a supported projection
 
 **Version 7.1.2 - 2026-03-30***
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 - Replaced CAIRO_LINE_JOIN_MITER with BEVEL for smoother line joins 
 - Brotli encoding is now done only for certain Con'tent-Types.
 - Add EPSG:5041 as a supported projection
-- "Upgraded to python 3.14
+- Upgraded to python 3.14
 
 **Version 7.1.2 - 2026-03-30***
 

--- a/data/config/includes/Projection.include.xml
+++ b/data/config/includes/Projection.include.xml
@@ -7,6 +7,7 @@
   <Projection id="EPSG:3857" proj4="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"/>
   <Projection id="EPSG:4258" proj4="+proj=longlat +ellps=GRS80 +no_defs"/>
   <Projection id="EPSG:4326" proj4="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"/>
+  <Projection id="EPSG:5041" proj4="+proj=stere +lat_0=90 +lon_0=0 +k=0.994 +x_0=2000000 +y_0=2000000 +datum=WGS84 +units=m +no_defs +type=crs"/>
   <Projection id="CRS:84" proj4="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"/>
   <Projection id="EPSG:25831" proj4="+proj=utm +zone=31 +ellps=GRS80 +units=m +no_defs"/>
   <Projection id="EPSG:25832" proj4="+proj=utm +zone=32 +ellps=GRS80 +units=m +no_defs"/>
@@ -14,7 +15,7 @@
   </Projection>
   <Projection id="EPSG:7399" proj4="+proj=moll +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs "/>
   <Projection id="EPSG:50001" proj4="+proj=stere +lat_ts=60.0 +lat_0=90 +lon_0=-111.0 +k_0=1.0 +x_0=3020946.0 +y_0=7622187.0 +units=m +ellps=WGS84 +datum=WGS84 +no_defs ">
-    <LatLonBox minx="-2000000"  miny="-2000000" maxx="10000000" maxy="8500000"/>
+    <LatLonBox minx="-2000000" miny="-2000000" maxx="10000000" maxy="8500000"/>
   </Projection>
   <Projection id="EPSG:54030" proj4="+proj=robin +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs "/>
   <Projection id="EPSG:32661" proj4="+proj=stere +lat_0=90 +lat_ts=90 +lon_0=0 +k=0.994 +x_0=2000000 +y_0=2000000 +ellps=WGS84 +datum=WGS84 +units=m +no_defs"/>

--- a/tests/expectedoutputs/TestCSV/test_CSV_reference_timesupport_GetCapabilities.xml
+++ b/tests/expectedoutputs/TestCSV/test_CSV_reference_timesupport_GetCapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 3.1.2, of Jun 30 2025 11:29:01 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testCSVReader_reference_time&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:4326" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
 <BoundingBox CRS="EPSG:54030" minx="20763.744634" miny="5129624.479875" maxx="20763.744634" maxy="5129626.479875" />
 <BoundingBox CRS="EPSG:7399" minx="19479.628720" miny="5673073.474727" maxx="19479.628720" maxy="5673075.474727" />
 <BoundingBox CRS="EPSG:900913" minx="27829.872698" miny="6123506.170632" maxx="27829.872698" maxy="6123508.170632" />
@@ -117,12 +119,29 @@
 <BoundingBox CRS="EPSG:4258" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:4326" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
 <BoundingBox CRS="EPSG:54030" minx="20763.744634" miny="5129624.479875" maxx="20763.744634" maxy="5129626.479875" />
 <BoundingBox CRS="EPSG:7399" minx="19479.628720" miny="5673073.474727" maxx="19479.628720" maxy="5673075.474727" />
 <BoundingBox CRS="EPSG:900913" minx="27829.872698" miny="6123506.170632" maxx="27829.872698" maxy="6123508.170632" />
 <Dimension name="time" units="ISO8601" default="2018-12-04T12:10:00Z" multipleValues="1" nearestValue="0" current="1">2018-12-04T12:00:00Z,2018-12-04T12:05:00Z,2018-12-04T12:10:00Z</Dimension>
 <Dimension name="reference_time" units="ISO8601" default="2018-12-04T12:05:00Z" multipleValues="1" nearestValue="0" current="1">2018-12-04T12:00:00Z,2018-12-04T12:05:00Z</Dimension>
-   <Style>    <Name>windbarb/point</Name>    <Title>windbarb/point</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testCSVReader_reference_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=wind&amp;format=image/png&amp;STYLE=windbarb/point"/>    </LegendURL>  </Style>   <Style>    <Name>windvector/point</Name>    <Title>windvector/point</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testCSVReader_reference_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=wind&amp;format=image/png&amp;STYLE=windvector/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>windbarb/point</Name>
+    <Title>windbarb/point</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testCSVReader_reference_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=wind&amp;format=image/png&amp;STYLE=windbarb/point"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>windvector/point</Name>
+    <Title>windvector/point</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testCSVReader_reference_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=wind&amp;format=image/png&amp;STYLE=windvector/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>index</Name>
 <Title>Index</Title>
@@ -146,12 +165,21 @@
 <BoundingBox CRS="EPSG:4258" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:4326" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
 <BoundingBox CRS="EPSG:54030" minx="20763.744634" miny="5129624.479875" maxx="20763.744634" maxy="5129626.479875" />
 <BoundingBox CRS="EPSG:7399" minx="19479.628720" miny="5673073.474727" maxx="19479.628720" maxy="5673075.474727" />
 <BoundingBox CRS="EPSG:900913" minx="27829.872698" miny="6123506.170632" maxx="27829.872698" maxy="6123508.170632" />
 <Dimension name="time" units="ISO8601" default="2018-12-04T12:10:00Z" multipleValues="1" nearestValue="0" current="1">2018-12-04T12:00:00Z,2018-12-04T12:05:00Z,2018-12-04T12:10:00Z</Dimension>
 <Dimension name="reference_time" units="ISO8601" default="2018-12-04T12:05:00Z" multipleValues="1" nearestValue="0" current="1">2018-12-04T12:00:00Z,2018-12-04T12:05:00Z</Dimension>
-   <Style>    <Name>name/point</Name>    <Title>name/point</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testCSVReader_reference_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=index&amp;format=image/png&amp;STYLE=name/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>name/point</Name>
+    <Title>name/point</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testCSVReader_reference_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=index&amp;format=image/png&amp;STYLE=name/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>name</Name>
 <Title>Name</Title>
@@ -175,12 +203,21 @@
 <BoundingBox CRS="EPSG:4258" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:4326" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
 <BoundingBox CRS="EPSG:54030" minx="20763.744634" miny="5129624.479875" maxx="20763.744634" maxy="5129626.479875" />
 <BoundingBox CRS="EPSG:7399" minx="19479.628720" miny="5673073.474727" maxx="19479.628720" maxy="5673075.474727" />
 <BoundingBox CRS="EPSG:900913" minx="27829.872698" miny="6123506.170632" maxx="27829.872698" maxy="6123508.170632" />
 <Dimension name="time" units="ISO8601" default="2018-12-04T12:10:00Z" multipleValues="1" nearestValue="0" current="1">2018-12-04T12:00:00Z,2018-12-04T12:05:00Z,2018-12-04T12:10:00Z</Dimension>
 <Dimension name="reference_time" units="ISO8601" default="2018-12-04T12:05:00Z" multipleValues="1" nearestValue="0" current="1">2018-12-04T12:00:00Z,2018-12-04T12:05:00Z</Dimension>
-   <Style>    <Name>name/point</Name>    <Title>name/point</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testCSVReader_reference_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=name&amp;format=image/png&amp;STYLE=name/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>name/point</Name>
+    <Title>name/point</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testCSVReader_reference_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=name&amp;format=image/png&amp;STYLE=name/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestConvertLatLonBnds/test_ConvertLatLonBnds_getCapabilities.xml
+++ b/tests/expectedoutputs/TestConvertLatLonBnds/test_ConvertLatLonBnds_getCapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 19 2025 08:49:47 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=example_file_latlonbnds%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="51.000000" miny="3.000000" maxx="53.000000" maxy="7.000000" />
 <BoundingBox CRS="EPSG:4326" minx="51.000000" miny="3.000000" maxx="53.000000" maxy="7.000000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2222484.709163" miny="-2492318.258747" maxx="2548227.202889" maxy="-2219400.154905" />
 <BoundingBox CRS="EPSG:54030" minx="240542.924370" miny="5430131.345542" maxx="569872.152023" maxy="5635244.448398" />
 <BoundingBox CRS="EPSG:7399" minx="218886.997619" miny="5977787.767639" maxx="525373.296180" maxy="6183922.479106" />
 <BoundingBox CRS="EPSG:900913" minx="333958.472380" miny="6621293.722740" maxx="779236.435553" maxy="6982997.920390" />
@@ -117,12 +119,57 @@
 <BoundingBox CRS="EPSG:4258" minx="51.000000" miny="3.000000" maxx="53.000000" maxy="7.000000" />
 <BoundingBox CRS="EPSG:4326" minx="51.000000" miny="3.000000" maxx="53.000000" maxy="7.000000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2222484.709163" miny="-2492318.258747" maxx="2548227.202889" maxy="-2219400.154905" />
 <BoundingBox CRS="EPSG:54030" minx="240542.924370" miny="5430131.345542" maxx="569872.152023" maxy="5635244.448398" />
 <BoundingBox CRS="EPSG:7399" minx="218886.997619" miny="5977787.767639" maxx="525373.296180" maxy="6183922.479106" />
 <BoundingBox CRS="EPSG:900913" minx="333958.472380" miny="6621293.722740" maxx="779236.435553" maxy="6982997.920390" />
 <Dimension name="time" units="ISO8601" default="2024-06-01T02:00:00Z" multipleValues="1" nearestValue="0" current="1">2024-06-01T00:00:00Z,2024-06-01T01:00:00Z,2024-06-01T02:00:00Z</Dimension>
 <Dimension name="threshold" units="1" default="40" multipleValues="1" nearestValue="0" >10,20,30,40</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=example_file_latlonbnds%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probability&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=example_file_latlonbnds%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probability&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=example_file_latlonbnds%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probability&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=example_file_latlonbnds%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probability&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=example_file_latlonbnds%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probability&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=example_file_latlonbnds%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probability&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=example_file_latlonbnds%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probability&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=example_file_latlonbnds%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probability&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=example_file_latlonbnds%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probability&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=example_file_latlonbnds%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probability&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestDataPostProcessor/test_DataPostProcessor_SubstractLevels_GetCapabilities.xml
+++ b/tests/expectedoutputs/TestDataPostProcessor/test_DataPostProcessor_SubstractLevels_GetCapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.6.0, of Mar  5 2026 13:00:40 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datapostproc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
@@ -117,12 +119,22 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
 <Dimension name="time" units="ISO8601" default="2017-01-01T00:10:00Z" multipleValues="1" nearestValue="0" current="1">2017-01-01T00:00:00Z,2017-01-01T00:05:00Z,2017-01-01T00:10:00Z</Dimension>
 <Dimension name="member" units="member number" default="member1" multipleValues="1" nearestValue="0" >member6,member5,member4,member3,member2,member1</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datapostproc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=output&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datapostproc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=output&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>RAD_NL25_PCP_CM</Name>
 <Title>Precipitation Radar NL</Title>
@@ -146,12 +158,21 @@
 <BoundingBox CRS="EPSG:4258" minx="48.895303" miny="0.000000" maxx="55.973600" maxy="10.856452" />
 <BoundingBox CRS="EPSG:4326" minx="48.895303" miny="0.000000" maxx="55.973600" maxy="10.856452" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2000000.000000" miny="-2703305.597319" maxx="2745713.040381" maxy="-1888346.216710" />
 <BoundingBox CRS="EPSG:54030" minx="0.000000" miny="5212368.744545" maxx="853649.694601" maxy="5936460.867117" />
 <BoundingBox CRS="EPSG:7399" minx="0.000000" miny="5757301.056717" maxx="763611.971696" maxy="6483919.801602" />
 <BoundingBox CRS="EPSG:900913" minx="0.000000" miny="6257115.219364" maxx="1208534.698398" maxy="7553161.958695" />
 <BoundingBox CRS="PROJ4:%2Bproj%3Dstere%20%2Blat_0%3D90%20%2Blon_0%3D0%20%2Blat_ts%3D60%20%2Ba%3D6378%2E14%20%2Bb%3D6356%2E75%20%2Bx_0%3D0%20y_0%3D0" minx="0.000000" miny="-4415002.985868" maxx="700002.419949" maxy="-3649999.338064" />
 <Dimension name="time" units="ISO8601" default="2021-06-22T20:00:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-22T20:00:00Z</Dimension>
-   <Style>    <Name>radar/nearest</Name>    <Title>radar/nearest</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datapostproc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RAD_NL25_PCP_CM&amp;format=image/png&amp;STYLE=radar/nearest"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>radar/nearest</Name>
+    <Title>radar/nearest</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datapostproc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RAD_NL25_PCP_CM&amp;format=image/png&amp;STYLE=radar/nearest"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>testdata</Name>
 <Title>Testdata (testdata)</Title>
@@ -175,10 +196,20 @@
 <BoundingBox CRS="EPSG:4258" minx="37.352373" miny="-27.248854" maxx="65.890829" maxy="32.682179" />
 <BoundingBox CRS="EPSG:4326" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
 <BoundingBox CRS="EPSG:54030" minx="-2010910.349488" miny="3994561.026658" maxx="2383791.664599" maxy="6899708.714622" />
 <BoundingBox CRS="EPSG:7399" minx="-1688218.598491" miny="4491365.234972" maxx="1973986.260472" maxy="7420353.104506" />
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datapostproc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datapostproc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>unscaled_fahrenheit</Name>
 <Title>air_temperature (unscaled_param)</Title>
@@ -202,13 +233,23 @@
 <BoundingBox CRS="EPSG:4258" minx="50.000000" miny="3.000000" maxx="55.000000" maxy="8.000000" />
 <BoundingBox CRS="EPSG:4326" minx="50.000000" miny="3.000000" maxx="55.000000" maxy="8.000000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2209682.661355" miny="-2616951.098794" maxx="2643437.209734" maxy="-1967483.524033" />
 <BoundingBox CRS="EPSG:54030" minx="236664.507768" miny="5326895.725983" maxx="655971.688193" maxy="5838367.444509" />
 <BoundingBox CRS="EPSG:7399" minx="212322.761361" miny="5873471.956211" maxx="608506.548968" maxy="6386579.968095" />
 <BoundingBox CRS="EPSG:900913" minx="333958.472380" miny="6446275.841017" maxx="890555.926346" maxy="7361866.113051" />
 <BoundingBox CRS="PROJ4:%2Bproj%3Dlonglat%20%2Bdatum%3DWGS84%20%2Bno_defs%20%2Btype%3Dcrs" minx="3.000000" miny="55.000000" maxx="8.000000" maxy="50.000000" />
 <Dimension name="time" units="ISO8601" default="2026-02-13T04:00:00Z" multipleValues="1" nearestValue="0" current="1">2026-02-13T00:00:00Z/2026-02-13T04:00:00Z/PT1H</Dimension>
 <Dimension name="reference_time" units="hours since 2026-02-13T00:00:00Z" default="2026-02-13T00:00:00Z" multipleValues="1" nearestValue="0" current="1">2026-02-13T00:00:00Z</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datapostproc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=unscaled_fahrenheit&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datapostproc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=unscaled_fahrenheit&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>scaled_fahrenheit</Name>
 <Title>air_temperature (scaled_param)</Title>
@@ -232,13 +273,23 @@
 <BoundingBox CRS="EPSG:4258" minx="50.000000" miny="3.000000" maxx="55.000000" maxy="8.000000" />
 <BoundingBox CRS="EPSG:4326" minx="50.000000" miny="3.000000" maxx="55.000000" maxy="8.000000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2209682.661355" miny="-2616951.098794" maxx="2643437.209734" maxy="-1967483.524033" />
 <BoundingBox CRS="EPSG:54030" minx="236664.507768" miny="5326895.725983" maxx="655971.688193" maxy="5838367.444509" />
 <BoundingBox CRS="EPSG:7399" minx="212322.761361" miny="5873471.956211" maxx="608506.548968" maxy="6386579.968095" />
 <BoundingBox CRS="EPSG:900913" minx="333958.472380" miny="6446275.841017" maxx="890555.926346" maxy="7361866.113051" />
 <BoundingBox CRS="PROJ4:%2Bproj%3Dlonglat%20%2Bdatum%3DWGS84%20%2Bno_defs%20%2Btype%3Dcrs" minx="3.000000" miny="55.000000" maxx="8.000000" maxy="50.000000" />
 <Dimension name="time" units="ISO8601" default="2026-02-13T04:00:00Z" multipleValues="1" nearestValue="0" current="1">2026-02-13T00:00:00Z/2026-02-13T04:00:00Z/PT1H</Dimension>
 <Dimension name="reference_time" units="hours since 2026-02-13T00:00:00Z" default="2026-02-13T00:00:00Z" multipleValues="1" nearestValue="0" current="1">2026-02-13T00:00:00Z</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datapostproc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=scaled_fahrenheit&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datapostproc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=scaled_fahrenheit&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestDestineFloodmindData/test_GetCapabilities_NetCDF_WithEnsembleDim_WithoutEnsembleVariable.xml
+++ b/tests/expectedoutputs/TestDestineFloodmindData/test_GetCapabilities_NetCDF_WithEnsembleDim_WithoutEnsembleVariable.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.6.0, of Mar 11 2026 09:23:04 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=destine_floodmind%2Fnetcdf_hdsr_small_no_ensemble_variable%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -92,6 +93,7 @@
 <BoundingBox CRS="EPSG:4258" minx="51.150654" miny="4.945222" maxx="53.159329" maxy="4.968126" />
 <BoundingBox CRS="EPSG:4326" minx="52.149667" miny="4.944852" maxx="52.158341" maxy="4.967753" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2375375.107913" miny="-2339707.406920" maxx="2377200.221029" maxy="-2338490.189162" />
 <BoundingBox CRS="EPSG:54030" minx="399084.043013" miny="5548268.037319" maxx="400958.369008" maxy="5549156.983893" />
 <BoundingBox CRS="EPSG:7399" minx="365219.491349" miny="6096796.961151" maxx="366955.352464" maxy="6097689.931110" />
 <BoundingBox CRS="EPSG:900913" minx="550458.429538" miny="6827232.541487" maxx="553007.690403" maxy="6828806.267347" />
@@ -119,16 +121,13 @@
 <BoundingBox CRS="EPSG:4258" minx="51.150654" miny="4.945222" maxx="53.159329" maxy="4.968126" />
 <BoundingBox CRS="EPSG:4326" minx="52.149667" miny="4.944852" maxx="52.158341" maxy="4.967753" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2375375.107913" miny="-2339707.406920" maxx="2377200.221029" maxy="-2338490.189162" />
 <BoundingBox CRS="EPSG:54030" minx="399084.043013" miny="5548268.037319" maxx="400958.369008" maxy="5549156.983893" />
 <BoundingBox CRS="EPSG:7399" minx="365219.491349" miny="6096796.961151" maxx="366955.352464" maxy="6097689.931110" />
 <BoundingBox CRS="EPSG:900913" minx="550458.429538" miny="6827232.541487" maxx="553007.690403" maxy="6828806.267347" />
 <BoundingBox CRS="PROJ4:%2Bproj%3Dsterea%20%2Blat_0%3D52%2E15616055555555%20%2Blon_0%3D5%2E38763888888889%20%2Bk%3D0%2E9999079%20%2Bx_0%3D155000%20%2By_0%3D463000%20%2Bellps%3Dbessel%20%2Btowgs84%3D565%2E4171%2C50%2E3319%2C465%2E5524%2C%2D0%2E398957388243134%2C0%2E343987817378283%2C%2D1%2E87740163998045%2C4%2E0725%20%2Bunits%3Dm%20%2Bno_defs" minx="124730.272197" miny="462479.663931" maxx="126291.845180" maxy="463435.448045" />
-
-<!-- Dimensions -->
 <Dimension name="time" units="ISO8601" default="2020-01-01T22:00:00Z" multipleValues="1" nearestValue="0" current="1">2020-01-01T00:00:00Z/2020-01-01T22:00:00Z/PT1H</Dimension>
 <Dimension name="ensemble" units="1" default="3" multipleValues="1" nearestValue="0" >1,2,3</Dimension>
-
-<!-- Styles -->
    <Style>
     <Name>auto/nearest</Name>
     <Title>Auto style blue-white-red</Title>

--- a/tests/expectedoutputs/TestGeoJSON/test_GeoJSON_time_GetCapabilities.xml
+++ b/tests/expectedoutputs/TestGeoJSON/test_GeoJSON_time_GetCapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 3.1.2, of Jun 30 2025 11:29:01 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testGeoJSONReader_time&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="43.580391" miny="22.500000" maxx="50.064192" maxy="30.937500" />
 <BoundingBox CRS="EPSG:4326" minx="43.580391" miny="22.500000" maxx="50.064192" maxy="30.937500" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="3766180.814882" miny="-3029613.058561" maxx="4798782.508589" maxy="-1958634.440993" />
 <BoundingBox CRS="EPSG:54030" minx="1844087.875547" miny="4655537.216460" maxx="2641501.603111" maxy="5333535.398077" />
 <BoundingBox CRS="EPSG:7399" minx="1709981.705414" miny="5185535.942585" maxx="2537039.886805" maxy="5880192.535616" />
 <BoundingBox CRS="EPSG:900913" minx="2504688.542849" miny="5400734.670517" maxx="3443946.746417" maxy="6457400.149532" />
@@ -117,11 +119,20 @@
 <BoundingBox CRS="EPSG:4258" minx="43.580391" miny="22.500000" maxx="50.064192" maxy="30.937500" />
 <BoundingBox CRS="EPSG:4326" minx="43.580391" miny="22.500000" maxx="50.064192" maxy="30.937500" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="3766180.814882" miny="-3029613.058561" maxx="4798782.508589" maxy="-1958634.440993" />
 <BoundingBox CRS="EPSG:54030" minx="1844087.875547" miny="4655537.216460" maxx="2641501.603111" maxy="5333535.398077" />
 <BoundingBox CRS="EPSG:7399" minx="1709981.705414" miny="5185535.942585" maxx="2537039.886805" maxy="5880192.535616" />
 <BoundingBox CRS="EPSG:900913" minx="2504688.542849" miny="5400734.670517" maxx="3443946.746417" maxy="6457400.149532" />
 <Dimension name="time" units="ISO8601" default="2018-12-04T12:10:00Z" multipleValues="1" nearestValue="0" current="1">2018-12-04T12:00:00Z,2018-12-04T12:05:00Z,2018-12-04T12:10:00Z</Dimension>
-   <Style>    <Name>features/nearest</Name>    <Title>features/nearest</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testGeoJSONReader_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=features&amp;format=image/png&amp;STYLE=features/nearest"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>features/nearest</Name>
+    <Title>features/nearest</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testGeoJSONReader_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=features&amp;format=image/png&amp;STYLE=features/nearest"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestRendering/test_RenderingGeoJSON_time_GetCapabilities.xml
+++ b/tests/expectedoutputs/TestRendering/test_RenderingGeoJSON_time_GetCapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 4.3.7, of Nov  4 2025 11:45:31 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testGeoJSONReader_time&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="43.580391" miny="22.500000" maxx="50.064192" maxy="30.937500" />
 <BoundingBox CRS="EPSG:4326" minx="43.580391" miny="22.500000" maxx="50.064192" maxy="30.937500" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="3766180.814882" miny="-3029613.058561" maxx="4798782.508589" maxy="-1958634.440993" />
 <BoundingBox CRS="EPSG:54030" minx="1844087.875547" miny="4655537.216460" maxx="2641501.603111" maxy="5333535.398077" />
 <BoundingBox CRS="EPSG:7399" minx="1709981.705414" miny="5185535.942585" maxx="2537039.886805" maxy="5880192.535616" />
 <BoundingBox CRS="EPSG:900913" minx="2504688.542849" miny="5400734.670517" maxx="3443946.746417" maxy="6457400.149532" />
@@ -117,11 +119,20 @@
 <BoundingBox CRS="EPSG:4258" minx="43.580391" miny="22.500000" maxx="50.064192" maxy="30.937500" />
 <BoundingBox CRS="EPSG:4326" minx="43.580391" miny="22.500000" maxx="50.064192" maxy="30.937500" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="3766180.814882" miny="-3029613.058561" maxx="4798782.508589" maxy="-1958634.440993" />
 <BoundingBox CRS="EPSG:54030" minx="1844087.875547" miny="4655537.216460" maxx="2641501.603111" maxy="5333535.398077" />
 <BoundingBox CRS="EPSG:7399" minx="1709981.705414" miny="5185535.942585" maxx="2537039.886805" maxy="5880192.535616" />
 <BoundingBox CRS="EPSG:900913" minx="2504688.542849" miny="5400734.670517" maxx="3443946.746417" maxy="6457400.149532" />
 <Dimension name="time" units="ISO8601" default="2018-12-04T12:10:00Z" multipleValues="1" nearestValue="0" current="1">2018-12-04T12:00:00Z,2018-12-04T12:05:00Z,2018-12-04T12:10:00Z</Dimension>
-   <Style>    <Name>features/nearest</Name>    <Title>features/nearest</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testGeoJSONReader_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=features&amp;format=image/png&amp;STYLE=features/nearest"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>features/nearest</Name>
+    <Title>features/nearest</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testGeoJSONReader_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=features&amp;format=image/png&amp;STYLE=features/nearest"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWCS/test_WCSDescribeCoverage_Multidimdata.xml
+++ b/tests/expectedoutputs/TestWCS/test_WCSDescribeCoverage_Multidimdata.xml
@@ -78,13 +78,17 @@
           <gml:pos>-2000000.000000 -2000000.000000</gml:pos>
           <gml:pos>10000000.000000 8500000.000000</gml:pos>
         </gml:Envelope>
+        <gml:Envelope srsName="EPSG:5041">
+          <gml:pos>-407173329.856895 -406795071.401436</gml:pos>
+          <gml:pos>411420024.012517 411546161.390658</gml:pos>
+        </gml:Envelope>
         <gml:Envelope srsName="EPSG:54030">
           <gml:pos>-16294244.470419 -8493172.970167</gml:pos>
           <gml:pos>16956530.805045 8610630.466538</gml:pos>
         </gml:Envelope>
         <gml:Envelope srsName="EPSG:7399">
           <gml:pos>-17284159.484400 -8898366.230070</gml:pos>
-          <gml:pos>17986681.325950 9020047.848074</gml:pos>
+          <gml:pos>17986681.325950 9011275.281223</gml:pos>
         </gml:Envelope>
         <gml:Envelope srsName="EPSG:900913">
           <gml:pos>-19201993.871211 -22228632.557364</gml:pos>
@@ -185,6 +189,7 @@
       <requestResponseCRSs>EPSG:4258</requestResponseCRSs>
       <requestResponseCRSs>EPSG:4326</requestResponseCRSs>
       <requestResponseCRSs>EPSG:50001</requestResponseCRSs>
+      <requestResponseCRSs>EPSG:5041</requestResponseCRSs>
       <requestResponseCRSs>EPSG:54030</requestResponseCRSs>
       <requestResponseCRSs>EPSG:7399</requestResponseCRSs>
       <requestResponseCRSs>EPSG:900913</requestResponseCRSs>

--- a/tests/expectedoutputs/TestWCS/test_WCSDescribeCoverage_Multidimdata_99_timesteps.xml
+++ b/tests/expectedoutputs/TestWCS/test_WCSDescribeCoverage_Multidimdata_99_timesteps.xml
@@ -83,6 +83,10 @@
           <gml:pos>-2000000.000000 -2000000.000000</gml:pos>
           <gml:pos>10000000.000000 8500000.000000</gml:pos>
         </gml:Envelope>
+        <gml:Envelope srsName="EPSG:5041">
+          <gml:pos>-956875261.313672 -956583178.620243</gml:pos>
+          <gml:pos>959123209.982084 959999102.204602</gml:pos>
+        </gml:Envelope>
         <gml:Envelope srsName="EPSG:54030">
           <gml:pos>-16769347.747524 -8576525.559211</gml:pos>
           <gml:pos>16485922.151792 8537587.027768</gml:pos>
@@ -154,6 +158,7 @@
       <requestResponseCRSs>EPSG:4258</requestResponseCRSs>
       <requestResponseCRSs>EPSG:4326</requestResponseCRSs>
       <requestResponseCRSs>EPSG:50001</requestResponseCRSs>
+      <requestResponseCRSs>EPSG:5041</requestResponseCRSs>
       <requestResponseCRSs>EPSG:54030</requestResponseCRSs>
       <requestResponseCRSs>EPSG:7399</requestResponseCRSs>
       <requestResponseCRSs>EPSG:900913</requestResponseCRSs>

--- a/tests/expectedoutputs/TestWCS/test_WCSDescribeCoverage_Multidimdata_large_2day_height.xml
+++ b/tests/expectedoutputs/TestWCS/test_WCSDescribeCoverage_Multidimdata_large_2day_height.xml
@@ -83,6 +83,10 @@
           <gml:pos>-2000000.000000 -2000000.000000</gml:pos>
           <gml:pos>10000000.000000 8500000.000000</gml:pos>
         </gml:Envelope>
+        <gml:Envelope srsName="EPSG:5041">
+          <gml:pos>-476720074.926217 -477304033.059373</gml:pos>
+          <gml:pos>481304033.059373 480720074.926217</gml:pos>
+        </gml:Envelope>
         <gml:Envelope srsName="EPSG:54030">
           <gml:pos>-16532317.502283 -8516243.829905</gml:pos>
           <gml:pos>16721258.273737 8419013.706324</gml:pos>
@@ -171,6 +175,7 @@
       <requestResponseCRSs>EPSG:4258</requestResponseCRSs>
       <requestResponseCRSs>EPSG:4326</requestResponseCRSs>
       <requestResponseCRSs>EPSG:50001</requestResponseCRSs>
+      <requestResponseCRSs>EPSG:5041</requestResponseCRSs>
       <requestResponseCRSs>EPSG:54030</requestResponseCRSs>
       <requestResponseCRSs>EPSG:7399</requestResponseCRSs>
       <requestResponseCRSs>EPSG:900913</requestResponseCRSs>

--- a/tests/expectedoutputs/TestWCS/test_WCSDescribeCoverage_Multidimdata_large_daily.xml
+++ b/tests/expectedoutputs/TestWCS/test_WCSDescribeCoverage_Multidimdata_large_daily.xml
@@ -83,6 +83,10 @@
           <gml:pos>-2000000.000000 -2000000.000000</gml:pos>
           <gml:pos>10000000.000000 8500000.000000</gml:pos>
         </gml:Envelope>
+        <gml:Envelope srsName="EPSG:5041">
+          <gml:pos>-956875261.313672 -956583178.620243</gml:pos>
+          <gml:pos>959123209.982084 959999102.204602</gml:pos>
+        </gml:Envelope>
         <gml:Envelope srsName="EPSG:54030">
           <gml:pos>-16769347.747524 -8576525.559211</gml:pos>
           <gml:pos>16485922.151792 8537587.027768</gml:pos>
@@ -154,6 +158,7 @@
       <requestResponseCRSs>EPSG:4258</requestResponseCRSs>
       <requestResponseCRSs>EPSG:4326</requestResponseCRSs>
       <requestResponseCRSs>EPSG:50001</requestResponseCRSs>
+      <requestResponseCRSs>EPSG:5041</requestResponseCRSs>
       <requestResponseCRSs>EPSG:54030</requestResponseCRSs>
       <requestResponseCRSs>EPSG:7399</requestResponseCRSs>
       <requestResponseCRSs>EPSG:900913</requestResponseCRSs>

--- a/tests/expectedoutputs/TestWCS/test_WCSDescribeCoverage_Multidimdata_large_random.xml
+++ b/tests/expectedoutputs/TestWCS/test_WCSDescribeCoverage_Multidimdata_large_random.xml
@@ -78,6 +78,10 @@
           <gml:pos>-2000000.000000 -2000000.000000</gml:pos>
           <gml:pos>10000000.000000 8500000.000000</gml:pos>
         </gml:Envelope>
+        <gml:Envelope srsName="EPSG:5041">
+          <gml:pos>-956875261.313672 -956583178.620243</gml:pos>
+          <gml:pos>959123209.982084 959999102.204602</gml:pos>
+        </gml:Envelope>
         <gml:Envelope srsName="EPSG:54030">
           <gml:pos>-16769347.747524 -8576525.559211</gml:pos>
           <gml:pos>16485922.151792 8537587.027768</gml:pos>
@@ -353,6 +357,7 @@
       <requestResponseCRSs>EPSG:4258</requestResponseCRSs>
       <requestResponseCRSs>EPSG:4326</requestResponseCRSs>
       <requestResponseCRSs>EPSG:50001</requestResponseCRSs>
+      <requestResponseCRSs>EPSG:5041</requestResponseCRSs>
       <requestResponseCRSs>EPSG:54030</requestResponseCRSs>
       <requestResponseCRSs>EPSG:7399</requestResponseCRSs>
       <requestResponseCRSs>EPSG:900913</requestResponseCRSs>

--- a/tests/expectedoutputs/TestWCS/test_WCSDescribeCoverage_testdatanc.xml
+++ b/tests/expectedoutputs/TestWCS/test_WCSDescribeCoverage_testdatanc.xml
@@ -78,6 +78,10 @@
           <gml:pos>-2000000.000000 -2000000.000000</gml:pos>
           <gml:pos>10000000.000000 8500000.000000</gml:pos>
         </gml:Envelope>
+        <gml:Envelope srsName="EPSG:5041">
+          <gml:pos>-7498001.230434 -8223848.076474</gml:pos>
+          <gml:pos>3272454.133168 535002.459267</gml:pos>
+        </gml:Envelope>
         <gml:Envelope srsName="EPSG:54030">
           <gml:pos>-6408021.286199 1297326.829390</gml:pos>
           <gml:pos>670998.883042 5878649.483190</gml:pos>
@@ -138,6 +142,7 @@
       <requestResponseCRSs>EPSG:4258</requestResponseCRSs>
       <requestResponseCRSs>EPSG:4326</requestResponseCRSs>
       <requestResponseCRSs>EPSG:50001</requestResponseCRSs>
+      <requestResponseCRSs>EPSG:5041</requestResponseCRSs>
       <requestResponseCRSs>EPSG:54030</requestResponseCRSs>
       <requestResponseCRSs>EPSG:7399</requestResponseCRSs>
       <requestResponseCRSs>EPSG:900913</requestResponseCRSs>
@@ -227,6 +232,10 @@
           <gml:pos>-2000000.000000 -2000000.000000</gml:pos>
           <gml:pos>10000000.000000 8500000.000000</gml:pos>
         </gml:Envelope>
+        <gml:Envelope srsName="EPSG:5041">
+          <gml:pos>-7498001.230434 -8223848.076474</gml:pos>
+          <gml:pos>3272454.133168 535002.459267</gml:pos>
+        </gml:Envelope>
         <gml:Envelope srsName="EPSG:54030">
           <gml:pos>-6408021.286199 1297326.829390</gml:pos>
           <gml:pos>670998.883042 5878649.483190</gml:pos>
@@ -287,6 +296,7 @@
       <requestResponseCRSs>EPSG:4258</requestResponseCRSs>
       <requestResponseCRSs>EPSG:4326</requestResponseCRSs>
       <requestResponseCRSs>EPSG:50001</requestResponseCRSs>
+      <requestResponseCRSs>EPSG:5041</requestResponseCRSs>
       <requestResponseCRSs>EPSG:54030</requestResponseCRSs>
       <requestResponseCRSs>EPSG:7399</requestResponseCRSs>
       <requestResponseCRSs>EPSG:900913</requestResponseCRSs>
@@ -376,6 +386,10 @@
           <gml:pos>-2000000.000000 -2000000.000000</gml:pos>
           <gml:pos>10000000.000000 8500000.000000</gml:pos>
         </gml:Envelope>
+        <gml:Envelope srsName="EPSG:5041">
+          <gml:pos>-7498001.230434 -8223848.076474</gml:pos>
+          <gml:pos>3272454.133168 535002.459267</gml:pos>
+        </gml:Envelope>
         <gml:Envelope srsName="EPSG:54030">
           <gml:pos>-6408021.286199 1297326.829390</gml:pos>
           <gml:pos>670998.883042 5878649.483190</gml:pos>
@@ -436,6 +450,7 @@
       <requestResponseCRSs>EPSG:4258</requestResponseCRSs>
       <requestResponseCRSs>EPSG:4326</requestResponseCRSs>
       <requestResponseCRSs>EPSG:50001</requestResponseCRSs>
+      <requestResponseCRSs>EPSG:5041</requestResponseCRSs>
       <requestResponseCRSs>EPSG:54030</requestResponseCRSs>
       <requestResponseCRSs>EPSG:7399</requestResponseCRSs>
       <requestResponseCRSs>EPSG:900913</requestResponseCRSs>

--- a/tests/expectedoutputs/TestWCS/test_WCSGetCapabilities_testdatanc.xml
+++ b/tests/expectedoutputs/TestWCS/test_WCSGetCapabilities_testdatanc.xml
@@ -11,7 +11,7 @@
   <name>ADAGUC_AUTO_WCS_AutoResource testdata.nc</name>
   <label>ADAGUC_AUTO_WCS_AutoResource testdata.nc</label>
   <abstract>ADAGUC_AUTO_WCS_AutoResource testdata.nc</abstract>
-  <ServerInfo>ADAGUCServer version 2.27.0, of Sep  6 2024 09:44:02</ServerInfo>
+  <ServerInfo>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55</ServerInfo>
   <fees>NONE</fees>
   <accessConstraints>
     NONE

--- a/tests/expectedoutputs/TestWMS/testWMSGetCapabilities_quantizehigh.xml
+++ b/tests/expectedoutputs/TestWMS/testWMSGetCapabilities_quantizehigh.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 3.1.2, of Jun 30 2025 11:29:01 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.quantizehigh&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:4326" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
 <BoundingBox CRS="EPSG:54030" minx="20763.744634" miny="5129624.479875" maxx="20763.744634" maxy="5129626.479875" />
 <BoundingBox CRS="EPSG:7399" minx="19479.628720" miny="5673073.474727" maxx="19479.628720" maxy="5673075.474727" />
 <BoundingBox CRS="EPSG:900913" minx="27829.872698" miny="6123506.170632" maxx="27829.872698" maxy="6123508.170632" />
@@ -117,11 +119,21 @@
 <BoundingBox CRS="EPSG:4258" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:4326" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
 <BoundingBox CRS="EPSG:54030" minx="20763.744634" miny="5129624.479875" maxx="20763.744634" maxy="5129626.479875" />
 <BoundingBox CRS="EPSG:7399" minx="19479.628720" miny="5673073.474727" maxx="19479.628720" maxy="5673075.474727" />
 <BoundingBox CRS="EPSG:900913" minx="27829.872698" miny="6123506.170632" maxx="27829.872698" maxy="6123508.170632" />
 <Dimension name="time" units="ISO8601" default="2018-12-04T13:00:00Z" multipleValues="1" nearestValue="0" current="1">2018-12-04T12:10:00Z/2018-12-04T13:00:00Z/PT10M</Dimension>
-   <Style>    <Name>default</Name>    <Title>default</Title>    <Abstract>default</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.quantizehigh&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=wind&amp;format=image/png&amp;STYLE=default"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>default</Name>
+    <Title>default</Title>
+    <Abstract>default</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.quantizehigh&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=wind&amp;format=image/png&amp;STYLE=default"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/testWMSGetCapabilities_quantizelow.xml
+++ b/tests/expectedoutputs/TestWMS/testWMSGetCapabilities_quantizelow.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 3.1.2, of Jun 30 2025 11:29:01 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.quantizelow&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:4326" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
 <BoundingBox CRS="EPSG:54030" minx="20763.744634" miny="5129624.479875" maxx="20763.744634" maxy="5129626.479875" />
 <BoundingBox CRS="EPSG:7399" minx="19479.628720" miny="5673073.474727" maxx="19479.628720" maxy="5673075.474727" />
 <BoundingBox CRS="EPSG:900913" minx="27829.872698" miny="6123506.170632" maxx="27829.872698" maxy="6123508.170632" />
@@ -117,11 +119,21 @@
 <BoundingBox CRS="EPSG:4258" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:4326" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
 <BoundingBox CRS="EPSG:54030" minx="20763.744634" miny="5129624.479875" maxx="20763.744634" maxy="5129626.479875" />
 <BoundingBox CRS="EPSG:7399" minx="19479.628720" miny="5673073.474727" maxx="19479.628720" maxy="5673075.474727" />
 <BoundingBox CRS="EPSG:900913" minx="27829.872698" miny="6123506.170632" maxx="27829.872698" maxy="6123508.170632" />
 <Dimension name="time" units="ISO8601" default="2018-12-04T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2018-12-04T12:00:00Z,2018-12-04T12:10:00Z,2018-12-04T12:20:00Z,2018-12-04T12:40:00Z</Dimension>
-   <Style>    <Name>default</Name>    <Title>default</Title>    <Abstract>default</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.quantizelow&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=wind&amp;format=image/png&amp;STYLE=default"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>default</Name>
+    <Title>default</Title>
+    <Abstract>default</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.quantizelow&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=wind&amp;format=image/png&amp;STYLE=default"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/testWMSGetCapabilities_quantizeround.xml
+++ b/tests/expectedoutputs/TestWMS/testWMSGetCapabilities_quantizeround.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 3.1.2, of Jun 30 2025 11:29:01 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.quantizeround&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:4326" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
 <BoundingBox CRS="EPSG:54030" minx="20763.744634" miny="5129624.479875" maxx="20763.744634" maxy="5129626.479875" />
 <BoundingBox CRS="EPSG:7399" minx="19479.628720" miny="5673073.474727" maxx="19479.628720" maxy="5673075.474727" />
 <BoundingBox CRS="EPSG:900913" minx="27829.872698" miny="6123506.170632" maxx="27829.872698" maxy="6123508.170632" />
@@ -117,11 +119,21 @@
 <BoundingBox CRS="EPSG:4258" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:4326" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
 <BoundingBox CRS="EPSG:54030" minx="20763.744634" miny="5129624.479875" maxx="20763.744634" maxy="5129626.479875" />
 <BoundingBox CRS="EPSG:7399" minx="19479.628720" miny="5673073.474727" maxx="19479.628720" maxy="5673075.474727" />
 <BoundingBox CRS="EPSG:900913" minx="27829.872698" miny="6123506.170632" maxx="27829.872698" maxy="6123508.170632" />
 <Dimension name="time" units="ISO8601" default="2018-12-04T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2018-12-04T12:00:00Z/2018-12-04T12:40:00Z/PT10M</Dimension>
-   <Style>    <Name>default</Name>    <Title>default</Title>    <Abstract>default</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.quantizeround&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=wind&amp;format=image/png&amp;STYLE=default"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>default</Name>
+    <Title>default</Title>
+    <Abstract>default</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.quantizeround&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=wind&amp;format=image/png&amp;STYLE=default"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDBPathFileInSubfoldersGetCapabilities.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDBPathFileInSubfoldersGetCapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 18 2025 12:39:18 </Keyword>
+            <Keyword>ADAGUCServer version 6.6.0, of Mar 11 2026 11:07:16 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testScanPathSubfolder&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -124,7 +124,15 @@
 <BoundingBox CRS="EPSG:900913" minx="0.000000" miny="6257115.219364" maxx="1208534.698398" maxy="7553161.958695" />
 <BoundingBox CRS="PROJ4:%2Bproj%3Dstere%20%2Blat_0%3D90%20%2Blon_0%3D0%20%2Blat_ts%3D60%20%2Ba%3D6378%2E14%20%2Bb%3D6356%2E75%20%2Bx_0%3D0%20y_0%3D0" minx="0.000000" miny="-4415002.985868" maxx="700002.419949" maxy="-3649999.338064" />
 <Dimension name="time" units="ISO8601" default="2021-06-22T20:00:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-22T20:00:00Z</Dimension>
-   <Style>    <Name>radar/nearest</Name>    <Title>radar/nearest</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testScanPathSubfolder&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RAD_NL25_PCP_CM&amp;format=image/png&amp;STYLE=radar/nearest"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>radar/nearest</Name>
+    <Title>radar/nearest</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testScanPathSubfolder&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RAD_NL25_PCP_CM&amp;format=image/png&amp;STYLE=radar/nearest"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDBPathFileWithNonMatchingPathGetCapabilities.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDBPathFileWithNonMatchingPathGetCapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 18 2025 12:39:18 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testScanPathSubfolderSuffix&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>

--- a/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDBTailPath_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDBTailPath_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.3.0, of Feb  6 2026 22:36:22 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
@@ -117,13 +119,50 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
 <Dimension name="time" units="ISO8601" default="2017-01-01T00:10:00Z" multipleValues="1" nearestValue="0" current="1">2017-01-01T00:00:00Z,2017-01-01T00:05:00Z,2017-01-01T00:10:00Z</Dimension>
 <Dimension name="member" units="member number" default="member1" multipleValues="1" nearestValue="0" >member6,member5,member4,member3,member2,member1</Dimension>
 <Dimension name="elevation" units="meters" default="9000" multipleValues="1" nearestValue="0" >1000,2000,3000,4000,5000,6000,7000,8000,9000</Dimension>
-   <Style>    <Name>testdata/nearest</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/bilinear</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/bilinear"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/nearestcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearestcontour"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/shadedcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/shadedcontour"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>testdata/nearest</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/bilinear</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/bilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/nearestcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearestcontour"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/shadedcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/shadedcontour"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDBTailPath_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1_and_seq2.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDBTailPath_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1_and_seq2.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.3.0, of Feb  6 2026 22:36:22 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
@@ -117,13 +119,50 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
 <Dimension name="time" units="ISO8601" default="2017-01-01T00:25:00Z" multipleValues="1" nearestValue="0" current="1">2017-01-01T00:00:00Z/2017-01-01T00:25:00Z/PT5M</Dimension>
 <Dimension name="member" units="member number" default="member1" multipleValues="1" nearestValue="0" >member6,member5,member4,member3,member2,member1</Dimension>
 <Dimension name="elevation" units="meters" default="9000" multipleValues="1" nearestValue="0" >1000,2000,3000,4000,5000,6000,7000,8000,9000</Dimension>
-   <Style>    <Name>testdata/nearest</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/bilinear</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/bilinear"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/nearestcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearestcontour"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/shadedcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/shadedcontour"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>testdata/nearest</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/bilinear</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/bilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/nearestcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearestcontour"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/shadedcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/shadedcontour"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDB_WMSGetCapabilities_timeseries_twofiles.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDB_WMSGetCapabilities_timeseries_twofiles.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.6.0, of Mar  9 2026 11:27:22 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
@@ -117,13 +119,50 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
 <Dimension name="time" units="ISO8601" default="2017-01-01T00:25:00Z" multipleValues="1" nearestValue="0" current="1">2017-01-01T00:00:00Z/2017-01-01T00:25:00Z/PT5M</Dimension>
 <Dimension name="member" units="member number" default="member1" multipleValues="1" nearestValue="0" >member6,member5,member4,member3,member2,member1</Dimension>
 <Dimension name="elevation" units="meters" default="9000" multipleValues="1" nearestValue="0" >1000,2000,3000,4000,5000,6000,7000,8000,9000</Dimension>
-   <Style>    <Name>testdata/nearest</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/bilinear</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/bilinear"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/nearestcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearestcontour"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/shadedcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/shadedcontour"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>testdata/nearest</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/bilinear</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/bilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/nearestcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearestcontour"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/shadedcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/shadedcontour"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilitiesGetMap_testdatanc_WMSGetCapabilities_testdatanc.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilitiesGetMap_testdatanc_WMSGetCapabilities_testdatanc.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 19 2025 08:49:47 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="37.352373" miny="-27.248854" maxx="65.890829" maxy="32.682179" />
 <BoundingBox CRS="EPSG:4326" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
 <BoundingBox CRS="EPSG:54030" minx="-2010910.349488" miny="3994561.026658" maxx="2383791.664599" maxy="6899708.714622" />
 <BoundingBox CRS="EPSG:7399" minx="-1688218.598491" miny="4491365.234972" maxx="1973986.260472" maxy="7420353.104506" />
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
@@ -117,10 +119,55 @@
 <BoundingBox CRS="EPSG:4258" minx="37.352373" miny="-27.248854" maxx="65.890829" maxy="32.682179" />
 <BoundingBox CRS="EPSG:4326" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
 <BoundingBox CRS="EPSG:54030" minx="-2010910.349488" miny="3994561.026658" maxx="2383791.664599" maxy="6899708.714622" />
 <BoundingBox CRS="EPSG:7399" minx="-1688218.598491" miny="4491365.234972" maxx="1973986.260472" maxy="7420353.104506" />
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_403_default_time_referenced_to_forecast_time.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_403_default_time_referenced_to_forecast_time.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 3.1.2, of Jun 30 2025 11:29:01 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.403_default_time_referenced_to_forecast_time&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -92,6 +93,7 @@
 <BoundingBox CRS="EPSG:4258" minx="41.926322" miny="-5.197559" maxx="59.916479" maxy="19.363445" />
 <BoundingBox CRS="EPSG:4326" minx="41.926322" miny="-5.197559" maxx="59.916479" maxy="19.363445" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="1510492.846031" miny="-3551923.560319" maxx="3243352.395372" maxy="-1407852.277061" />
 <BoundingBox CRS="EPSG:54030" minx="-442976.950433" miny="4480694.298309" maxx="1499953.844268" maxy="6327856.290422" />
 <BoundingBox CRS="EPSG:7399" minx="-424845.011613" miny="5003557.056445" maxx="1323400.052562" maxy="6868776.212061" />
 <BoundingBox CRS="EPSG:900913" minx="-578589.671269" miny="5149949.146233" maxx="2155528.800430" maxy="8381166.264714" />
@@ -119,6 +121,7 @@
 <BoundingBox CRS="EPSG:4258" minx="41.926322" miny="-5.197559" maxx="59.916479" maxy="19.363445" />
 <BoundingBox CRS="EPSG:4326" minx="41.926322" miny="-5.197559" maxx="59.916479" maxy="19.363445" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="1510492.846031" miny="-3551923.560319" maxx="3243352.395372" maxy="-1407852.277061" />
 <BoundingBox CRS="EPSG:54030" minx="-442976.950433" miny="4480694.298309" maxx="1499953.844268" maxy="6327856.290422" />
 <BoundingBox CRS="EPSG:7399" minx="-424845.011613" miny="5003557.056445" maxx="1323400.052562" maxy="6868776.212061" />
 <BoundingBox CRS="EPSG:900913" minx="-578589.671269" miny="5149949.146233" maxx="2155528.800430" maxy="8381166.264714" />
@@ -126,7 +129,16 @@
 <Dimension name="time" units="ISO8601" default="2024-07-11T03:00:00Z" multipleValues="1" nearestValue="0" current="1">2024-07-11T03:00:00Z/2024-07-13T17:00:00Z/PT1H</Dimension>
 <Dimension name="reference_time" units="ISO8601" default="2024-07-11T05:00:00Z" multipleValues="1" nearestValue="0" current="1">2024-07-11T02:00:00Z,2024-07-11T03:00:00Z,2024-07-11T04:00:00Z,2024-07-11T05:00:00Z</Dimension>
 <Dimension name="pressure_level_in_hpa" units="hPa" default="925" multipleValues="1" nearestValue="0" >500,700,850,925</Dimension>
-   <Style>    <Name>default</Name>    <Title>default</Title>    <Abstract>default</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.403_default_time_referenced_to_forecast_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=time_default_min&amp;format=image/png&amp;STYLE=default"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>default</Name>
+    <Title>default</Title>
+    <Abstract>default</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.403_default_time_referenced_to_forecast_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=time_default_min&amp;format=image/png&amp;STYLE=default"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>time_default_max</Name>
 <Title>time_default_max</Title>
@@ -150,6 +162,7 @@
 <BoundingBox CRS="EPSG:4258" minx="41.926322" miny="-5.197559" maxx="59.916479" maxy="19.363445" />
 <BoundingBox CRS="EPSG:4326" minx="41.926322" miny="-5.197559" maxx="59.916479" maxy="19.363445" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="1510492.846031" miny="-3551923.560319" maxx="3243352.395372" maxy="-1407852.277061" />
 <BoundingBox CRS="EPSG:54030" minx="-442976.950433" miny="4480694.298309" maxx="1499953.844268" maxy="6327856.290422" />
 <BoundingBox CRS="EPSG:7399" minx="-424845.011613" miny="5003557.056445" maxx="1323400.052562" maxy="6868776.212061" />
 <BoundingBox CRS="EPSG:900913" minx="-578589.671269" miny="5149949.146233" maxx="2155528.800430" maxy="8381166.264714" />
@@ -157,7 +170,16 @@
 <Dimension name="time" units="ISO8601" default="2024-07-13T17:00:00Z" multipleValues="1" nearestValue="0" current="1">2024-07-11T03:00:00Z/2024-07-13T17:00:00Z/PT1H</Dimension>
 <Dimension name="reference_time" units="ISO8601" default="2024-07-11T05:00:00Z" multipleValues="1" nearestValue="0" current="1">2024-07-11T02:00:00Z,2024-07-11T03:00:00Z,2024-07-11T04:00:00Z,2024-07-11T05:00:00Z</Dimension>
 <Dimension name="pressure_level_in_hpa" units="hPa" default="925" multipleValues="1" nearestValue="0" >500,700,850,925</Dimension>
-   <Style>    <Name>default</Name>    <Title>default</Title>    <Abstract>default</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.403_default_time_referenced_to_forecast_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=time_default_max&amp;format=image/png&amp;STYLE=default"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>default</Name>
+    <Title>default</Title>
+    <Abstract>default</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.403_default_time_referenced_to_forecast_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=time_default_max&amp;format=image/png&amp;STYLE=default"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>time_default_forecast_reference_time</Name>
 <Title>time_default_forecast_reference_time</Title>
@@ -181,6 +203,7 @@
 <BoundingBox CRS="EPSG:4258" minx="41.926322" miny="-5.197559" maxx="59.916479" maxy="19.363445" />
 <BoundingBox CRS="EPSG:4326" minx="41.926322" miny="-5.197559" maxx="59.916479" maxy="19.363445" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="1510492.846031" miny="-3551923.560319" maxx="3243352.395372" maxy="-1407852.277061" />
 <BoundingBox CRS="EPSG:54030" minx="-442976.950433" miny="4480694.298309" maxx="1499953.844268" maxy="6327856.290422" />
 <BoundingBox CRS="EPSG:7399" minx="-424845.011613" miny="5003557.056445" maxx="1323400.052562" maxy="6868776.212061" />
 <BoundingBox CRS="EPSG:900913" minx="-578589.671269" miny="5149949.146233" maxx="2155528.800430" maxy="8381166.264714" />
@@ -188,7 +211,16 @@
 <Dimension name="time" units="ISO8601" default="2024-07-11T05:00:00Z" multipleValues="1" nearestValue="0" current="1">2024-07-11T03:00:00Z/2024-07-13T17:00:00Z/PT1H</Dimension>
 <Dimension name="reference_time" units="ISO8601" default="2024-07-11T05:00:00Z" multipleValues="1" nearestValue="0" current="1">2024-07-11T02:00:00Z,2024-07-11T03:00:00Z,2024-07-11T04:00:00Z,2024-07-11T05:00:00Z</Dimension>
 <Dimension name="pressure_level_in_hpa" units="hPa" default="925" multipleValues="1" nearestValue="0" >500,700,850,925</Dimension>
-   <Style>    <Name>default</Name>    <Title>default</Title>    <Abstract>default</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.403_default_time_referenced_to_forecast_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=time_default_forecast_reference_time&amp;format=image/png&amp;STYLE=default"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>default</Name>
+    <Title>default</Title>
+    <Abstract>default</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.403_default_time_referenced_to_forecast_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=time_default_forecast_reference_time&amp;format=image/png&amp;STYLE=default"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>time_default_forecast_reference_time_and_duration</Name>
 <Title>time_default_forecast_reference_time_and_duration</Title>
@@ -212,6 +244,7 @@
 <BoundingBox CRS="EPSG:4258" minx="41.926322" miny="-5.197559" maxx="59.916479" maxy="19.363445" />
 <BoundingBox CRS="EPSG:4326" minx="41.926322" miny="-5.197559" maxx="59.916479" maxy="19.363445" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="1510492.846031" miny="-3551923.560319" maxx="3243352.395372" maxy="-1407852.277061" />
 <BoundingBox CRS="EPSG:54030" minx="-442976.950433" miny="4480694.298309" maxx="1499953.844268" maxy="6327856.290422" />
 <BoundingBox CRS="EPSG:7399" minx="-424845.011613" miny="5003557.056445" maxx="1323400.052562" maxy="6868776.212061" />
 <BoundingBox CRS="EPSG:900913" minx="-578589.671269" miny="5149949.146233" maxx="2155528.800430" maxy="8381166.264714" />
@@ -219,7 +252,16 @@
 <Dimension name="time" units="ISO8601" default="2024-07-11T06:00:00Z" multipleValues="1" nearestValue="0" current="1">2024-07-11T03:00:00Z/2024-07-13T17:00:00Z/PT1H</Dimension>
 <Dimension name="reference_time" units="ISO8601" default="2024-07-11T05:00:00Z" multipleValues="1" nearestValue="0" current="1">2024-07-11T02:00:00Z,2024-07-11T03:00:00Z,2024-07-11T04:00:00Z,2024-07-11T05:00:00Z</Dimension>
 <Dimension name="pressure_level_in_hpa" units="hPa" default="925" multipleValues="1" nearestValue="0" >500,700,850,925</Dimension>
-   <Style>    <Name>default</Name>    <Title>default</Title>    <Abstract>default</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.403_default_time_referenced_to_forecast_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=time_default_forecast_reference_time_and_duration&amp;format=image/png&amp;STYLE=default"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>default</Name>
+    <Title>default</Title>
+    <Abstract>default</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.403_default_time_referenced_to_forecast_time&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=time_default_forecast_reference_time_and_duration&amp;format=image/png&amp;STYLE=default"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_DimensionUnits.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_DimensionUnits.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 19 2025 08:49:47 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.311-getcapabilities-dimension-units&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -92,6 +93,7 @@
 <BoundingBox CRS="EPSG:4258" minx="48.950000" miny="-0.050000" maxx="49.650000" maxy="1.050000" />
 <BoundingBox CRS="EPSG:4326" minx="48.950000" miny="-0.050000" maxx="49.650000" maxy="1.050000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="1995850.338946" miny="-2755161.899057" maxx="2087138.015594" maxy="-2666365.726464" />
 <BoundingBox CRS="EPSG:54030" minx="-4129.484085" miny="5218050.618405" maxx="86719.165778" maxy="5290663.240390" />
 <BoundingBox CRS="EPSG:7399" minx="-3854.940004" miny="5763075.644727" maxx="80953.740090" maxy="5836770.452716" />
 <BoundingBox CRS="EPSG:900913" minx="-5565.974540" miny="6266381.694671" maxx="116885.465333" maxy="6385881.202576" />
@@ -119,6 +121,7 @@
 <BoundingBox CRS="EPSG:4258" minx="48.950000" miny="-0.050000" maxx="49.650000" maxy="1.050000" />
 <BoundingBox CRS="EPSG:4326" minx="48.950000" miny="-0.050000" maxx="49.650000" maxy="1.050000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="1995850.338946" miny="-2755161.899057" maxx="2087138.015594" maxy="-2666365.726464" />
 <BoundingBox CRS="EPSG:54030" minx="-4129.484085" miny="5218050.618405" maxx="86719.165778" maxy="5290663.240390" />
 <BoundingBox CRS="EPSG:7399" minx="-3854.940004" miny="5763075.644727" maxx="80953.740090" maxy="5836770.452716" />
 <BoundingBox CRS="EPSG:900913" minx="-5565.974540" miny="6266381.694671" maxx="116885.465333" maxy="6385881.202576" />
@@ -126,7 +129,16 @@
 <Dimension name="time" units="ISO8601" default="2023-10-26T05:00:00Z" multipleValues="1" nearestValue="0" current="1">2023-10-26T05:00:00Z</Dimension>
 <Dimension name="reference_time" units="ISO8601" default="2023-10-26T00:00:00Z" multipleValues="1" nearestValue="0" current="1">2023-10-26T00:00:00Z</Dimension>
 <Dimension name="height_above_ground_level_in_m" units="m" default="10" multipleValues="1" nearestValue="0" >10</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.311-getcapabilities-dimension-units&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=wind-speed-of-gust-hagl&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.311-getcapabilities-dimension-units&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=wind-speed-of-gust-hagl&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_KMDS_PointNetCDF_pointstylepoint.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_KMDS_PointNetCDF_pointstylepoint.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 3.1.2, of Jun 30 2025 11:29:01 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
@@ -118,10 +120,20 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
-   <Style>    <Name>stationname/point</Name>    <Title>Richter magnitude scale</Title>    <Abstract>With discrete colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=stationname&amp;format=image/png&amp;STYLE=stationname/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>stationname/point</Name>
+    <Title>Richter magnitude scale</Title>
+    <Abstract>With discrete colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=stationname&amp;format=image/png&amp;STYLE=stationname/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>height</Name>
 <Title>stationshoogte [m]</Title>
@@ -146,10 +158,20 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
-   <Style>    <Name>height/point</Name>    <Title>Richter magnitude scale</Title>    <Abstract>With discrete colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=height&amp;format=image/png&amp;STYLE=height/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>height/point</Name>
+    <Title>Richter magnitude scale</Title>
+    <Abstract>With discrete colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=height&amp;format=image/png&amp;STYLE=height/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>dd</Name>
 <Title>windrichting [graden]</Title>
@@ -174,11 +196,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>wind_direction/point</Name>    <Title>Wind direction</Title>    <Abstract>With discrete colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=dd&amp;format=image/png&amp;STYLE=wind_direction/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>wind_direction/point</Name>
+    <Title>Wind direction</Title>
+    <Abstract>With discrete colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=dd&amp;format=image/png&amp;STYLE=wind_direction/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>ff</Name>
 <Title>windsnelheid [m/s]</Title>
@@ -203,11 +235,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>windspeed/point</Name>    <Title>Wind direction</Title>    <Abstract>With discrete colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ff&amp;format=image/png&amp;STYLE=windspeed/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>windspeed/point</Name>
+    <Title>Wind direction</Title>
+    <Abstract>With discrete colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ff&amp;format=image/png&amp;STYLE=windspeed/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>ff_dd</Name>
 <Title>windsnelheid [m/s] en windrichting [graden]</Title>
@@ -232,11 +274,48 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>windspeed_arrow/barb</Name>    <Title>Wind direction arrow</Title>    <Abstract>With an arrow on a disc.</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ff_dd&amp;format=image/png&amp;STYLE=windspeed_arrow/barb"/>    </LegendURL>  </Style>   <Style>    <Name>windspeed_vector/barb</Name>    <Title>Wind direction vector</Title>    <Abstract>As vector</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ff_dd&amp;format=image/png&amp;STYLE=windspeed_vector/barb"/>    </LegendURL>  </Style>   <Style>    <Name>windspeed_barb/barb</Name>    <Title>Wind direction barb</Title>    <Abstract>As barb</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ff_dd&amp;format=image/png&amp;STYLE=windspeed_barb/barb"/>    </LegendURL>  </Style>   <Style>    <Name>windspeed_barb_no_outline/barb</Name>    <Title>Wind direction barb no outline</Title>    <Abstract>As barb</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ff_dd&amp;format=image/png&amp;STYLE=windspeed_barb_no_outline/barb"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>windspeed_arrow/barb</Name>
+    <Title>Wind direction arrow</Title>
+    <Abstract>With an arrow on a disc.</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ff_dd&amp;format=image/png&amp;STYLE=windspeed_arrow/barb"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>windspeed_vector/barb</Name>
+    <Title>Wind direction vector</Title>
+    <Abstract>As vector</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ff_dd&amp;format=image/png&amp;STYLE=windspeed_vector/barb"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>windspeed_barb/barb</Name>
+    <Title>Wind direction barb</Title>
+    <Abstract>As barb</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ff_dd&amp;format=image/png&amp;STYLE=windspeed_barb/barb"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>windspeed_barb_no_outline/barb</Name>
+    <Title>Wind direction barb no outline</Title>
+    <Abstract>As barb</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ff_dd&amp;format=image/png&amp;STYLE=windspeed_barb_no_outline/barb"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>gff</Name>
 <Title>windstoten [m/s]</Title>
@@ -261,11 +340,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>windspeed/point</Name>    <Title>Wind direction</Title>    <Abstract>With discrete colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=gff&amp;format=image/png&amp;STYLE=windspeed/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>windspeed/point</Name>
+    <Title>Wind direction</Title>
+    <Abstract>With discrete colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=gff&amp;format=image/png&amp;STYLE=windspeed/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>ta</Name>
 <Title>temperatuur [C]</Title>
@@ -290,11 +379,39 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>temperature/point</Name>    <Title>Temperature</Title>    <Abstract>Temperature</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ta&amp;format=image/png&amp;STYLE=temperature/point"/>    </LegendURL>  </Style>   <Style>    <Name>temperature-volume/point</Name>    <Title>Temperature</Title>    <Abstract>Temperature</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ta&amp;format=image/png&amp;STYLE=temperature-volume/point"/>    </LegendURL>  </Style>   <Style>    <Name>temperature-disc/point</Name>    <Title>Temperature</Title>    <Abstract>Temperature</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ta&amp;format=image/png&amp;STYLE=temperature-disc/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>temperature/point</Name>
+    <Title>Temperature</Title>
+    <Abstract>Temperature</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ta&amp;format=image/png&amp;STYLE=temperature/point"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>temperature-volume/point</Name>
+    <Title>Temperature</Title>
+    <Abstract>Temperature</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ta&amp;format=image/png&amp;STYLE=temperature-volume/point"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>temperature-disc/point</Name>
+    <Title>Temperature</Title>
+    <Abstract>Temperature</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ta&amp;format=image/png&amp;STYLE=temperature-disc/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>rh</Name>
 <Title>luchtvochtigheid [%]</Title>
@@ -319,11 +436,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>percentage/point</Name>    <Title>Percentage</Title>    <Abstract>Percentage</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=rh&amp;format=image/png&amp;STYLE=percentage/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>percentage/point</Name>
+    <Title>Percentage</Title>
+    <Abstract>Percentage</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=rh&amp;format=image/png&amp;STYLE=percentage/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>pp</Name>
 <Title>luchtdruk [hPa]</Title>
@@ -348,11 +475,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>pressure/point</Name>    <Title>pressure</Title>    <Abstract>pressure</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=pp&amp;format=image/png&amp;STYLE=pressure/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>pressure/point</Name>
+    <Title>pressure</Title>
+    <Abstract>pressure</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=pp&amp;format=image/png&amp;STYLE=pressure/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>zm</Name>
 <Title>zicht [m]</Title>
@@ -377,11 +514,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>zm/point</Name>    <Title>Meteorological Optical Range</Title>    <Abstract>Meteorological Optical Range</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=zm&amp;format=image/png&amp;STYLE=zm/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>zm/point</Name>
+    <Title>Meteorological Optical Range</Title>
+    <Abstract>Meteorological Optical Range</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=zm&amp;format=image/png&amp;STYLE=zm/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>hc</Name>
 <Title>wolkenbasis [ft]</Title>
@@ -406,11 +553,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>wolkenbasis/point</Name>    <Title>wolkenbasis</Title>    <Abstract>wolkenbasis</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=hc&amp;format=image/png&amp;STYLE=wolkenbasis/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>wolkenbasis/point</Name>
+    <Title>wolkenbasis</Title>
+    <Abstract>wolkenbasis</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=hc&amp;format=image/png&amp;STYLE=wolkenbasis/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>hc1</Name>
 <Title>wolkenbasis 1e laag [ft]</Title>
@@ -435,11 +592,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>wolkenbasis/point</Name>    <Title>wolkenbasis</Title>    <Abstract>wolkenbasis</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=hc1&amp;format=image/png&amp;STYLE=wolkenbasis/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>wolkenbasis/point</Name>
+    <Title>wolkenbasis</Title>
+    <Abstract>wolkenbasis</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=hc1&amp;format=image/png&amp;STYLE=wolkenbasis/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>hc2</Name>
 <Title>wolkenbasis 2e laag [ft]</Title>
@@ -464,11 +631,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>wolkenbasis/point</Name>    <Title>wolkenbasis</Title>    <Abstract>wolkenbasis</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=hc2&amp;format=image/png&amp;STYLE=wolkenbasis/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>wolkenbasis/point</Name>
+    <Title>wolkenbasis</Title>
+    <Abstract>wolkenbasis</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=hc2&amp;format=image/png&amp;STYLE=wolkenbasis/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>hc3</Name>
 <Title>wolkenbasis 3e laag [ft]</Title>
@@ -493,11 +670,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>wolkenbasis/point</Name>    <Title>wolkenbasis</Title>    <Abstract>wolkenbasis</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=hc3&amp;format=image/png&amp;STYLE=wolkenbasis/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>wolkenbasis/point</Name>
+    <Title>wolkenbasis</Title>
+    <Abstract>wolkenbasis</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=hc3&amp;format=image/png&amp;STYLE=wolkenbasis/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>nc</Name>
 <Title>totale bewolking [octa]</Title>
@@ -522,11 +709,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>bewolkingsgraad/point</Name>    <Title>bewolkingsgraad[octa]</Title>    <Abstract>bewolkingsgraad</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=nc&amp;format=image/png&amp;STYLE=bewolkingsgraad/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>bewolkingsgraad/point</Name>
+    <Title>bewolkingsgraad[octa]</Title>
+    <Abstract>bewolkingsgraad</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=nc&amp;format=image/png&amp;STYLE=bewolkingsgraad/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>nc1</Name>
 <Title>bewolkingsgraad 1e laag [octa]</Title>
@@ -551,11 +748,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>bewolkingsgraad/point</Name>    <Title>bewolkingsgraad[octa]</Title>    <Abstract>bewolkingsgraad</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=nc1&amp;format=image/png&amp;STYLE=bewolkingsgraad/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>bewolkingsgraad/point</Name>
+    <Title>bewolkingsgraad[octa]</Title>
+    <Abstract>bewolkingsgraad</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=nc1&amp;format=image/png&amp;STYLE=bewolkingsgraad/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>nc2</Name>
 <Title>bewolkingsgraad 2e laag [octa]</Title>
@@ -580,11 +787,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>bewolkingsgraad/point</Name>    <Title>bewolkingsgraad[octa]</Title>    <Abstract>bewolkingsgraad</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=nc2&amp;format=image/png&amp;STYLE=bewolkingsgraad/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>bewolkingsgraad/point</Name>
+    <Title>bewolkingsgraad[octa]</Title>
+    <Abstract>bewolkingsgraad</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=nc2&amp;format=image/png&amp;STYLE=bewolkingsgraad/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>nc3</Name>
 <Title>bewolkingsgraad 3e laag [octa]</Title>
@@ -609,11 +826,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>bewolkingsgraad/point</Name>    <Title>bewolkingsgraad[octa]</Title>    <Abstract>bewolkingsgraad</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=nc3&amp;format=image/png&amp;STYLE=bewolkingsgraad/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>bewolkingsgraad/point</Name>
+    <Title>bewolkingsgraad[octa]</Title>
+    <Abstract>bewolkingsgraad</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=nc3&amp;format=image/png&amp;STYLE=bewolkingsgraad/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>D1H</Name>
 <Title>neerslagduur in afgelopen uur [min]</Title>
@@ -638,11 +865,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>precipitation/point</Name>    <Title>precipitation</Title>    <Abstract>precipitation</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=D1H&amp;format=image/png&amp;STYLE=precipitation/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>precipitation/point</Name>
+    <Title>precipitation</Title>
+    <Abstract>precipitation</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=D1H&amp;format=image/png&amp;STYLE=precipitation/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>D1H</Name>
 <Title>neerslagduur in afgelopen uur [min]</Title>
@@ -667,11 +904,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>precipitation/point</Name>    <Title>precipitation</Title>    <Abstract>precipitation</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=D1H&amp;format=image/png&amp;STYLE=precipitation/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>precipitation/point</Name>
+    <Title>precipitation</Title>
+    <Abstract>precipitation</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=D1H&amp;format=image/png&amp;STYLE=precipitation/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>dr</Name>
 <Title>neerslagduur(neerslagmeter) [sec]</Title>
@@ -696,11 +943,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>precipitation/point</Name>    <Title>precipitation</Title>    <Abstract>precipitation</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=dr&amp;format=image/png&amp;STYLE=precipitation/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>precipitation/point</Name>
+    <Title>precipitation</Title>
+    <Abstract>precipitation</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=dr&amp;format=image/png&amp;STYLE=precipitation/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>pr</Name>
 <Title>neerslagduur(PWS) [sec]</Title>
@@ -725,11 +982,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>precipitation/point</Name>    <Title>precipitation</Title>    <Abstract>precipitation</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=pr&amp;format=image/png&amp;STYLE=precipitation/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>precipitation/point</Name>
+    <Title>precipitation</Title>
+    <Abstract>precipitation</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=pr&amp;format=image/png&amp;STYLE=precipitation/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>rg</Name>
 <Title>neerslagintensiteit(neerslagmeter) [mm/uur]</Title>
@@ -754,11 +1021,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>precipitation/point</Name>    <Title>precipitation</Title>    <Abstract>precipitation</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=rg&amp;format=image/png&amp;STYLE=precipitation/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>precipitation/point</Name>
+    <Title>precipitation</Title>
+    <Abstract>precipitation</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=rg&amp;format=image/png&amp;STYLE=precipitation/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>pg</Name>
 <Title>neerslagintensiteit(PWS) [mm/uur]</Title>
@@ -783,11 +1060,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>precipitation/point</Name>    <Title>precipitation</Title>    <Abstract>precipitation</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=pg&amp;format=image/png&amp;STYLE=precipitation/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>precipitation/point</Name>
+    <Title>precipitation</Title>
+    <Abstract>precipitation</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=pg&amp;format=image/png&amp;STYLE=precipitation/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>R1H</Name>
 <Title>neerslaghoeveelheid laatste uur [mm]</Title>
@@ -812,11 +1099,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>precipitation/point</Name>    <Title>precipitation</Title>    <Abstract>precipitation</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=R1H&amp;format=image/png&amp;STYLE=precipitation/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>precipitation/point</Name>
+    <Title>precipitation</Title>
+    <Abstract>precipitation</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=R1H&amp;format=image/png&amp;STYLE=precipitation/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>R6H</Name>
 <Title>neerslaghoeveelheid laatste 6 uur [mm]</Title>
@@ -841,11 +1138,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>precipitation/point</Name>    <Title>precipitation</Title>    <Abstract>precipitation</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=R6H&amp;format=image/png&amp;STYLE=precipitation/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>precipitation/point</Name>
+    <Title>precipitation</Title>
+    <Abstract>precipitation</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=R6H&amp;format=image/png&amp;STYLE=precipitation/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>R12H</Name>
 <Title>neerslaghoeveelheid laatste 12 uur [mm]</Title>
@@ -870,11 +1177,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>precipitation/point</Name>    <Title>precipitation</Title>    <Abstract>precipitation</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=R12H&amp;format=image/png&amp;STYLE=precipitation/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>precipitation/point</Name>
+    <Title>precipitation</Title>
+    <Abstract>precipitation</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=R12H&amp;format=image/png&amp;STYLE=precipitation/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>R24H</Name>
 <Title>neerslaghoeveelheid laatste 24 uur [mm]</Title>
@@ -899,11 +1216,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>precipitation/point</Name>    <Title>precipitation</Title>    <Abstract>precipitation</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=R24H&amp;format=image/png&amp;STYLE=precipitation/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>precipitation/point</Name>
+    <Title>precipitation</Title>
+    <Abstract>precipitation</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=R24H&amp;format=image/png&amp;STYLE=precipitation/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>td</Name>
 <Title>dauwpuntstemperatuur [C]</Title>
@@ -928,11 +1255,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>temperature/point</Name>    <Title>Temperature</Title>    <Abstract>Temperature</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=td&amp;format=image/png&amp;STYLE=temperature/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>temperature/point</Name>
+    <Title>Temperature</Title>
+    <Abstract>Temperature</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=td&amp;format=image/png&amp;STYLE=temperature/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>tgn</Name>
 <Title>temperatuur 10cm [C</Title>
@@ -957,11 +1294,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>temperature/point</Name>    <Title>Temperature</Title>    <Abstract>Temperature</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=tgn&amp;format=image/png&amp;STYLE=temperature/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>temperature/point</Name>
+    <Title>Temperature</Title>
+    <Abstract>Temperature</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=tgn&amp;format=image/png&amp;STYLE=temperature/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>Tgn6</Name>
 <Title>minimum temperatuur-10cm laatste 6 uur [C]</Title>
@@ -986,11 +1333,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>temperature/point</Name>    <Title>Temperature</Title>    <Abstract>Temperature</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Tgn6&amp;format=image/png&amp;STYLE=temperature/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>temperature/point</Name>
+    <Title>Temperature</Title>
+    <Abstract>Temperature</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Tgn6&amp;format=image/png&amp;STYLE=temperature/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>Tgn12</Name>
 <Title>minimum temperatuur-10cm laatste 12 uur [C]</Title>
@@ -1015,11 +1372,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>temperature/point</Name>    <Title>Temperature</Title>    <Abstract>Temperature</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Tgn12&amp;format=image/png&amp;STYLE=temperature/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>temperature/point</Name>
+    <Title>Temperature</Title>
+    <Abstract>Temperature</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Tgn12&amp;format=image/png&amp;STYLE=temperature/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>Tgn14</Name>
 <Title>minimum temperatuur-10cm laatste 14 uur [C]</Title>
@@ -1044,11 +1411,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>temperature/point</Name>    <Title>Temperature</Title>    <Abstract>Temperature</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Tgn14&amp;format=image/png&amp;STYLE=temperature/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>temperature/point</Name>
+    <Title>Temperature</Title>
+    <Abstract>Temperature</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Tgn14&amp;format=image/png&amp;STYLE=temperature/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>tn</Name>
 <Title>minimum temperatuur [C]</Title>
@@ -1073,11 +1450,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>temperature/point</Name>    <Title>Temperature</Title>    <Abstract>Temperature</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=tn&amp;format=image/png&amp;STYLE=temperature/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>temperature/point</Name>
+    <Title>Temperature</Title>
+    <Abstract>Temperature</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=tn&amp;format=image/png&amp;STYLE=temperature/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>Tn6</Name>
 <Title>minimum temperatuur laatste 6 uur [C]</Title>
@@ -1102,11 +1489,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>temperature/point</Name>    <Title>Temperature</Title>    <Abstract>Temperature</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Tn6&amp;format=image/png&amp;STYLE=temperature/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>temperature/point</Name>
+    <Title>Temperature</Title>
+    <Abstract>Temperature</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Tn6&amp;format=image/png&amp;STYLE=temperature/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>Tn12</Name>
 <Title>minimum temperatuur laatste 12 uur [C]</Title>
@@ -1131,11 +1528,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>temperature/point</Name>    <Title>Temperature</Title>    <Abstract>Temperature</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Tn12&amp;format=image/png&amp;STYLE=temperature/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>temperature/point</Name>
+    <Title>Temperature</Title>
+    <Abstract>Temperature</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Tn12&amp;format=image/png&amp;STYLE=temperature/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>Tn14</Name>
 <Title>minimum temperatuur laatste 14 uur [C]</Title>
@@ -1160,11 +1567,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>temperature/point</Name>    <Title>Temperature</Title>    <Abstract>Temperature</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Tn14&amp;format=image/png&amp;STYLE=temperature/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>temperature/point</Name>
+    <Title>Temperature</Title>
+    <Abstract>Temperature</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Tn14&amp;format=image/png&amp;STYLE=temperature/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>tx</Name>
 <Title>maximum temperatuur [C]</Title>
@@ -1189,11 +1606,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>temperature/point</Name>    <Title>Temperature</Title>    <Abstract>Temperature</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=tx&amp;format=image/png&amp;STYLE=temperature/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>temperature/point</Name>
+    <Title>Temperature</Title>
+    <Abstract>Temperature</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=tx&amp;format=image/png&amp;STYLE=temperature/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>Tx6</Name>
 <Title>maximum temperatuur laatste 6 uur [C]</Title>
@@ -1218,11 +1645,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>temperature/point</Name>    <Title>Temperature</Title>    <Abstract>Temperature</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Tx6&amp;format=image/png&amp;STYLE=temperature/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>temperature/point</Name>
+    <Title>Temperature</Title>
+    <Abstract>Temperature</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Tx6&amp;format=image/png&amp;STYLE=temperature/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>Tx12</Name>
 <Title>maximum temperatuur laatste 12 uur [C]</Title>
@@ -1247,11 +1684,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>temperature/point</Name>    <Title>Temperature</Title>    <Abstract>Temperature</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Tx12&amp;format=image/png&amp;STYLE=temperature/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>temperature/point</Name>
+    <Title>Temperature</Title>
+    <Abstract>Temperature</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Tx12&amp;format=image/png&amp;STYLE=temperature/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>ss</Name>
 <Title>zonneschijnduur [min]</Title>
@@ -1276,11 +1723,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>duration/point</Name>    <Title>duration[min]</Title>    <Abstract>duration</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ss&amp;format=image/png&amp;STYLE=duration/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>duration/point</Name>
+    <Title>duration[min]</Title>
+    <Abstract>duration</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ss&amp;format=image/png&amp;STYLE=duration/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>pwc</Name>
 <Title>actuele weercode</Title>
@@ -1305,11 +1762,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>weercode/point</Name>    <Title>weercode</Title>    <Abstract>weercode</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=pwc&amp;format=image/png&amp;STYLE=weercode/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>weercode/point</Name>
+    <Title>weercode</Title>
+    <Abstract>weercode</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=pwc&amp;format=image/png&amp;STYLE=weercode/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>ww</Name>
 <Title>actuele wawa weercode</Title>
@@ -1334,11 +1801,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z/2020-12-20T12:40:00Z/PT5M</Dimension>
-   <Style>    <Name>weercode/point</Name>    <Title>weercode</Title>    <Abstract>weercode</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ww&amp;format=image/png&amp;STYLE=weercode/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>weercode/point</Name>
+    <Title>weercode</Title>
+    <Abstract>weercode</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ww&amp;format=image/png&amp;STYLE=weercode/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>ww-10</Name>
 <Title>verleden wawa weercode (-10min)</Title>
@@ -1363,11 +1840,21 @@
 <BoundingBox CRS="EPSG:4258" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:4326" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
 <BoundingBox CRS="EPSG:54030" minx="-6408021.286199" miny="1297326.829390" maxx="670998.883042" maxy="5878649.483190" />
 <BoundingBox CRS="EPSG:7399" minx="-6748084.942175" miny="1495513.911739" maxx="706607.743114" maxy="6426594.553880" />
 <BoundingBox CRS="EPSG:900913" minx="-7600430.977505" miny="1360506.839359" maxx="795858.888223" maxy="7439724.721958" />
 <Dimension name="time" units="ISO8601" default="2020-12-20T12:40:00Z" multipleValues="1" nearestValue="0" current="1">2020-12-20T12:30:00Z,2020-12-20T12:40:00Z</Dimension>
-   <Style>    <Name>weercode/point</Name>    <Title>weercode</Title>    <Abstract>weercode</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ww-10&amp;format=image/png&amp;STYLE=weercode/point"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>weercode/point</Name>
+    <Title>weercode</Title>
+    <Abstract>weercode</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ww-10&amp;format=image/png&amp;STYLE=weercode/point"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_PASCAL_probabilities_manydims_timewindow.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_PASCAL_probabilities_manydims_timewindow.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 19 2025 08:49:47 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=pascal%2FNetCDF4_probabilities_greater_than_or_equal_to_36_1_0_12_2025%2D07%2D02T10_00_00Z_2025%2D07%2D02T00_00_00Z%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -92,6 +93,7 @@
 <BoundingBox CRS="EPSG:4258" minx="48.991000" miny="-0.014500" maxx="56.011000" maxy="11.295500" />
 <BoundingBox CRS="EPSG:4326" minx="48.991000" miny="-0.014500" maxx="56.011000" maxy="11.295500" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="1998797.905458" miny="-2749996.025036" maxx="2930377.601350" maxy="-1808590.961851" />
 <BoundingBox CRS="EPSG:54030" minx="-1197.220328" miny="5222308.942734" maxx="932634.635340" maxy="5940218.262293" />
 <BoundingBox CRS="EPSG:7399" minx="-1117.353231" miny="5767402.687526" maxx="870418.166689" maxy="6487641.412002" />
 <BoundingBox CRS="EPSG:900913" minx="-1614.132617" miny="6273334.420261" maxx="1257409.308255" maxy="7560605.756670" />
@@ -119,6 +121,7 @@
 <BoundingBox CRS="EPSG:4258" minx="48.991000" miny="-0.014500" maxx="56.011000" maxy="11.295500" />
 <BoundingBox CRS="EPSG:4326" minx="48.991000" miny="-0.014500" maxx="56.011000" maxy="11.295500" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="1998797.905458" miny="-2749996.025036" maxx="2930377.601350" maxy="-1808590.961851" />
 <BoundingBox CRS="EPSG:54030" minx="-1197.220328" miny="5222308.942734" maxx="932634.635340" maxy="5940218.262293" />
 <BoundingBox CRS="EPSG:7399" minx="-1117.353231" miny="5767402.687526" maxx="870418.166689" maxy="6487641.412002" />
 <BoundingBox CRS="EPSG:900913" minx="-1614.132617" miny="6273334.420261" maxx="1257409.308255" maxy="7560605.756670" />
@@ -128,7 +131,51 @@
 <Dimension name="reference_time" units="seconds since 1970-01-01" default="2025-07-02T00:00:00Z" multipleValues="1" nearestValue="0" current="1">2025-07-02T00:00:00Z</Dimension>
 <Dimension name="radius" units="1" default="0.12" multipleValues="1" nearestValue="0" >0.12</Dimension>
 <Dimension name="condition" units="1" default="greater_than_or_equal_to_36" multipleValues="1" nearestValue="0" >greater_than_or_equal_to_36</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=pascal%2FNetCDF4_probabilities_greater_than_or_equal_to_36_1_0_12_2025%2D07%2D02T10_00_00Z_2025%2D07%2D02T00_00_00Z%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probabilities&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=pascal%2FNetCDF4_probabilities_greater_than_or_equal_to_36_1_0_12_2025%2D07%2D02T10_00_00Z_2025%2D07%2D02T00_00_00Z%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probabilities&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=pascal%2FNetCDF4_probabilities_greater_than_or_equal_to_36_1_0_12_2025%2D07%2D02T10_00_00Z_2025%2D07%2D02T00_00_00Z%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probabilities&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=pascal%2FNetCDF4_probabilities_greater_than_or_equal_to_36_1_0_12_2025%2D07%2D02T10_00_00Z_2025%2D07%2D02T00_00_00Z%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probabilities&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=pascal%2FNetCDF4_probabilities_greater_than_or_equal_to_36_1_0_12_2025%2D07%2D02T10_00_00Z_2025%2D07%2D02T00_00_00Z%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probabilities&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=pascal%2FNetCDF4_probabilities_greater_than_or_equal_to_36_1_0_12_2025%2D07%2D02T10_00_00Z_2025%2D07%2D02T00_00_00Z%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probabilities&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=pascal%2FNetCDF4_probabilities_greater_than_or_equal_to_36_1_0_12_2025%2D07%2D02T10_00_00Z_2025%2D07%2D02T00_00_00Z%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probabilities&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=pascal%2FNetCDF4_probabilities_greater_than_or_equal_to_36_1_0_12_2025%2D07%2D02T10_00_00Z_2025%2D07%2D02T00_00_00Z%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probabilities&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=pascal%2FNetCDF4_probabilities_greater_than_or_equal_to_36_1_0_12_2025%2D07%2D02T10_00_00Z_2025%2D07%2D02T00_00_00Z%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probabilities&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=pascal%2FNetCDF4_probabilities_greater_than_or_equal_to_36_1_0_12_2025%2D07%2D02T10_00_00Z_2025%2D07%2D02T00_00_00Z%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=probabilities&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_multidimnc_autostyle.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_multidimnc_autostyle.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.3.0, of Feb  6 2026 22:36:22 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
@@ -121,13 +123,130 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
 <Dimension name="time" units="ISO8601" default="2017-01-01T00:10:00Z" multipleValues="1" nearestValue="0" current="1">2017-01-01T00:00:00Z,2017-01-01T00:05:00Z,2017-01-01T00:10:00Z</Dimension>
 <Dimension name="member" units="member number" default="member1" multipleValues="1" nearestValue="0" >member6,member5,member4,member3,member2,member1</Dimension>
 <Dimension name="elevation" units="meters" default="9000" multipleValues="1" nearestValue="0" >1000,2000,3000,4000,5000,6000,7000,8000,9000</Dimension>
-   <Style>    <Name>testdata_style_1/nearest</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata_style_1/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_1/bilinear</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata_style_1/bilinear"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_1/nearestcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata_style_1/nearestcontour"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_1/shadedcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata_style_1/shadedcontour"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_2/nearest</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata_style_2/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_2/bilinear</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata_style_2/bilinear"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_2/nearestcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata_style_2/nearestcontour"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_2/shadedcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata_style_2/shadedcontour"/>    </LegendURL>  </Style>   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>testdata_style_1/nearest</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata_style_1/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata_style_1/bilinear</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata_style_1/bilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata_style_1/nearestcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata_style_1/nearestcontour"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata_style_1/shadedcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata_style_1/shadedcontour"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata_style_2/nearest</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata_style_2/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata_style_2/bilinear</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata_style_2/bilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata_style_2/nearestcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata_style_2/nearestcontour"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata_style_2/shadedcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata_style_2/shadedcontour"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_multidimncdataset_autostyle.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_multidimncdataset_autostyle.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.3.0, of Feb  6 2026 22:36:22 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
@@ -117,13 +119,94 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
 <Dimension name="time" units="ISO8601" default="2017-01-01T00:25:00Z" multipleValues="1" nearestValue="0" current="1">2017-01-01T00:00:00Z/2017-01-01T00:25:00Z/PT5M</Dimension>
 <Dimension name="member" units="member number" default="member1" multipleValues="1" nearestValue="0" >member6,member5,member4,member3,member2,member1</Dimension>
 <Dimension name="elevation" units="meters" default="9000" multipleValues="1" nearestValue="0" >1000,2000,3000,4000,5000,6000,7000,8000,9000</Dimension>
-   <Style>    <Name>testdata/nearest</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/bilinear</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/bilinear"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/nearestcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearestcontour"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/shadedcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/shadedcontour"/>    </LegendURL>  </Style>   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>testdata/nearest</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/bilinear</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/bilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/nearestcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearestcontour"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/shadedcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/shadedcontour"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_no_error_on_existing_dataset_misconfigured_layer.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_no_error_on_existing_dataset_misconfigured_layer.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 19 2025 08:49:47 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datasetwithmisconfiguredlayer&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="37.352373" miny="-27.248854" maxx="65.890829" maxy="32.682179" />
 <BoundingBox CRS="EPSG:4326" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
 <BoundingBox CRS="EPSG:54030" minx="-2010910.349488" miny="3994561.026658" maxx="2383791.664599" maxy="6899708.714622" />
 <BoundingBox CRS="EPSG:7399" minx="-1688218.598491" miny="4491365.234972" maxx="1973986.260472" maxy="7420353.104506" />
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
@@ -117,10 +119,20 @@
 <BoundingBox CRS="EPSG:4258" minx="37.352373" miny="-27.248854" maxx="65.890829" maxy="32.682179" />
 <BoundingBox CRS="EPSG:4326" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
 <BoundingBox CRS="EPSG:54030" minx="-2010910.349488" miny="3994561.026658" maxx="2383791.664599" maxy="6899708.714622" />
 <BoundingBox CRS="EPSG:7399" minx="-1688218.598491" miny="4491365.234972" maxx="1973986.260472" maxy="7420353.104506" />
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datasetwithmisconfiguredlayer&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datasetwithmisconfiguredlayer&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+</Layer>
 
 <!-- Note: Error: Layer [testdatamisconfigured] is misconfigured -->
     </Layer>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_testdatanc.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_testdatanc.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 19 2025 08:49:47 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="37.352373" miny="-27.248854" maxx="65.890829" maxy="32.682179" />
 <BoundingBox CRS="EPSG:4326" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
 <BoundingBox CRS="EPSG:54030" minx="-2010910.349488" miny="3994561.026658" maxx="2383791.664599" maxy="6899708.714622" />
 <BoundingBox CRS="EPSG:7399" minx="-1688218.598491" miny="4491365.234972" maxx="1973986.260472" maxy="7420353.104506" />
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
@@ -117,10 +119,55 @@
 <BoundingBox CRS="EPSG:4258" minx="37.352373" miny="-27.248854" maxx="65.890829" maxy="32.682179" />
 <BoundingBox CRS="EPSG:4326" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
 <BoundingBox CRS="EPSG:54030" minx="-2010910.349488" miny="3994561.026658" maxx="2383791.664599" maxy="6899708.714622" />
 <BoundingBox CRS="EPSG:7399" minx="-1688218.598491" miny="4491365.234972" maxx="1973986.260472" maxy="7420353.104506" />
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_testdatanc_autostyle.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_testdatanc_autostyle.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.3.0, of Feb  6 2026 22:36:22 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="37.352373" miny="-27.248854" maxx="65.890829" maxy="32.682179" />
 <BoundingBox CRS="EPSG:4326" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
 <BoundingBox CRS="EPSG:54030" minx="-2010910.349488" miny="3994561.026658" maxx="2383791.664599" maxy="6899708.714622" />
 <BoundingBox CRS="EPSG:7399" minx="-1688218.598491" miny="4491365.234972" maxx="1973986.260472" maxy="7420353.104506" />
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
@@ -121,10 +123,127 @@
 <BoundingBox CRS="EPSG:4258" minx="37.352373" miny="-27.248854" maxx="65.890829" maxy="32.682179" />
 <BoundingBox CRS="EPSG:4326" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
 <BoundingBox CRS="EPSG:54030" minx="-2010910.349488" miny="3994561.026658" maxx="2383791.664599" maxy="6899708.714622" />
 <BoundingBox CRS="EPSG:7399" minx="-1688218.598491" miny="4491365.234972" maxx="1973986.260472" maxy="7420353.104506" />
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
-   <Style>    <Name>testdata_style_1/nearest</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_1/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_1/bilinear</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_1/bilinear"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_1/nearestcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_1/nearestcontour"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_1/shadedcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_1/shadedcontour"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_2/nearest</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_2/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_2/bilinear</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_2/bilinear"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_2/nearestcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_2/nearestcontour"/>    </LegendURL>  </Style>   <Style>    <Name>testdata_style_2/shadedcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_2/shadedcontour"/>    </LegendURL>  </Style>   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>testdata_style_1/nearest</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_1/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata_style_1/bilinear</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_1/bilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata_style_1/nearestcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_1/nearestcontour"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata_style_1/shadedcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_1/shadedcontour"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata_style_2/nearest</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_2/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata_style_2/bilinear</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_2/bilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata_style_2/nearestcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_2/nearestcontour"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata_style_2/shadedcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=testdata_style_2/shadedcontour"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_timeseries_path_netcdf_5dims_seq1.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_timeseries_path_netcdf_5dims_seq1.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.3.0, of Feb  6 2026 22:36:22 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
@@ -117,13 +119,50 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
 <Dimension name="time" units="ISO8601" default="2017-01-01T00:10:00Z" multipleValues="1" nearestValue="0" current="1">2017-01-01T00:00:00Z,2017-01-01T00:05:00Z,2017-01-01T00:10:00Z</Dimension>
 <Dimension name="member" units="member number" default="member1" multipleValues="1" nearestValue="0" >member6,member5,member4,member3,member2,member1</Dimension>
 <Dimension name="elevation" units="meters" default="9000" multipleValues="1" nearestValue="0" >1000,2000,3000,4000,5000,6000,7000,8000,9000</Dimension>
-   <Style>    <Name>testdata/nearest</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/bilinear</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/bilinear"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/nearestcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearestcontour"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/shadedcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/shadedcontour"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>testdata/nearest</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/bilinear</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/bilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/nearestcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearestcontour"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/shadedcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/shadedcontour"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_timeseries_path_netcdf_5dims_seq2.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_timeseries_path_netcdf_5dims_seq2.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.3.0, of Feb  6 2026 08:56:45 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
@@ -117,13 +119,50 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
 <Dimension name="time" units="ISO8601" default="2017-01-01T00:25:00Z" multipleValues="1" nearestValue="0" current="1">2017-01-01T00:00:00Z/2017-01-01T00:25:00Z/PT5M</Dimension>
 <Dimension name="member" units="member number" default="member1" multipleValues="1" nearestValue="0" >member6,member5,member4,member3,member2,member1</Dimension>
 <Dimension name="elevation" units="meters" default="9000" multipleValues="1" nearestValue="0" >1000,2000,3000,4000,5000,6000,7000,8000,9000</Dimension>
-   <Style>    <Name>testdata/nearest</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/bilinear</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/bilinear"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/nearestcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearestcontour"/>    </LegendURL>  </Style>   <Style>    <Name>testdata/shadedcontour</Name>    <Title>Rainbow colors</Title>    <Abstract>Drawing with rainbow colors</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/shadedcontour"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>testdata/nearest</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/bilinear</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/bilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/nearestcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/nearestcontour"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>testdata/shadedcontour</Name>
+    <Title>Rainbow colors</Title>
+    <Abstract>Drawing with rainbow colors</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data&amp;format=image/png&amp;STYLE=testdata/shadedcontour"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetFeatureInfo_forecastreferencetime_texthtml_TestDataGetCapabilities.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetFeatureInfo_forecastreferencetime_texthtml_TestDataGetCapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 19 2025 08:49:47 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="37.352373" miny="-27.248854" maxx="65.890829" maxy="32.682179" />
 <BoundingBox CRS="EPSG:4326" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
 <BoundingBox CRS="EPSG:54030" minx="-2010910.349488" miny="3994561.026658" maxx="2383791.664599" maxy="6899708.714622" />
 <BoundingBox CRS="EPSG:7399" minx="-1688218.598491" miny="4491365.234972" maxx="1973986.260472" maxy="7420353.104506" />
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
@@ -117,10 +119,55 @@
 <BoundingBox CRS="EPSG:4258" minx="37.352373" miny="-27.248854" maxx="65.890829" maxy="32.682179" />
 <BoundingBox CRS="EPSG:4326" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
 <BoundingBox CRS="EPSG:54030" minx="-2010910.349488" miny="3994561.026658" maxx="2383791.664599" maxy="6899708.714622" />
 <BoundingBox CRS="EPSG:7399" minx="-1688218.598491" miny="4491365.234972" maxx="1973986.260472" maxy="7420353.104506" />
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetMapGetCapabilities_testdatanc_WMSGetCapabilities_testdatanc.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetMapGetCapabilities_testdatanc_WMSGetCapabilities_testdatanc.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 19 2025 08:49:47 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="37.352373" miny="-27.248854" maxx="65.890829" maxy="32.682179" />
 <BoundingBox CRS="EPSG:4326" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
 <BoundingBox CRS="EPSG:54030" minx="-2010910.349488" miny="3994561.026658" maxx="2383791.664599" maxy="6899708.714622" />
 <BoundingBox CRS="EPSG:7399" minx="-1688218.598491" miny="4491365.234972" maxx="1973986.260472" maxy="7420353.104506" />
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
@@ -117,10 +119,55 @@
 <BoundingBox CRS="EPSG:4258" minx="37.352373" miny="-27.248854" maxx="65.890829" maxy="32.682179" />
 <BoundingBox CRS="EPSG:4326" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
 <BoundingBox CRS="EPSG:54030" minx="-2010910.349488" miny="3994561.026658" maxx="2383791.664599" maxy="6899708.714622" />
 <BoundingBox CRS="EPSG:7399" minx="-1688218.598491" miny="4491365.234972" maxx="1973986.260472" maxy="7420353.104506" />
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetMap_IrregularGrid_1Dimensional_latlon_nextdimensionstep_getcapabilities.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetMap_IrregularGrid_1Dimensional_latlon_nextdimensionstep_getcapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 19 2025 08:49:47 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_1Dlat1Dlon_grid%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="48.000000" miny="-12.000000" maxx="56.000000" maxy="12.000000" />
 <BoundingBox CRS="EPSG:4326" minx="48.000000" miny="-12.000000" maxx="56.000000" maxy="12.000000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="986381.559353" miny="-2875182.623640" maxx="3013618.440647" maxy="-1800251.543330" />
 <BoundingBox CRS="EPSG:54030" minx="-997307.251023" miny="5119205.279776" maxx="997307.251023" maxy="5939113.229856" />
 <BoundingBox CRS="EPSG:7399" minx="-936166.427234" miny="5662449.720378" maxx="936166.427234" maxy="6486546.956900" />
 <BoundingBox CRS="EPSG:900913" minx="-1335833.889519" miny="6106854.834885" maxx="1335833.889519" maxy="7558415.656082" />
@@ -117,12 +119,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.000000" miny="-12.000000" maxx="56.000000" maxy="12.000000" />
 <BoundingBox CRS="EPSG:4326" minx="48.000000" miny="-12.000000" maxx="56.000000" maxy="12.000000" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="986381.559353" miny="-2875182.623640" maxx="3013618.440647" maxy="-1800251.543330" />
 <BoundingBox CRS="EPSG:54030" minx="-997307.251023" miny="5119205.279776" maxx="997307.251023" maxy="5939113.229856" />
 <BoundingBox CRS="EPSG:7399" minx="-936166.427234" miny="5662449.720378" maxx="936166.427234" maxy="6486546.956900" />
 <BoundingBox CRS="EPSG:900913" minx="-1335833.889519" miny="6106854.834885" maxx="1335833.889519" maxy="7558415.656082" />
 <Dimension name="time" units="ISO8601" default="2017-01-01T00:11:00Z" multipleValues="1" nearestValue="0" current="1">2017-01-01T00:10:00Z,2017-01-01T00:11:00Z</Dimension>
 <Dimension name="extra" units="extra" default="0.9" multipleValues="1" nearestValue="0" >0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_1Dlat1Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_1Dlat1Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_1Dlat1Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_1Dlat1Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_1Dlat1Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_1Dlat1Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_1Dlat1Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_1Dlat1Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_1Dlat1Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_1Dlat1Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMS/test_WMSGetMap_IrregularGrid_2Dimensional_latlon_nextdimensionstep_getcapabilities.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetMap_IrregularGrid_2Dimensional_latlon_nextdimensionstep_getcapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 19 2025 08:49:47 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_2Dlat2Dlon_grid%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="50.047555" miny="0.079045" maxx="68.959048" maxy="14.878220" />
 <BoundingBox CRS="EPSG:4326" minx="50.047555" miny="0.079045" maxx="68.959048" maxy="14.878220" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2003258.047754" miny="-2617330.437195" maxx="3185571.966041" maxy="-282422.611583" />
 <BoundingBox CRS="EPSG:54030" minx="5432.081824" miny="5331814.750775" maxx="1219553.726683" maxy="7181859.894594" />
 <BoundingBox CRS="EPSG:7399" minx="4144.955793" miny="5878451.072574" maxx="1130980.084054" maxy="7686896.813082" />
 <BoundingBox CRS="EPSG:900913" minx="8799.245393" miny="6454515.620092" maxx="1656235.921469" maxy="10738077.545348" />
@@ -117,12 +119,57 @@
 <BoundingBox CRS="EPSG:4258" minx="50.047555" miny="0.079045" maxx="68.959048" maxy="14.878220" />
 <BoundingBox CRS="EPSG:4326" minx="50.047555" miny="0.079045" maxx="68.959048" maxy="14.878220" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2003258.047754" miny="-2617330.437195" maxx="3185571.966041" maxy="-282422.611583" />
 <BoundingBox CRS="EPSG:54030" minx="5432.081824" miny="5331814.750775" maxx="1219553.726683" maxy="7181859.894594" />
 <BoundingBox CRS="EPSG:7399" minx="4144.955793" miny="5878451.072574" maxx="1130980.084054" maxy="7686896.813082" />
 <BoundingBox CRS="EPSG:900913" minx="8799.245393" miny="6454515.620092" maxx="1656235.921469" maxy="10738077.545348" />
 <Dimension name="time" units="ISO8601" default="2017-01-01T00:11:00Z" multipleValues="1" nearestValue="0" current="1">2017-01-01T00:10:00Z,2017-01-01T00:11:00Z</Dimension>
 <Dimension name="extra" units="extra" default="0.9" multipleValues="1" nearestValue="0" >0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_2Dlat2Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_2Dlat2Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_2Dlat2Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_2Dlat2Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_2Dlat2Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_2Dlat2Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_2Dlat2Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_2Dlat2Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_2Dlat2Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_2Dlat2Dlon_grid%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=data_var_1&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMSDocumentCache/test_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1.xml
+++ b/tests/expectedoutputs/TestWMSDocumentCache/test_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.0.0, of Mar 24 2026 13:27:35 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testtimeseriescached&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
@@ -117,6 +119,7 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />

--- a/tests/expectedoutputs/TestWMSDocumentCache/test_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1_and_seq2.xml
+++ b/tests/expectedoutputs/TestWMSDocumentCache/test_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1_and_seq2.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.0.0, of Mar 24 2026 13:27:35 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testtimeseriescached&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
@@ -117,6 +119,7 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />

--- a/tests/expectedoutputs/TestWMSDocumentCache/test_WMSGetCapabilities_timeseries_twofiles.xml
+++ b/tests/expectedoutputs/TestWMSDocumentCache/test_WMSGetCapabilities_timeseries_twofiles.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.0.0, of Mar 24 2026 13:27:35 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testtimeseriescached&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />
@@ -117,6 +119,7 @@
 <BoundingBox CRS="EPSG:4258" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:4326" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
 <BoundingBox CRS="EPSG:54030" minx="-16294244.470419" miny="-8493172.970167" maxx="16956530.805045" maxy="8610630.466538" />
 <BoundingBox CRS="EPSG:7399" minx="-17284159.484400" miny="-8898366.230070" maxx="17986681.325950" maxy="9011275.281223" />
 <BoundingBox CRS="EPSG:900913" minx="-19201993.871211" miny="-22228632.557364" maxx="19982466.888021" maxy="34805382.412607" />

--- a/tests/expectedoutputs/TestWMSSLD/test_WMSGetMap_testdatanc_NOSLDURL.xml
+++ b/tests/expectedoutputs/TestWMSSLD/test_WMSGetMap_testdatanc_NOSLDURL.xml
@@ -1,1 +1,17 @@
-Unable to read configuration file.
+<?xml version='1.0' encoding="ISO-8859-1" standalone="no" ?>
+<ServiceExceptionReport version="1.3.0"  xmlns="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/wms/1.3.0/exceptions_1_3_0.xsd">
+  <ServiceException code="UnprocessableEntity">
+    Legend no2 not found;
+    Server has no legends configured. Cannot continue.;
+    Legend no2 not found;
+    Server has no legends configured. Cannot continue.;
+    Legend no2 not found;
+    Server has no legends configured. Cannot continue.;
+    Legend no2 not found;
+    Server has no legends configured. Cannot continue.;
+    Error occured during image data writing;
+    Returning from line 2480;
+    WMS GetMap Request failed;
+
+  </ServiceException>
+</ServiceExceptionReport>

--- a/tests/expectedoutputs/TestWMSTimeHeightProfiles/test_WMSGetCapabilities_TimeHeightProfiles.xml
+++ b/tests/expectedoutputs/TestWMSTimeHeightProfiles/test_WMSGetCapabilities_TimeHeightProfiles.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 19 2025 08:49:47 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=test%2Fceilonet%2Fceilonet_chm15k_backsct_la1_t12s_v1%2E0_06310_A20231202_extracted_small%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="50.941341" miny="3.095820" maxx="51.941341" maxy="4.095820" />
 <BoundingBox CRS="EPSG:4326" minx="50.941341" miny="3.095820" maxx="51.941341" maxy="4.095820" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2236636.957682" miny="-2499207.579300" maxx="2321824.106000" maxy="-2370491.121972" />
 <BoundingBox CRS="EPSG:54030" minx="250267.819665" miny="5424087.672457" maxx="333585.083442" maxy="5526906.416450" />
 <BoundingBox CRS="EPSG:7399" minx="229341.630247" miny="5971691.317382" maxx="307650.224519" maxy="6075231.074174" />
 <BoundingBox CRS="EPSG:900913" minx="344625.100433" miny="6610924.247303" maxx="455944.591226" maxy="6789526.168440" />
@@ -119,11 +121,56 @@ with P_raw = sum(P_raw_hr) * range_gate_hr / range_gate (beta_raw)</Title>
 <BoundingBox CRS="EPSG:4258" minx="50.941341" miny="3.095820" maxx="51.941341" maxy="4.095820" />
 <BoundingBox CRS="EPSG:4326" minx="50.941341" miny="3.095820" maxx="51.941341" maxy="4.095820" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2236636.957682" miny="-2499207.579300" maxx="2321824.106000" maxy="-2370491.121972" />
 <BoundingBox CRS="EPSG:54030" minx="250267.819665" miny="5424087.672457" maxx="333585.083442" maxy="5526906.416450" />
 <BoundingBox CRS="EPSG:7399" minx="229341.630247" miny="5971691.317382" maxx="307650.224519" maxy="6075231.074174" />
 <BoundingBox CRS="EPSG:900913" minx="344625.100433" miny="6610924.247303" maxx="455944.591226" maxy="6789526.168440" />
 <Dimension name="time" units="ISO8601" default="2023-12-02T06:40:00Z" multipleValues="1" nearestValue="0" current="1">2023-12-02T06:40:00Z</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fceilonet%2Fceilonet_chm15k_backsct_la1_t12s_v1%2E0_06310_A20231202_extracted_small%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=beta_raw&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fceilonet%2Fceilonet_chm15k_backsct_la1_t12s_v1%2E0_06310_A20231202_extracted_small%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=beta_raw&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fceilonet%2Fceilonet_chm15k_backsct_la1_t12s_v1%2E0_06310_A20231202_extracted_small%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=beta_raw&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fceilonet%2Fceilonet_chm15k_backsct_la1_t12s_v1%2E0_06310_A20231202_extracted_small%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=beta_raw&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fceilonet%2Fceilonet_chm15k_backsct_la1_t12s_v1%2E0_06310_A20231202_extracted_small%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=beta_raw&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fceilonet%2Fceilonet_chm15k_backsct_la1_t12s_v1%2E0_06310_A20231202_extracted_small%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=beta_raw&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fceilonet%2Fceilonet_chm15k_backsct_la1_t12s_v1%2E0_06310_A20231202_extracted_small%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=beta_raw&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fceilonet%2Fceilonet_chm15k_backsct_la1_t12s_v1%2E0_06310_A20231202_extracted_small%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=beta_raw&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fceilonet%2Fceilonet_chm15k_backsct_la1_t12s_v1%2E0_06310_A20231202_extracted_small%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=beta_raw&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fceilonet%2Fceilonet_chm15k_backsct_la1_t12s_v1%2E0_06310_A20231202_extracted_small%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=beta_raw&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMSTimeHeightProfiles/test_wmsgetcapabilities_timeheightprofiles_as_dataset.xml
+++ b/tests/expectedoutputs/TestWMSTimeHeightProfiles/test_wmsgetcapabilities_timeheightprofiles_as_dataset.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 3.1.2, of Jun 30 2025 11:29:01 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.timeheightprofiles&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -92,6 +93,7 @@
 <BoundingBox CRS="EPSG:4258" minx="50.941341" miny="3.095820" maxx="51.941341" maxy="4.095820" />
 <BoundingBox CRS="EPSG:4326" minx="50.941341" miny="3.095820" maxx="51.941341" maxy="4.095820" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2236636.957682" miny="-2499207.579300" maxx="2321824.106000" maxy="-2370491.121972" />
 <BoundingBox CRS="EPSG:54030" minx="250267.819665" miny="5424087.672457" maxx="333585.083442" maxy="5526906.416450" />
 <BoundingBox CRS="EPSG:7399" minx="229341.630247" miny="5971691.317382" maxx="307650.224519" maxy="6075231.074174" />
 <BoundingBox CRS="EPSG:900913" minx="344625.100433" miny="6610924.247303" maxx="455944.591226" maxy="6789526.168440" />
@@ -119,12 +121,29 @@
 <BoundingBox CRS="EPSG:4258" minx="50.941341" miny="3.095820" maxx="51.941341" maxy="4.095820" />
 <BoundingBox CRS="EPSG:4326" minx="50.941341" miny="3.095820" maxx="51.941341" maxy="4.095820" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2236636.957682" miny="-2499207.579300" maxx="2321824.106000" maxy="-2370491.121972" />
 <BoundingBox CRS="EPSG:54030" minx="250267.819665" miny="5424087.672457" maxx="333585.083442" maxy="5526906.416450" />
 <BoundingBox CRS="EPSG:7399" minx="229341.630247" miny="5971691.317382" maxx="307650.224519" maxy="6075231.074174" />
 <BoundingBox CRS="EPSG:900913" minx="344625.100433" miny="6610924.247303" maxx="455944.591226" maxy="6789526.168440" />
 <BoundingBox CRS="GFI:TIME_ELEVATION" minx="3.095820" miny="50.941341" maxx="4.095820" maxy="51.941341" />
 <Dimension name="time" units="ISO8601" default="2023-12-02T06:40:00Z" multipleValues="1" nearestValue="0" current="1">2023-12-02T06:40:00Z</Dimension>
-   <Style>    <Name>beta_raw/nearest</Name>    <Title>beta_raw/nearest</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.timeheightprofiles&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=beta_raw&amp;format=image/png&amp;STYLE=beta_raw/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>beta_raw/bilinear</Name>    <Title>beta_raw/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.timeheightprofiles&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=beta_raw&amp;format=image/png&amp;STYLE=beta_raw/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>beta_raw/nearest</Name>
+    <Title>beta_raw/nearest</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.timeheightprofiles&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=beta_raw&amp;format=image/png&amp;STYLE=beta_raw/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>beta_raw/bilinear</Name>
+    <Title>beta_raw/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.timeheightprofiles&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=beta_raw&amp;format=image/png&amp;STYLE=beta_raw/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMSTimeSeries/test_WMSGetCapabilities_adaguc_arcus_harmonie_sorted_model_levels.xml
+++ b/tests/expectedoutputs/TestWMSTimeSeries/test_WMSGetCapabilities_adaguc_arcus_harmonie_sorted_model_levels.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 19 2025 08:49:47 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.arcus_harmonie_sorted_model_levels&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -92,6 +93,7 @@
 <BoundingBox CRS="EPSG:4258" minx="48.991000" miny="-0.014500" maxx="56.011000" maxy="11.295500" />
 <BoundingBox CRS="EPSG:4326" minx="48.991000" miny="-0.014500" maxx="56.011000" maxy="11.295500" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="1998797.905458" miny="-2749996.025036" maxx="2930377.601350" maxy="-1808590.961851" />
 <BoundingBox CRS="EPSG:54030" minx="-1197.220328" miny="5222308.942734" maxx="932634.635340" maxy="5940218.262293" />
 <BoundingBox CRS="EPSG:7399" minx="-1117.353231" miny="5767402.687526" maxx="870418.166689" maxy="6487641.412002" />
 <BoundingBox CRS="EPSG:900913" minx="-1614.132617" miny="6273334.420261" maxx="1257409.308255" maxy="7560605.756670" />
@@ -119,6 +121,7 @@
 <BoundingBox CRS="EPSG:4258" minx="48.991000" miny="-0.014500" maxx="56.011000" maxy="11.295500" />
 <BoundingBox CRS="EPSG:4326" minx="48.991000" miny="-0.014500" maxx="56.011000" maxy="11.295500" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="1998797.905458" miny="-2749996.025036" maxx="2930377.601350" maxy="-1808590.961851" />
 <BoundingBox CRS="EPSG:54030" minx="-1197.220328" miny="5222308.942734" maxx="932634.635340" maxy="5940218.262293" />
 <BoundingBox CRS="EPSG:7399" minx="-1117.353231" miny="5767402.687526" maxx="870418.166689" maxy="6487641.412002" />
 <BoundingBox CRS="EPSG:900913" minx="-1614.132617" miny="6273334.420261" maxx="1257409.308255" maxy="7560605.756670" />
@@ -126,7 +129,16 @@
 <Dimension name="time" units="ISO8601" default="2024-12-23T13:00:00Z" multipleValues="1" nearestValue="0" current="1">2024-12-23T13:00:00Z</Dimension>
 <Dimension name="reference_time" units="ISO8601" default="2024-12-22T06:00:00Z" multipleValues="1" nearestValue="0" current="1">2024-12-22T06:00:00Z</Dimension>
 <Dimension name="model_level_number" units="hPa" default="90" multipleValues="1" nearestValue="0" >1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.arcus_harmonie_sorted_model_levels&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=air-temperature-ml&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.arcus_harmonie_sorted_model_levels&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=air-temperature-ml&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMSTimeSeries/test_WMSGetFeatureInfo_timeseries_forecastreferencetime_json_WMSGetCapabilities_testdatanc.xml
+++ b/tests/expectedoutputs/TestWMSTimeSeries/test_WMSGetFeatureInfo_timeseries_forecastreferencetime_json_WMSGetCapabilities_testdatanc.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 19 2025 08:49:47 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="37.352373" miny="-27.248854" maxx="65.890829" maxy="32.682179" />
 <BoundingBox CRS="EPSG:4326" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
 <BoundingBox CRS="EPSG:54030" minx="-2010910.349488" miny="3994561.026658" maxx="2383791.664599" maxy="6899708.714622" />
 <BoundingBox CRS="EPSG:7399" minx="-1688218.598491" miny="4491365.234972" maxx="1973986.260472" maxy="7420353.104506" />
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
@@ -117,10 +119,55 @@
 <BoundingBox CRS="EPSG:4258" minx="37.352373" miny="-27.248854" maxx="65.890829" maxy="32.682179" />
 <BoundingBox CRS="EPSG:4326" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
 <BoundingBox CRS="EPSG:54030" minx="-2010910.349488" miny="3994561.026658" maxx="2383791.664599" maxy="6899708.714622" />
 <BoundingBox CRS="EPSG:7399" minx="-1688218.598491" miny="4491365.234972" maxx="1973986.260472" maxy="7420353.104506" />
 <BoundingBox CRS="EPSG:900913" minx="-3032706.025370" miny="4488462.769264" maxx="3637528.401374" maxy="9846321.862963" />
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=testdata&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMSVolScan/test_WMSGetCapabilities_KNMI_VolScan.xml
+++ b/tests/expectedoutputs/TestWMSVolScan/test_WMSGetCapabilities_KNMI_VolScan.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 19 2025 08:49:47 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
@@ -117,12 +119,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>PhiDP</Name>
 <Title>PhiDP (PhiDP)</Title>
@@ -146,12 +193,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PhiDP&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PhiDP&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PhiDP&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PhiDP&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PhiDP&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PhiDP&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PhiDP&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PhiDP&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PhiDP&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PhiDP&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>RhoHV</Name>
 <Title>RhoHV (RhoHV)</Title>
@@ -175,12 +267,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RhoHV&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RhoHV&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RhoHV&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RhoHV&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RhoHV&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RhoHV&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RhoHV&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RhoHV&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RhoHV&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RhoHV&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>V</Name>
 <Title>V (V)</Title>
@@ -204,12 +341,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=V&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=V&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=V&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=V&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=V&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=V&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=V&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=V&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=V&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=V&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>W</Name>
 <Title>W (W)</Title>
@@ -233,12 +415,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=W&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=W&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=W&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=W&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=W&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=W&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=W&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=W&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=W&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=W&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>Z</Name>
 <Title>Z (Z)</Title>
@@ -262,12 +489,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Z&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Z&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Z&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Z&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Z&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Z&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Z&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Z&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Z&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Z&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>Zv</Name>
 <Title>Zv (Zv)</Title>
@@ -291,12 +563,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Zv&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Zv&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Zv&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Zv&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Zv&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Zv&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Zv&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Zv&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Zv&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Zv&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>ZDR</Name>
 <Title>ZDR (ZDR)</Title>
@@ -320,12 +637,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>Height</Name>
 <Title>Height (Height)</Title>
@@ -349,12 +711,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>

--- a/tests/expectedoutputs/TestWMSVolScan/test_WMSGetCapabilities_ODIM_VolScan.xml
+++ b/tests/expectedoutputs/TestWMSVolScan/test_WMSGetCapabilities_ODIM_VolScan.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 6.0.0, of Nov 19 2025 08:49:47 </Keyword>
+            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -73,6 +73,7 @@
 <CRS>EPSG:4258</CRS>
 <CRS>EPSG:4326</CRS>
 <CRS>EPSG:50001</CRS>
+<CRS>EPSG:5041</CRS>
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
@@ -91,6 +92,7 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
@@ -117,12 +119,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=KDP&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>PHIDP</Name>
 <Title>PHIDP (PHIDP)</Title>
@@ -146,12 +193,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PHIDP&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PHIDP&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PHIDP&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PHIDP&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PHIDP&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PHIDP&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PHIDP&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PHIDP&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PHIDP&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=PHIDP&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>RHOHV</Name>
 <Title>RHOHV (RHOHV)</Title>
@@ -175,12 +267,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RHOHV&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RHOHV&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RHOHV&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RHOHV&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RHOHV&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RHOHV&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RHOHV&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RHOHV&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RHOHV&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=RHOHV&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>VRADH</Name>
 <Title>VRADH (VRADH)</Title>
@@ -204,12 +341,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=VRADH&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=VRADH&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=VRADH&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=VRADH&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=VRADH&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=VRADH&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=VRADH&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=VRADH&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=VRADH&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=VRADH&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>WRADH</Name>
 <Title>WRADH (WRADH)</Title>
@@ -233,12 +415,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=WRADH&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=WRADH&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=WRADH&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=WRADH&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=WRADH&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=WRADH&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=WRADH&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=WRADH&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=WRADH&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=WRADH&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>DBZH</Name>
 <Title>DBZH (DBZH)</Title>
@@ -262,12 +489,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZH&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZH&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZH&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZH&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZH&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZH&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZH&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZH&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZH&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZH&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>DBZV</Name>
 <Title>DBZV (DBZV)</Title>
@@ -291,12 +563,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZV&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZV&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZV&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZV&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZV&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZV&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZV&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZV&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZV&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=DBZV&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>ZDR</Name>
 <Title>ZDR (ZDR)</Title>
@@ -320,12 +637,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=ZDR&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
 <Layer queryable="1" opaque="1" cascaded="0">
 <Name>Height</Name>
 <Title>Height (Height)</Title>
@@ -349,12 +711,57 @@
 <BoundingBox CRS="EPSG:4258" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:4326" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
 <BoundingBox CRS="EPSG:50001" minx="-2000000.000000" miny="-2000000.000000" maxx="10000000.000000" maxy="8500000.000000" />
+<BoundingBox CRS="EPSG:5041" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
 <BoundingBox CRS="EPSG:54030" minx="38517.746563" miny="5219403.478262" maxx="808409.364412" maxy="5809122.919112" />
 <BoundingBox CRS="EPSG:7399" minx="34630.012423" miny="5764450.407473" maxx="754605.015598" maxy="6357495.003425" />
 <BoundingBox CRS="EPSG:900913" minx="54221.780785" miny="6268589.825417" maxx="1089719.603288" maxy="7305934.122526" />
 <Dimension name="time" units="ISO8601" default="2021-06-18T18:50:00Z" multipleValues="1" nearestValue="0" current="1">2021-06-18T18:50:00Z</Dimension>
 <Dimension name="scan_elevation" units="degrees" default="8" multipleValues="1" nearestValue="0" >0.3l,0.3,0.8,1.2,2,2.8,4.5,6,8</Dimension>
-   <Style>    <Name>auto/nearest</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=auto/nearest"/>    </LegendURL>  </Style>   <Style>    <Name>autogeneric</Name>    <Title>Auto style blue-white-red</Title>    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=autogeneric"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear</Name>    <Title>Auto style bilnear blue-white-red</Title>    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=autobilinear"/>    </LegendURL>  </Style>   <Style>    <Name>autoboxoutline</Name>    <Title>Grid boxes</Title>    <Abstract>Render grid boxes if applicable</Abstract>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=autoboxoutline"/>    </LegendURL>  </Style>   <Style>    <Name>autobilinear_deprecated/bilinear</Name>    <Title>autobilinear_deprecated/bilinear</Title>    <LegendURL width="300" height="400">       <Format>image/png</Format>       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>    </LegendURL>  </Style></Layer>
+   <Style>
+    <Name>auto/nearest</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Fast nearest neighbour interpolation using the nearest neighbour renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=auto/nearest"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autogeneric</Name>
+    <Title>Auto style blue-white-red</Title>
+    <Abstract>Nearest neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=autogeneric"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear</Name>
+    <Title>Auto style bilnear blue-white-red</Title>
+    <Abstract>Bilinear neighbour interpolation using the generic renderer</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=autobilinear"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autoboxoutline</Name>
+    <Title>Grid boxes</Title>
+    <Abstract>Render grid boxes if applicable</Abstract>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=autoboxoutline"/>
+    </LegendURL>
+  </Style>
+   <Style>
+    <Name>autobilinear_deprecated/bilinear</Name>
+    <Title>autobilinear_deprecated/bilinear</Title>
+    <LegendURL width="300" height="400">
+       <Format>image/png</Format>
+       <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=Height&amp;format=image/png&amp;STYLE=autobilinear_deprecated/bilinear"/>
+    </LegendURL>
+  </Style>
+</Layer>
     </Layer>
   </Capability>
 </WMS_Capabilities>


### PR DESCRIPTION
Version 7.2.0

## What's Changed
* 677 add user agent back to logging by @maartenplieger in https://github.com/KNMI/adaguc-server/pull/680
* Fixed rendering issue with linear transform by @maartenplieger in https://github.com/KNMI/adaguc-server/pull/681
* Compiles under clang without warnings by @mgrunbauer in https://github.com/KNMI/adaguc-server/pull/684
* Refactored dimension handling by @maartenplieger in https://github.com/KNMI/adaguc-server/pull/679
* Run sanitize build in CI by @mgrunbauer in https://github.com/KNMI/adaguc-server/pull/686
* Improve error handling by @maartenplieger in https://github.com/KNMI/adaguc-server/pull/685
* Get time, reftime without param order dependency by @mgrunbauer in https://github.com/KNMI/adaguc-server/pull/678
* Use correct allocate data method by @maartenplieger in https://github.com/KNMI/adaguc-server/pull/687
* Replaced CAIRO_LINE_JOIN_MITER with BEVEL by @loescornelis in https://github.com/KNMI/adaguc-server/pull/683
* WMS GetFeatureInfo for timeseries now sorts properly when * is used for the time dimension by @maartenplieger in https://github.com/KNMI/adaguc-server/pull/689
* Upgrade py3.14 by @mgrunbauer in https://github.com/KNMI/adaguc-server/pull/692
* Brotli encoding is now done only for certain Content-Types. by @maartenplieger in https://github.com/KNMI/adaguc-server/pull/690
* Add EPSG:5041 as a supported projection


**Full Changelog**: https://github.com/KNMI/adaguc-server/compare/7.1.2...7.2.0