### PR TITLE
Use binary search for shadeinterval in bilinear interpolation

### DIFF
--- a/adagucserverEC/CDrawFunction.cpp
+++ b/adagucserverEC/CDrawFunction.cpp
@@ -1,4 +1,5 @@
 #include "CDrawFunction.h"
+#include <algorithm>
 
 template <class T> void drawIndexPixel(int &x, int &y, T &val, GDWDrawFunctionSettings &settings) {
   if (settings.legendLog != 0) {
@@ -54,9 +55,21 @@ template <class T> CColor determinePixelColorFromValue(T val, GDWDrawFunctionSet
         return settings->drawImage->getColorForIndex(determinePixelIndexFromValue(f, *settings));
 
       } else {
-        for (size_t j = 0; (j < settings->intervals.size()); j += 1) {
-          if (val >= settings->intervals[j].min && val < settings->intervals[j].max) {
-            return settings->intervals[j].color;
+        if (settings->intervalsCanUseBinarySearch) {
+          // If ShadeIntervals are sorted and non-overlapping, use binary search.
+          auto intervalIt = std::upper_bound(settings->intervals.begin(), settings->intervals.end(), val, [](auto value, const Interval &interval) { return value < interval.min; });
+          if (intervalIt != settings->intervals.begin()) {
+            intervalIt--;
+            if (val < intervalIt->max) {
+              return intervalIt->color;
+            }
+          }
+        } else {
+          // Cannot use binary search, just loop through intervals manually.
+          for (size_t j = 0; (j < settings->intervals.size()); j += 1) {
+            if (val >= settings->intervals[j].min && val < settings->intervals[j].max) {
+              return settings->intervals[j].color;
+            }
           }
         }
       }

--- a/adagucserverEC/CDrawFunction.cpp
+++ b/adagucserverEC/CDrawFunction.cpp
@@ -55,21 +55,12 @@ template <class T> CColor determinePixelColorFromValue(T val, GDWDrawFunctionSet
         return settings->drawImage->getColorForIndex(determinePixelIndexFromValue(f, *settings));
 
       } else {
-        if (settings->intervalsCanUseBinarySearch) {
-          // If ShadeIntervals are sorted and non-overlapping, use binary search.
-          auto intervalIt = std::upper_bound(settings->intervals.begin(), settings->intervals.end(), val, [](auto value, const Interval &interval) { return value < interval.min; });
-          if (intervalIt != settings->intervals.begin()) {
-            intervalIt--;
-            if (val < intervalIt->max) {
-              return intervalIt->color;
-            }
-          }
-        } else {
-          // Cannot use binary search, just loop through intervals manually.
-          for (size_t j = 0; (j < settings->intervals.size()); j += 1) {
-            if (val >= settings->intervals[j].min && val < settings->intervals[j].max) {
-              return settings->intervals[j].color;
-            }
+        // use binary search to find matching interval
+        auto intervalIt = std::upper_bound(settings->intervals.begin(), settings->intervals.end(), val, [](auto value, const Interval &interval) { return value < interval.min; });
+        if (intervalIt != settings->intervals.begin()) {
+          intervalIt--;
+          if (val < intervalIt->max) {
+            return intervalIt->color;
           }
         }
       }

--- a/adagucserverEC/CDrawFunction.cpp
+++ b/adagucserverEC/CDrawFunction.cpp
@@ -58,6 +58,7 @@ template <class T> CColor determinePixelColorFromValue(T val, GDWDrawFunctionSet
         // use binary search to find matching interval
         auto intervalIt = std::upper_bound(settings->intervals.begin(), settings->intervals.end(), val, [](auto value, const Interval &interval) { return value < interval.min; });
         if (intervalIt != settings->intervals.begin()) {
+          // std::upper_bound returns the first element that's >=value. We need to check the element before that
           intervalIt--;
           if (val < intervalIt->max) {
             return intervalIt->color;

--- a/adagucserverEC/GenericDataWarper/GDWDrawFunctionSettings.cpp
+++ b/adagucserverEC/GenericDataWarper/GDWDrawFunctionSettings.cpp
@@ -68,9 +68,16 @@ GDWDrawFunctionSettings getDrawFunctionSettings(CDataSource *dataSource, CDrawIm
       settings.shadeInterval = atof(styleConfiguration->shadeIntervals[0].elementValue.c_str());
     } else {
       settings.intervals.reserve(numShadeDefs);
+      settings.intervalsCanUseBinarySearch = numShadeDefs > 0;
       for (int j = 0; j < numShadeDefs; j++) {
         const CServerConfig::XMLE_ShadeInterval &shadeInterVal = styleConfiguration->shadeIntervals[j];
         settings.intervals.push_back(Interval({.min = atof(shadeInterVal.attr.min.c_str()), .max = atof(shadeInterVal.attr.max.c_str()), .color = CColor(shadeInterVal.attr.fillcolor.c_str())}));
+
+        // If intervals are not sorted, we cannot use binary search
+        const Interval &interval = settings.intervals.back();
+        if (interval.min >= interval.max || (j > 0 && interval.min < settings.intervals[j - 1].max)) {
+          settings.intervalsCanUseBinarySearch = false;
+        }
         /* Check for bgcolor */
         if (j == 0) {
           if (shadeInterVal.attr.bgcolor.empty() == false) {

--- a/adagucserverEC/GenericDataWarper/GDWDrawFunctionSettings.cpp
+++ b/adagucserverEC/GenericDataWarper/GDWDrawFunctionSettings.cpp
@@ -1,4 +1,5 @@
 #include "GenericDataWarper/GDWDrawFunctionSettings.h"
+#include <algorithm>
 #include <sys/types.h>
 #include <CImageOperators/smoothRasterField.h>
 
@@ -64,26 +65,22 @@ GDWDrawFunctionSettings getDrawFunctionSettings(CDataSource *dataSource, CDrawIm
   /* Make a shorthand vector from the shadeInterval configuration*/
   if (settings.isUsingShadeIntervals) {
     int numShadeDefs = (int)styleConfiguration->shadeIntervals.size();
-    if (numShadeDefs == 1 && !styleConfiguration->shadeIntervals[0].elementValue.empty()) {
-      settings.shadeInterval = atof(styleConfiguration->shadeIntervals[0].elementValue.c_str());
-    } else {
-      settings.intervals.reserve(numShadeDefs);
-      settings.intervalsCanUseBinarySearch = numShadeDefs > 0;
-      for (int j = 0; j < numShadeDefs; j++) {
-        const CServerConfig::XMLE_ShadeInterval &shadeInterVal = styleConfiguration->shadeIntervals[j];
-        settings.intervals.push_back(Interval({.min = atof(shadeInterVal.attr.min.c_str()), .max = atof(shadeInterVal.attr.max.c_str()), .color = CColor(shadeInterVal.attr.fillcolor.c_str())}));
-
-        // If intervals are not sorted, we cannot use binary search
-        const Interval &interval = settings.intervals.back();
-        if (interval.min >= interval.max || (j > 0 && interval.min < settings.intervals[j - 1].max)) {
-          settings.intervalsCanUseBinarySearch = false;
+    if (numShadeDefs > 0) {
+      if (numShadeDefs == 1 && !styleConfiguration->shadeIntervals[0].elementValue.empty()) {
+        settings.shadeInterval = atof(styleConfiguration->shadeIntervals[0].elementValue.c_str());
+      } else {
+        settings.intervals.reserve(numShadeDefs);
+        for (const auto &shadeInterval : styleConfiguration->shadeIntervals) {
+          settings.intervals.push_back(Interval({.min = atof(shadeInterval.attr.min.c_str()), .max = atof(shadeInterval.attr.max.c_str()), .color = CColor(shadeInterval.attr.fillcolor.c_str())}));
         }
-        /* Check for bgcolor */
-        if (j == 0) {
-          if (shadeInterVal.attr.bgcolor.empty() == false) {
-            settings.bgColorDefined = true;
-            settings.bgColor = CColor(shadeInterVal.attr.bgcolor.c_str());
-          }
+        // Sort shaded intervals on min value
+        std::sort(settings.intervals.begin(), settings.intervals.end(), [](const Interval &left, const Interval &right) { return left.min < right.min; });
+
+        // Check for bgcolor in first element
+        const std::string &firstElemBgColor = styleConfiguration->shadeIntervals.front().attr.bgcolor;
+        if (!firstElemBgColor.empty()) {
+          settings.bgColorDefined = true;
+          settings.bgColor = CColor(firstElemBgColor);
         }
       }
     }

--- a/adagucserverEC/GenericDataWarper/GDWDrawFunctionSettings.h
+++ b/adagucserverEC/GenericDataWarper/GDWDrawFunctionSettings.h
@@ -6,6 +6,7 @@
 #include "CGenericDataWarper.h"
 #include "CColor.h"
 #include "CDrawImage.h"
+#include <vector>
 
 enum InterpolationMethod { InterpolationMethodNearest, InterpolationMethodBilinear };
 enum LegendMode { LegendModeContinuous, LegendModeDiscrete };
@@ -34,6 +35,7 @@ struct GDWDrawFunctionSettings {
   bool drawgrid = true;
   InterpolationMethod interpolationMethod = InterpolationMethodNearest;
   std::vector<Interval> intervals;
+  bool intervalsCanUseBinarySearch = false;
   CDrawImage *drawImage;
   CDFType destinationDataType;
   void *destinationGrid = nullptr;

--- a/adagucserverEC/GenericDataWarper/GDWDrawFunctionSettings.h
+++ b/adagucserverEC/GenericDataWarper/GDWDrawFunctionSettings.h
@@ -35,7 +35,6 @@ struct GDWDrawFunctionSettings {
   bool drawgrid = true;
   InterpolationMethod interpolationMethod = InterpolationMethodNearest;
   std::vector<Interval> intervals;
-  bool intervalsCanUseBinarySearch = false;
   CDrawImage *drawImage;
   CDFType destinationDataType;
   void *destinationGrid = nullptr;

--- a/adagucserverEC/GenericDataWarper/GDWDrawFunctionSettings.h
+++ b/adagucserverEC/GenericDataWarper/GDWDrawFunctionSettings.h
@@ -6,7 +6,6 @@
 #include "CGenericDataWarper.h"
 #include "CColor.h"
 #include "CDrawImage.h"
-#include <vector>
 
 enum InterpolationMethod { InterpolationMethodNearest, InterpolationMethodBilinear };
 enum LegendMode { LegendModeContinuous, LegendModeDiscrete };

--- a/adagucserverEC/testadagucserver.cpp
+++ b/adagucserverEC/testadagucserver.cpp
@@ -6,6 +6,7 @@
 #include "CImgRenderFieldVectors.h"
 #include "f8vector.h"
 #include "ProjCache.h"
+#include "CDrawFunction.h"
 
 // To test this file do in the ./bin folder of adaguc-server:
 // cmake --build . --config Debug --target testadagucserver -j 10 -- && ctest --verbose
@@ -266,4 +267,44 @@ TEST(string, knmiH5TimeToISOString) {
   t[14] = '0';
   CDBDebug("t [%s]", t.c_str());
   CHECK("20211222T123400" == t);
+}
+
+TEST(CDrawFunction, determinePixelColorFromValue) {
+  GDWDrawFunctionSettings settings = {
+      .dfNodataValue = -9999,
+      .legendValueRange = 0,
+      .legendLowerRange = 0,
+      .legendUpperRange = 0,
+      .isUsingShadeIntervals = true,
+      .bgColorDefined = false,
+      .shadeInterval = 0,
+      .legendLog = 0,
+      .legendLogAsLog = 0,
+      .legendScale = 0,
+      .legendOffset = 0,
+      .bgColor = CColor(0, 0, 0, 255),
+      .hasNodataValue = true,
+      .drawgridboxoutline = false,
+      .drawgrid = true,
+      .interpolationMethod = InterpolationMethodNearest,
+      .intervals = {},
+      .drawImage = nullptr,
+      .destinationDataType = CDF_FLOAT,
+      .destinationGrid = nullptr,
+      .smoothingFiter = 0,
+      .smoothingMemo = {},
+  };
+  // Test if it returns default color when there are no shadeintervals
+  CHECK(determinePixelColorFromValue(0, &settings).c_str() == CColor(0, 0, 0, 0).c_str());
+
+  settings.intervals.push_back({.min = -1, .max = 0, .color = CColor(50, 50, 50, 50)});
+  settings.intervals.push_back({.min = 0, .max = 1, .color = CColor(100, 100, 100, 100)});
+  settings.intervals.push_back({.min = 1, .max = 2, .color = CColor(150, 150, 150, 150)});
+
+  // Test if correct colors are returned based on shade intervals
+  CHECK(determinePixelColorFromValue(-2, &settings).c_str() == CColor(0, 0, 0, 0).c_str());
+  CHECK(determinePixelColorFromValue(-1, &settings).c_str() == CColor(50, 50, 50, 50).c_str());
+  CHECK(determinePixelColorFromValue(0, &settings).c_str() == CColor(100, 100, 100, 100).c_str());
+  CHECK(determinePixelColorFromValue(1, &settings).c_str() == CColor(150, 150, 150, 150).c_str());
+  CHECK(determinePixelColorFromValue(2, &settings).c_str() == CColor(0, 0, 0, 0).c_str());
 }


### PR DESCRIPTION
Profiling the generic warper with `interpolationmethod="bilinear"` for a dataset with many `<ShadeInterval>` elements, revealed that over 100 calls, 45% of runtime was spent in `memoizedDeterminePixelColorFromValue<float>`.

Further debugging showed adaguc eventually calls `determinePixelColorFromValue` from `CDrawFunction.cpp` for every pixel. Adaguc then loops through the shaded intervals, which is slow.

This PR uses `std::upper_bound` which uses binary search to find the matching shaded interval.

It helps especially with a large number of shaded intervals (e.g. 100), it's just about equal for 5 shaded intervals according to the benchmark (80 calls):

|Number of shaded intervals|Master|Branch|
|-|-|-|
|100|12.47|7.22|
|5|6.85|6.83|

Flamegraph master:
<img width="1634" height="837" alt="master" src="https://github.com/user-attachments/assets/83643ffc-d07e-4fd8-8adc-b2b872f2a9b9" />
Flamegraph branch:
<img width="1636" height="835" alt="branch" src="https://github.com/user-attachments/assets/663fb149-2592-4474-9c93-919fbb0c551a" />