### PR TITLE
Disabling range requests

### DIFF
--- a/python/python_fastapi_server/main.py
+++ b/python/python_fastapi_server/main.py
@@ -10,6 +10,8 @@ from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from asgi_logger import AccessLoggerMiddleware
 
 from middleware.x_forwarded_headers import ForwardedHostAndPrefixMiddleware
+from middleware.disable_range_requests import DisableRangeRequests
+
 from routers.ContentTypeBasedBrotli import ContentTypeBasedBrotli
 from routers.autowms import autowms_router
 from routers.edr import edrApiApp
@@ -53,6 +55,8 @@ if allowed_hosts is not None and len(allowed_hosts) > 0:
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=[host.strip() for host in allowed_hosts.split(",")])
 
 app.add_middleware(ForwardedHostAndPrefixMiddleware, trusted_hosts=os.environ.get("ADAGUC_TRUSTED_PROXIES", "127.0.0.1"))
+
+app.add_middleware(DisableRangeRequests)
 
 if "ADAGUC_REDIS" in os.environ:
     app.add_middleware(CachingMiddleware)

--- a/python/python_fastapi_server/middleware/disable_range_requests.py
+++ b/python/python_fastapi_server/middleware/disable_range_requests.py
@@ -1,0 +1,18 @@
+import logging
+
+from starlette.responses import PlainTextResponse
+from uvicorn._types import ASGI3Application, ASGIReceiveCallable, ASGISendCallable, Scope
+
+
+class DisableRangeRequests:
+
+    def __init__(self, app: ASGI3Application) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        headers: dict[bytes, bytes] = dict(scope["headers"])
+        logging.info(str(headers))
+        if b"range" in headers:
+            response = PlainTextResponse("Range requests are not supported", status_code=400)
+            return await response(scope, receive, send)
+        return await self.app(scope, receive, send)

--- a/python/python_fastapi_server/test_range_header_support.py
+++ b/python/python_fastapi_server/test_range_header_support.py
@@ -1,0 +1,58 @@
+"""
+Range headers are currently not supported.
+"""
+
+import os
+import re
+from importlib import reload
+from xml.etree import ElementTree
+from fastapi.testclient import TestClient
+from fastapi import Response
+import main
+
+
+def get_testclient(environment=None):
+    """Return a fresh testclient with specific environment settings"""
+
+    # Default environment
+    os.environ["EXTERNALADDRESS"] = ""
+    os.environ["ADAGUC_TRUSTED_HOSTS"] = ""
+    os.environ["ADAGUC_TRUSTED_PROXIES"] = ""
+    os.environ["ADAGUC_CONFIG"] = os.path.join(os.environ["ADAGUC_PATH"], "data", "config", "adaguc.dataset.xml")
+
+    # Configured environment
+    if environment is not None:
+        for item, value in environment.items():
+            os.environ[item] = value
+
+    # Force reload of the app, so environment variables are propagated to the middlewares
+    reload(main)
+    client = TestClient(
+        main.app,
+        client=("adaguc-testclient", 50000),
+    )
+    client.base_url = "http://default-test-server"
+    client.client = {}
+    client.headers = {}
+    return client
+
+
+def test_range_requests_blocked():
+    """
+    Test that range header request are really blocked
+    """
+    client = get_testclient(
+        environment={
+            "EXTERNALADDRESS": "",
+            "ADAGUC_TRUSTED_HOSTS": "",
+            "ADAGUC_TRUSTED_PROXIES": "*",  # default
+        }
+    )
+    response = client.get(
+        "/adaguc-server?service=WMS&request=getCapabilities",
+        headers={
+            "Host": "my-host-to-be-ignored",
+            "Range": "bytes=0-0",
+        },
+    )
+    assert response.status_code == 400


### PR DESCRIPTION
Range requests are now disabled. We simply do not support them.

To test:

```
curl -r 0-199,1000-1199 "http://localhost:8080/adagucserver?source=mv100.nc&&service=WMS&request=getmap&format=image/png&layers=dep
th&width=400&CRS=EPSG:4326&STYLES=&EXCEPTIONS=INIMAGE&showlegend=true&0.5026339875397062"
```

Should return a 400.

Note that GeoWeb still makes range requests, this will soon be fixed.