### PR TITLE
Support inverted BBOX axis order for EPSG:32661 in WMS 1.3.0

### DIFF
--- a/adagucserverEC/CServerConfig_CPPXSD.h
+++ b/adagucserverEC/CServerConfig_CPPXSD.h
@@ -1381,7 +1381,7 @@ struct CServerConfig : CXMLObjectInterface {
   };
   struct XMLE_Projection : CXMLObjectInterface {
     struct Cattr {
-      std::string id, proj4;
+      std::string id, proj4, invertxyforwms130;
     } attr;
     std::vector<XMLE_LatLonBox *> LatLonBox;
     ~XMLE_Projection() { XMLE_DELOBJ(LatLonBox); }
@@ -1389,9 +1389,11 @@ struct CServerConfig : CXMLObjectInterface {
       if ("id" == attrCfg.name) {
         attr.id = attrCfg.value;
         return true;
-      }
-      if ("proj4" == attrCfg.name) {
+      } else if ("proj4" == attrCfg.name) {
         attr.proj4 = attrCfg.value;
+        return true;
+      } else if ("invertxyforwms130" == attrCfg.name) {
+        attr.invertxyforwms130 = attrCfg.value;
         return true;
       }
       return false;

--- a/adagucserverEC/CServerParams.cpp
+++ b/adagucserverEC/CServerParams.cpp
@@ -214,12 +214,11 @@ bool CServerParams::checkBBOXXYOrder(const char *projName) {
     } else {
       projNameString = projName;
     }
-    if (projNameString == ("EPSG:4326"))
-      return true;
-    else if (projNameString == ("EPSG:4258"))
-      return true;
-    else if (projNameString == ("CRS:84"))
-      return true;
+    auto comp = [projNameString](CServerConfig::XMLE_Projection *a) { return a->attr.id == projNameString.c_str(); };
+    auto it = std::find_if(cfg->Projection.begin(), cfg->Projection.end(), comp);
+    if (it != cfg->Projection.end()) {
+      return CT::equalsIgnoreCase((*it)->attr.invertxyforwms130, "true");
+    }
   }
   return false;
 }

--- a/data/config/includes/Projection.include.xml
+++ b/data/config/includes/Projection.include.xml
@@ -5,8 +5,8 @@
   <Projection id="EPSG:3575" proj4="+proj=laea +lat_0=90 +lon_0=10 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs"/>
 
   <Projection id="EPSG:3857" proj4="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"/>
-  <Projection id="EPSG:4258" proj4="+proj=longlat +ellps=GRS80 +no_defs"/>
-  <Projection id="EPSG:4326" proj4="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"/>
+  <Projection id="EPSG:4258" invertxyforwms130="true" proj4="+proj=longlat +ellps=GRS80 +no_defs"/>
+  <Projection id="EPSG:4326" invertxyforwms130="true" proj4="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"/>
   <Projection id="EPSG:5041" proj4="+proj=stere +lat_0=90 +lon_0=0 +k=0.994 +x_0=2000000 +y_0=2000000 +datum=WGS84 +units=m +no_defs +type=crs"/>
   <Projection id="CRS:84" proj4="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"/>
   <Projection id="EPSG:25831" proj4="+proj=utm +zone=31 +ellps=GRS80 +units=m +no_defs"/>
@@ -18,7 +18,7 @@
     <LatLonBox minx="-2000000" miny="-2000000" maxx="10000000" maxy="8500000"/>
   </Projection>
   <Projection id="EPSG:54030" proj4="+proj=robin +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs "/>
-  <Projection id="EPSG:32661" proj4="+proj=stere +lat_0=90 +lat_ts=90 +lon_0=0 +k=0.994 +x_0=2000000 +y_0=2000000 +ellps=WGS84 +datum=WGS84 +units=m +no_defs"/>
+  <Projection id="EPSG:32661" invertxyforwms130="true" proj4="+proj=stere +lat_0=90 +lat_ts=90 +lon_0=0 +k=0.994 +x_0=2000000 +y_0=2000000 +ellps=WGS84 +datum=WGS84 +units=m +no_defs"/>
   <Projection id="EPSG:40000" proj4="+proj=stere +ellps=WGS84 +lat_0=90 +lon_0=0 +no_defs"/>
   <Projection id="EPSG:900913" proj4=" +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +no_defs"/>
   <Projection id="EPSG:3067" proj4="+proj=utm +zone=35 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs"/>

--- a/python/lib/adaguc/AdagucTestTools.py
+++ b/python/lib/adaguc/AdagucTestTools.py
@@ -311,22 +311,20 @@ class AdagucTestTools:
         except Exception:
             pass
 
-        # Boundingbox extent values are too varying by different Proj libraries
-        def removeBBOX(root):
-            if root.tag.title() == "Boundingbox":
-                # root.getparent().remove(root)
-                try:
-                    del root.attrib["minx"]
-                    del root.attrib["miny"]
-                    del root.attrib["maxx"]
-                    del root.attrib["maxy"]
-                except Exception:
-                    pass
-            for elem in root.getchildren():
-                removeBBOX(elem)
+        # Boundingbox extent values are too varying by different Proj libraries, so
+        # accept small differences instead of failing on them.
+        def compareBBOX(root1, root2, threshold=100):
+            if root1.tag.title() == "Boundingbox" and root2.tag.title() == "Boundingbox":
+                for attrName in ("minx", "miny", "maxx", "maxy"):
+                    try:
+                        if abs(float(root1.attrib[attrName]) - float(root2.attrib[attrName])) <= threshold:
+                            root2.attrib[attrName] = root1.attrib[attrName]
+                    except Exception:
+                        pass
+            for elem1, elem2 in zip(root1.getchildren(), root2.getchildren()):
+                compareBBOX(elem1, elem2)
 
-        removeBBOX(obj1)
-        removeBBOX(obj2)
+        compareBBOX(obj1, obj2)
 
         # Remove contents of problem envelopes EPSG:28992 and EPSG:7399 because they are inconsistent
         def removeGmlEnvelope(root, epsg_code):

--- a/tests/expectedoutputs/TestCSV/test_CSV_reference_timesupport_GetCapabilities.xml
+++ b/tests/expectedoutputs/TestCSV/test_CSV_reference_timesupport_GetCapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testCSVReader_reference_time&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
+<BoundingBox CRS="CRS:84" minx="0.250000" miny="47.099998" maxx="0.250000" maxy="49.099998" />
 <BoundingBox CRS="EPSG:25831" minx="295267.526825" miny="5331072.043142" maxx="295267.526825" maxy="5331074.043142" />
 <BoundingBox CRS="EPSG:25832" minx="-151168.761917" miny="5364559.671213" maxx="-151168.761917" maxy="5364561.671213" />
 <BoundingBox CRS="EPSG:28992" minx="-227870.303123" miny="24978.089268" maxx="-227870.303123" maxy="24980.089268" />
 <BoundingBox CRS="EPSG:3035" minx="3596861.700352" miny="2824165.391868" maxx="3596861.700352" maxy="2824167.391868" />
 <BoundingBox CRS="EPSG:3067" minx="-1481251.794314" miny="5683942.666186" maxx="-1481251.794314" maxy="5683944.666186" />
-<BoundingBox CRS="EPSG:32661" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
+<BoundingBox CRS="EPSG:32661" minx="-2862516.368656" miny="2021216.860424" maxx="-2862514.368656" maxy="2021216.860424" />
 <BoundingBox CRS="EPSG:3411" minx="3369518.975082" miny="-3340242.934311" maxx="3369518.975082" maxy="-3340240.934311" />
 <BoundingBox CRS="EPSG:3412" minx="139827.348331" miny="32045863.308502" maxx="139827.348331" maxy="32045865.308502" />
 <BoundingBox CRS="EPSG:3575" minx="-773790.384558" miny="-4503195.781262" maxx="-773790.384558" maxy="-4503193.781262" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>0.250000</eastBoundLongitude>
   <southBoundLatitude>47.099998</southBoundLatitude>
   <northBoundLatitude>49.099998</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.250000" miny="47.099998" maxx="0.250000" maxy="49.099998" />
 <BoundingBox CRS="EPSG:25831" minx="295267.526825" miny="5331072.043142" maxx="295267.526825" maxy="5331074.043142" />
 <BoundingBox CRS="EPSG:25832" minx="-151168.761917" miny="5364559.671213" maxx="-151168.761917" maxy="5364561.671213" />
 <BoundingBox CRS="EPSG:28992" minx="-227870.303123" miny="24978.089268" maxx="-227870.303123" maxy="24980.089268" />
 <BoundingBox CRS="EPSG:3035" minx="3596861.700352" miny="2824165.391868" maxx="3596861.700352" maxy="2824167.391868" />
 <BoundingBox CRS="EPSG:3067" minx="-1481251.794314" miny="5683942.666186" maxx="-1481251.794314" maxy="5683944.666186" />
-<BoundingBox CRS="EPSG:32661" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
+<BoundingBox CRS="EPSG:32661" minx="-2862516.368656" miny="2021216.860424" maxx="-2862514.368656" maxy="2021216.860424" />
 <BoundingBox CRS="EPSG:3411" minx="3369518.975082" miny="-3340242.934311" maxx="3369518.975082" maxy="-3340240.934311" />
 <BoundingBox CRS="EPSG:3412" minx="139827.348331" miny="32045863.308502" maxx="139827.348331" maxy="32045865.308502" />
 <BoundingBox CRS="EPSG:3575" minx="-773790.384558" miny="-4503195.781262" maxx="-773790.384558" maxy="-4503193.781262" />
@@ -150,13 +150,13 @@
   <eastBoundLongitude>0.250000</eastBoundLongitude>
   <southBoundLatitude>47.099998</southBoundLatitude>
   <northBoundLatitude>49.099998</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.250000" miny="47.099998" maxx="0.250000" maxy="49.099998" />
 <BoundingBox CRS="EPSG:25831" minx="295267.526825" miny="5331072.043142" maxx="295267.526825" maxy="5331074.043142" />
 <BoundingBox CRS="EPSG:25832" minx="-151168.761917" miny="5364559.671213" maxx="-151168.761917" maxy="5364561.671213" />
 <BoundingBox CRS="EPSG:28992" minx="-227870.303123" miny="24978.089268" maxx="-227870.303123" maxy="24980.089268" />
 <BoundingBox CRS="EPSG:3035" minx="3596861.700352" miny="2824165.391868" maxx="3596861.700352" maxy="2824167.391868" />
 <BoundingBox CRS="EPSG:3067" minx="-1481251.794314" miny="5683942.666186" maxx="-1481251.794314" maxy="5683944.666186" />
-<BoundingBox CRS="EPSG:32661" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
+<BoundingBox CRS="EPSG:32661" minx="-2862516.368656" miny="2021216.860424" maxx="-2862514.368656" maxy="2021216.860424" />
 <BoundingBox CRS="EPSG:3411" minx="3369518.975082" miny="-3340242.934311" maxx="3369518.975082" maxy="-3340240.934311" />
 <BoundingBox CRS="EPSG:3412" minx="139827.348331" miny="32045863.308502" maxx="139827.348331" maxy="32045865.308502" />
 <BoundingBox CRS="EPSG:3575" minx="-773790.384558" miny="-4503195.781262" maxx="-773790.384558" maxy="-4503193.781262" />
@@ -188,13 +188,13 @@
   <eastBoundLongitude>0.250000</eastBoundLongitude>
   <southBoundLatitude>47.099998</southBoundLatitude>
   <northBoundLatitude>49.099998</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.250000" miny="47.099998" maxx="0.250000" maxy="49.099998" />
 <BoundingBox CRS="EPSG:25831" minx="295267.526825" miny="5331072.043142" maxx="295267.526825" maxy="5331074.043142" />
 <BoundingBox CRS="EPSG:25832" minx="-151168.761917" miny="5364559.671213" maxx="-151168.761917" maxy="5364561.671213" />
 <BoundingBox CRS="EPSG:28992" minx="-227870.303123" miny="24978.089268" maxx="-227870.303123" maxy="24980.089268" />
 <BoundingBox CRS="EPSG:3035" minx="3596861.700352" miny="2824165.391868" maxx="3596861.700352" maxy="2824167.391868" />
 <BoundingBox CRS="EPSG:3067" minx="-1481251.794314" miny="5683942.666186" maxx="-1481251.794314" maxy="5683944.666186" />
-<BoundingBox CRS="EPSG:32661" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
+<BoundingBox CRS="EPSG:32661" minx="-2862516.368656" miny="2021216.860424" maxx="-2862514.368656" maxy="2021216.860424" />
 <BoundingBox CRS="EPSG:3411" minx="3369518.975082" miny="-3340242.934311" maxx="3369518.975082" maxy="-3340240.934311" />
 <BoundingBox CRS="EPSG:3412" minx="139827.348331" miny="32045863.308502" maxx="139827.348331" maxy="32045865.308502" />
 <BoundingBox CRS="EPSG:3575" minx="-773790.384558" miny="-4503195.781262" maxx="-773790.384558" maxy="-4503193.781262" />

--- a/tests/expectedoutputs/TestConvertLatLonBnds/test_ConvertLatLonBnds_getCapabilities.xml
+++ b/tests/expectedoutputs/TestConvertLatLonBnds/test_ConvertLatLonBnds_getCapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=example_file_latlonbnds%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="51.000000" miny="3.000000" maxx="53.000000" maxy="7.000000" />
+<BoundingBox CRS="CRS:84" minx="3.000000" miny="51.000000" maxx="7.000000" maxy="53.000000" />
 <BoundingBox CRS="EPSG:25831" minx="500000.000000" miny="5649824.888132" maxx="780631.054591" maxy="5879757.629488" />
 <BoundingBox CRS="EPSG:25832" minx="79142.928873" miny="5651728.682548" maxx="365786.750925" maxy="5889126.580102" />
 <BoundingBox CRS="EPSG:28992" minx="-12557.532230" miny="334483.538071" maxx="268209.963283" maxy="559655.555150" />
 <BoundingBox CRS="EPSG:3035" minx="3830472.135998" miny="3103060.820291" maxx="4119643.144373" maxy="3343905.347139" />
 <BoundingBox CRS="EPSG:3067" minx="-1172478.152224" miny="5842822.027990" maxx="-834194.575060" maxy="6146203.668400" />
-<BoundingBox CRS="EPSG:32661" minx="2222484.709163" miny="-2492318.258747" maxx="2548227.202889" maxy="-2219400.154905" />
+<BoundingBox CRS="EPSG:32661" minx="-2492318.258747" miny="2222484.709163" maxx="-2219400.154905" maxy="2548227.202889" />
 <BoundingBox CRS="EPSG:3411" minx="3082510.121445" miny="-2937027.807203" maxx="3458830.718135" maxy="-2553718.553925" />
 <BoundingBox CRS="EPSG:3412" minx="1812906.080463" miny="34381581.662488" maxx="4467203.359901" maxy="36605442.257300" />
 <BoundingBox CRS="EPSG:3575" minx="-519959.003821" miny="-4260681.181741" maxx="-212280.378599" maxy="-4025876.051045" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>7.000000</eastBoundLongitude>
   <southBoundLatitude>51.000000</southBoundLatitude>
   <northBoundLatitude>53.000000</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="51.000000" miny="3.000000" maxx="53.000000" maxy="7.000000" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="3.000000" miny="51.000000" maxx="7.000000" maxy="53.000000" />
 <BoundingBox CRS="EPSG:25831" minx="500000.000000" miny="5649824.888132" maxx="780631.054591" maxy="5879757.629488" />
 <BoundingBox CRS="EPSG:25832" minx="79142.928873" miny="5651728.682548" maxx="365786.750925" maxy="5889126.580102" />
 <BoundingBox CRS="EPSG:28992" minx="-12557.532230" miny="334483.538071" maxx="268209.963283" maxy="559655.555150" />
 <BoundingBox CRS="EPSG:3035" minx="3830472.135998" miny="3103060.820291" maxx="4119643.144373" maxy="3343905.347139" />
 <BoundingBox CRS="EPSG:3067" minx="-1172478.152224" miny="5842822.027990" maxx="-834194.575060" maxy="6146203.668400" />
-<BoundingBox CRS="EPSG:32661" minx="2222484.709163" miny="-2492318.258747" maxx="2548227.202889" maxy="-2219400.154905" />
+<BoundingBox CRS="EPSG:32661" minx="-2492318.258747" miny="2222484.709163" maxx="-2219400.154905" maxy="2548227.202889" />
 <BoundingBox CRS="EPSG:3411" minx="3082510.121445" miny="-2937027.807203" maxx="3458830.718135" maxy="-2553718.553925" />
 <BoundingBox CRS="EPSG:3412" minx="1812906.080463" miny="34381581.662488" maxx="4467203.359901" maxy="36605442.257300" />
 <BoundingBox CRS="EPSG:3575" minx="-519959.003821" miny="-4260681.181741" maxx="-212280.378599" maxy="-4025876.051045" />

--- a/tests/expectedoutputs/TestGeoJSON/test_GeoJSON_time_GetCapabilities.xml
+++ b/tests/expectedoutputs/TestGeoJSON/test_GeoJSON_time_GetCapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testGeoJSONReader_time&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="43.580391" miny="22.500000" maxx="50.064192" maxy="30.937500" />
+<BoundingBox CRS="CRS:84" minx="22.500000" miny="43.580391" maxx="30.937500" maxy="50.064192" />
 <BoundingBox CRS="EPSG:25831" minx="1890432.192136" miny="5013834.560496" maxx="2756872.780310" maxy="5930298.686432" />
 <BoundingBox CRS="EPSG:25832" minx="1464574.773534" miny="4914677.949044" maxx="2272426.770493" maxy="5780365.404660" />
 <BoundingBox CRS="EPSG:28992" minx="1373068.997232" miny="-337349.517275" maxx="2206836.899836" maxy="548917.494040" />
 <BoundingBox CRS="EPSG:3035" minx="5211113.262056" miny="2358788.209791" maxx="5991398.738404" maxy="3207566.704798" />
 <BoundingBox CRS="EPSG:3067" minx="136664.707256" miny="4825269.495098" maxx="817914.566929" maxy="5555473.099745" />
-<BoundingBox CRS="EPSG:32661" minx="3766180.814882" miny="-3029613.058561" maxx="4798782.508589" maxy="-1958634.440993" />
+<BoundingBox CRS="EPSG:32661" minx="-3029613.058561" miny="3766180.814882" maxx="-1958634.440993" maxy="4798782.508589" />
 <BoundingBox CRS="EPSG:3411" minx="4160465.295476" miny="-2032778.046650" maxx="5152713.886442" maxy="-1094201.755101" />
 <BoundingBox CRS="EPSG:3412" minx="10953720.735868" miny="24551153.424756" maxx="17357839.542316" maxy="31193283.566161" />
 <BoundingBox CRS="EPSG:3575" minx="944654.756170" miny="-4915365.778946" maxx="1799149.841794" maxy="-4076333.036397" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>30.937500</eastBoundLongitude>
   <southBoundLatitude>43.580391</southBoundLatitude>
   <northBoundLatitude>50.064192</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="43.580391" miny="22.500000" maxx="50.064192" maxy="30.937500" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="22.500000" miny="43.580391" maxx="30.937500" maxy="50.064192" />
 <BoundingBox CRS="EPSG:25831" minx="1890432.192136" miny="5013834.560496" maxx="2756872.780310" maxy="5930298.686432" />
 <BoundingBox CRS="EPSG:25832" minx="1464574.773534" miny="4914677.949044" maxx="2272426.770493" maxy="5780365.404660" />
 <BoundingBox CRS="EPSG:28992" minx="1373068.997232" miny="-337349.517275" maxx="2206836.899836" maxy="548917.494040" />
 <BoundingBox CRS="EPSG:3035" minx="5211113.262056" miny="2358788.209791" maxx="5991398.738404" maxy="3207566.704798" />
 <BoundingBox CRS="EPSG:3067" minx="136664.707256" miny="4825269.495098" maxx="817914.566929" maxy="5555473.099745" />
-<BoundingBox CRS="EPSG:32661" minx="3766180.814882" miny="-3029613.058561" maxx="4798782.508589" maxy="-1958634.440993" />
+<BoundingBox CRS="EPSG:32661" minx="-3029613.058561" miny="3766180.814882" maxx="-1958634.440993" maxy="4798782.508589" />
 <BoundingBox CRS="EPSG:3411" minx="4160465.295476" miny="-2032778.046650" maxx="5152713.886442" maxy="-1094201.755101" />
 <BoundingBox CRS="EPSG:3412" minx="10953720.735868" miny="24551153.424756" maxx="17357839.542316" maxy="31193283.566161" />
 <BoundingBox CRS="EPSG:3575" minx="944654.756170" miny="-4915365.778946" maxx="1799149.841794" maxy="-4076333.036397" />

--- a/tests/expectedoutputs/TestRendering/test_RenderingGeoJSON_time_GetCapabilities.xml
+++ b/tests/expectedoutputs/TestRendering/test_RenderingGeoJSON_time_GetCapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testGeoJSONReader_time&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="43.580391" miny="22.500000" maxx="50.064192" maxy="30.937500" />
+<BoundingBox CRS="CRS:84" minx="22.500000" miny="43.580391" maxx="30.937500" maxy="50.064192" />
 <BoundingBox CRS="EPSG:25831" minx="1890432.192136" miny="5013834.560496" maxx="2756872.780310" maxy="5930298.686432" />
 <BoundingBox CRS="EPSG:25832" minx="1464574.773534" miny="4914677.949044" maxx="2272426.770493" maxy="5780365.404660" />
 <BoundingBox CRS="EPSG:28992" minx="1373068.997232" miny="-337349.517275" maxx="2206836.899836" maxy="548917.494040" />
 <BoundingBox CRS="EPSG:3035" minx="5211113.262056" miny="2358788.209791" maxx="5991398.738404" maxy="3207566.704798" />
 <BoundingBox CRS="EPSG:3067" minx="136664.707256" miny="4825269.495098" maxx="817914.566929" maxy="5555473.099745" />
-<BoundingBox CRS="EPSG:32661" minx="3766180.814882" miny="-3029613.058561" maxx="4798782.508589" maxy="-1958634.440993" />
+<BoundingBox CRS="EPSG:32661" minx="-3029613.058561" miny="3766180.814882" maxx="-1958634.440993" maxy="4798782.508589" />
 <BoundingBox CRS="EPSG:3411" minx="4160465.295476" miny="-2032778.046650" maxx="5152713.886442" maxy="-1094201.755101" />
 <BoundingBox CRS="EPSG:3412" minx="10953720.735868" miny="24551153.424756" maxx="17357839.542316" maxy="31193283.566161" />
 <BoundingBox CRS="EPSG:3575" minx="944654.756170" miny="-4915365.778946" maxx="1799149.841794" maxy="-4076333.036397" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>30.937500</eastBoundLongitude>
   <southBoundLatitude>43.580391</southBoundLatitude>
   <northBoundLatitude>50.064192</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="43.580391" miny="22.500000" maxx="50.064192" maxy="30.937500" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="22.500000" miny="43.580391" maxx="30.937500" maxy="50.064192" />
 <BoundingBox CRS="EPSG:25831" minx="1890432.192136" miny="5013834.560496" maxx="2756872.780310" maxy="5930298.686432" />
 <BoundingBox CRS="EPSG:25832" minx="1464574.773534" miny="4914677.949044" maxx="2272426.770493" maxy="5780365.404660" />
 <BoundingBox CRS="EPSG:28992" minx="1373068.997232" miny="-337349.517275" maxx="2206836.899836" maxy="548917.494040" />
 <BoundingBox CRS="EPSG:3035" minx="5211113.262056" miny="2358788.209791" maxx="5991398.738404" maxy="3207566.704798" />
 <BoundingBox CRS="EPSG:3067" minx="136664.707256" miny="4825269.495098" maxx="817914.566929" maxy="5555473.099745" />
-<BoundingBox CRS="EPSG:32661" minx="3766180.814882" miny="-3029613.058561" maxx="4798782.508589" maxy="-1958634.440993" />
+<BoundingBox CRS="EPSG:32661" minx="-3029613.058561" miny="3766180.814882" maxx="-1958634.440993" maxy="4798782.508589" />
 <BoundingBox CRS="EPSG:3411" minx="4160465.295476" miny="-2032778.046650" maxx="5152713.886442" maxy="-1094201.755101" />
 <BoundingBox CRS="EPSG:3412" minx="10953720.735868" miny="24551153.424756" maxx="17357839.542316" maxy="31193283.566161" />
 <BoundingBox CRS="EPSG:3575" minx="944654.756170" miny="-4915365.778946" maxx="1799149.841794" maxy="-4076333.036397" />

--- a/tests/expectedoutputs/TestWMS/testWMSGetCapabilities_quantizehigh.xml
+++ b/tests/expectedoutputs/TestWMS/testWMSGetCapabilities_quantizehigh.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.quantizehigh&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
+<BoundingBox CRS="CRS:84" minx="0.250000" miny="47.099998" maxx="0.250000" maxy="49.099998" />
 <BoundingBox CRS="EPSG:25831" minx="295267.526825" miny="5331072.043142" maxx="295267.526825" maxy="5331074.043142" />
 <BoundingBox CRS="EPSG:25832" minx="-151168.761917" miny="5364559.671213" maxx="-151168.761917" maxy="5364561.671213" />
 <BoundingBox CRS="EPSG:28992" minx="-227870.303123" miny="24978.089268" maxx="-227870.303123" maxy="24980.089268" />
 <BoundingBox CRS="EPSG:3035" minx="3596861.700352" miny="2824165.391868" maxx="3596861.700352" maxy="2824167.391868" />
 <BoundingBox CRS="EPSG:3067" minx="-1481251.794314" miny="5683942.666186" maxx="-1481251.794314" maxy="5683944.666186" />
-<BoundingBox CRS="EPSG:32661" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
+<BoundingBox CRS="EPSG:32661" minx="-2862516.368656" miny="2021216.860424" maxx="-2862514.368656" maxy="2021216.860424" />
 <BoundingBox CRS="EPSG:3411" minx="3369518.975082" miny="-3340242.934311" maxx="3369518.975082" maxy="-3340240.934311" />
 <BoundingBox CRS="EPSG:3412" minx="139827.348331" miny="32045863.308502" maxx="139827.348331" maxy="32045865.308502" />
 <BoundingBox CRS="EPSG:3575" minx="-773790.384558" miny="-4503195.781262" maxx="-773790.384558" maxy="-4503193.781262" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>0.250000</eastBoundLongitude>
   <southBoundLatitude>47.099998</southBoundLatitude>
   <northBoundLatitude>49.099998</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.250000" miny="47.099998" maxx="0.250000" maxy="49.099998" />
 <BoundingBox CRS="EPSG:25831" minx="295267.526825" miny="5331072.043142" maxx="295267.526825" maxy="5331074.043142" />
 <BoundingBox CRS="EPSG:25832" minx="-151168.761917" miny="5364559.671213" maxx="-151168.761917" maxy="5364561.671213" />
 <BoundingBox CRS="EPSG:28992" minx="-227870.303123" miny="24978.089268" maxx="-227870.303123" maxy="24980.089268" />
 <BoundingBox CRS="EPSG:3035" minx="3596861.700352" miny="2824165.391868" maxx="3596861.700352" maxy="2824167.391868" />
 <BoundingBox CRS="EPSG:3067" minx="-1481251.794314" miny="5683942.666186" maxx="-1481251.794314" maxy="5683944.666186" />
-<BoundingBox CRS="EPSG:32661" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
+<BoundingBox CRS="EPSG:32661" minx="-2862516.368656" miny="2021216.860424" maxx="-2862514.368656" maxy="2021216.860424" />
 <BoundingBox CRS="EPSG:3411" minx="3369518.975082" miny="-3340242.934311" maxx="3369518.975082" maxy="-3340240.934311" />
 <BoundingBox CRS="EPSG:3412" minx="139827.348331" miny="32045863.308502" maxx="139827.348331" maxy="32045865.308502" />
 <BoundingBox CRS="EPSG:3575" minx="-773790.384558" miny="-4503195.781262" maxx="-773790.384558" maxy="-4503193.781262" />

--- a/tests/expectedoutputs/TestWMS/testWMSGetCapabilities_quantizelow.xml
+++ b/tests/expectedoutputs/TestWMS/testWMSGetCapabilities_quantizelow.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.quantizelow&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
+<BoundingBox CRS="CRS:84" minx="0.250000" miny="47.099998" maxx="0.250000" maxy="49.099998" />
 <BoundingBox CRS="EPSG:25831" minx="295267.526825" miny="5331072.043142" maxx="295267.526825" maxy="5331074.043142" />
 <BoundingBox CRS="EPSG:25832" minx="-151168.761917" miny="5364559.671213" maxx="-151168.761917" maxy="5364561.671213" />
 <BoundingBox CRS="EPSG:28992" minx="-227870.303123" miny="24978.089268" maxx="-227870.303123" maxy="24980.089268" />
 <BoundingBox CRS="EPSG:3035" minx="3596861.700352" miny="2824165.391868" maxx="3596861.700352" maxy="2824167.391868" />
 <BoundingBox CRS="EPSG:3067" minx="-1481251.794314" miny="5683942.666186" maxx="-1481251.794314" maxy="5683944.666186" />
-<BoundingBox CRS="EPSG:32661" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
+<BoundingBox CRS="EPSG:32661" minx="-2862516.368656" miny="2021216.860424" maxx="-2862514.368656" maxy="2021216.860424" />
 <BoundingBox CRS="EPSG:3411" minx="3369518.975082" miny="-3340242.934311" maxx="3369518.975082" maxy="-3340240.934311" />
 <BoundingBox CRS="EPSG:3412" minx="139827.348331" miny="32045863.308502" maxx="139827.348331" maxy="32045865.308502" />
 <BoundingBox CRS="EPSG:3575" minx="-773790.384558" miny="-4503195.781262" maxx="-773790.384558" maxy="-4503193.781262" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>0.250000</eastBoundLongitude>
   <southBoundLatitude>47.099998</southBoundLatitude>
   <northBoundLatitude>49.099998</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.250000" miny="47.099998" maxx="0.250000" maxy="49.099998" />
 <BoundingBox CRS="EPSG:25831" minx="295267.526825" miny="5331072.043142" maxx="295267.526825" maxy="5331074.043142" />
 <BoundingBox CRS="EPSG:25832" minx="-151168.761917" miny="5364559.671213" maxx="-151168.761917" maxy="5364561.671213" />
 <BoundingBox CRS="EPSG:28992" minx="-227870.303123" miny="24978.089268" maxx="-227870.303123" maxy="24980.089268" />
 <BoundingBox CRS="EPSG:3035" minx="3596861.700352" miny="2824165.391868" maxx="3596861.700352" maxy="2824167.391868" />
 <BoundingBox CRS="EPSG:3067" minx="-1481251.794314" miny="5683942.666186" maxx="-1481251.794314" maxy="5683944.666186" />
-<BoundingBox CRS="EPSG:32661" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
+<BoundingBox CRS="EPSG:32661" minx="-2862516.368656" miny="2021216.860424" maxx="-2862514.368656" maxy="2021216.860424" />
 <BoundingBox CRS="EPSG:3411" minx="3369518.975082" miny="-3340242.934311" maxx="3369518.975082" maxy="-3340240.934311" />
 <BoundingBox CRS="EPSG:3412" minx="139827.348331" miny="32045863.308502" maxx="139827.348331" maxy="32045865.308502" />
 <BoundingBox CRS="EPSG:3575" minx="-773790.384558" miny="-4503195.781262" maxx="-773790.384558" maxy="-4503193.781262" />

--- a/tests/expectedoutputs/TestWMS/testWMSGetCapabilities_quantizeround.xml
+++ b/tests/expectedoutputs/TestWMS/testWMSGetCapabilities_quantizeround.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.quantizeround&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
+<BoundingBox CRS="CRS:84" minx="0.250000" miny="47.099998" maxx="0.250000" maxy="49.099998" />
 <BoundingBox CRS="EPSG:25831" minx="295267.526825" miny="5331072.043142" maxx="295267.526825" maxy="5331074.043142" />
 <BoundingBox CRS="EPSG:25832" minx="-151168.761917" miny="5364559.671213" maxx="-151168.761917" maxy="5364561.671213" />
 <BoundingBox CRS="EPSG:28992" minx="-227870.303123" miny="24978.089268" maxx="-227870.303123" maxy="24980.089268" />
 <BoundingBox CRS="EPSG:3035" minx="3596861.700352" miny="2824165.391868" maxx="3596861.700352" maxy="2824167.391868" />
 <BoundingBox CRS="EPSG:3067" minx="-1481251.794314" miny="5683942.666186" maxx="-1481251.794314" maxy="5683944.666186" />
-<BoundingBox CRS="EPSG:32661" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
+<BoundingBox CRS="EPSG:32661" minx="-2862516.368656" miny="2021216.860424" maxx="-2862514.368656" maxy="2021216.860424" />
 <BoundingBox CRS="EPSG:3411" minx="3369518.975082" miny="-3340242.934311" maxx="3369518.975082" maxy="-3340240.934311" />
 <BoundingBox CRS="EPSG:3412" minx="139827.348331" miny="32045863.308502" maxx="139827.348331" maxy="32045865.308502" />
 <BoundingBox CRS="EPSG:3575" minx="-773790.384558" miny="-4503195.781262" maxx="-773790.384558" maxy="-4503193.781262" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>0.250000</eastBoundLongitude>
   <southBoundLatitude>47.099998</southBoundLatitude>
   <northBoundLatitude>49.099998</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="47.099998" miny="0.250000" maxx="49.099998" maxy="0.250000" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.250000" miny="47.099998" maxx="0.250000" maxy="49.099998" />
 <BoundingBox CRS="EPSG:25831" minx="295267.526825" miny="5331072.043142" maxx="295267.526825" maxy="5331074.043142" />
 <BoundingBox CRS="EPSG:25832" minx="-151168.761917" miny="5364559.671213" maxx="-151168.761917" maxy="5364561.671213" />
 <BoundingBox CRS="EPSG:28992" minx="-227870.303123" miny="24978.089268" maxx="-227870.303123" maxy="24980.089268" />
 <BoundingBox CRS="EPSG:3035" minx="3596861.700352" miny="2824165.391868" maxx="3596861.700352" maxy="2824167.391868" />
 <BoundingBox CRS="EPSG:3067" minx="-1481251.794314" miny="5683942.666186" maxx="-1481251.794314" maxy="5683944.666186" />
-<BoundingBox CRS="EPSG:32661" minx="2021216.860424" miny="-2862516.368656" maxx="2021216.860424" maxy="-2862514.368656" />
+<BoundingBox CRS="EPSG:32661" minx="-2862516.368656" miny="2021216.860424" maxx="-2862514.368656" maxy="2021216.860424" />
 <BoundingBox CRS="EPSG:3411" minx="3369518.975082" miny="-3340242.934311" maxx="3369518.975082" maxy="-3340240.934311" />
 <BoundingBox CRS="EPSG:3412" minx="139827.348331" miny="32045863.308502" maxx="139827.348331" maxy="32045865.308502" />
 <BoundingBox CRS="EPSG:3575" minx="-773790.384558" miny="-4503195.781262" maxx="-773790.384558" maxy="-4503193.781262" />

--- a/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDBTailPath_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDBTailPath_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+<BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>179.505554</eastBoundLongitude>
   <southBoundLatitude>-90.488892</southBoundLatitude>
   <northBoundLatitude>89.511108</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />

--- a/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDBTailPath_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1_and_seq2.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDBTailPath_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1_and_seq2.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+<BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>179.505554</eastBoundLongitude>
   <southBoundLatitude>-90.488892</southBoundLatitude>
   <northBoundLatitude>89.511108</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />

--- a/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDB_WMSGetCapabilities_timeseries_twofiles.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSCMDUpdateDB_WMSGetCapabilities_timeseries_twofiles.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+<BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>179.505554</eastBoundLongitude>
   <southBoundLatitude>-90.488892</southBoundLatitude>
   <northBoundLatitude>89.511108</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilitiesGetMap_testdatanc_WMSGetCapabilities_testdatanc.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilitiesGetMap_testdatanc_WMSGetCapabilities_testdatanc.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
+<BoundingBox CRS="CRS:84" minx="-27.243262" miny="37.353267" maxx="32.676474" maxy="65.888228" />
 <BoundingBox CRS="EPSG:25831" minx="-1027208.918278" miny="4257313.340443" maxx="2043762.674535" maxy="7377735.559200" />
 <BoundingBox CRS="EPSG:25832" minx="-1466672.497489" miny="4259561.094168" maxx="1661151.953190" maxy="7434111.038690" />
 <BoundingBox CRS="EPSG:28992" minx="-1500000.013502" miny="-999999.971392" maxx="1500000.013695" maxy="1999999.970643" />
 <BoundingBox CRS="EPSG:3035" minx="2295838.493287" miny="1712442.289194" maxx="5435712.495466" maxy="4854629.220149" />
 <BoundingBox CRS="EPSG:3067" minx="-3107150.509005" miny="4216726.250381" maxx="783036.427152" maxy="8092286.994278" />
-<BoundingBox CRS="EPSG:32661" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
+<BoundingBox CRS="EPSG:32661" minx="-4115048.787613" miny="563088.214526" maxx="-526949.004322" maxy="4171081.663734" />
 <BoundingBox CRS="EPSG:3411" minx="933738.467048" miny="-5198602.302407" maxx="5505159.473396" maxy="-624860.474641" />
 <BoundingBox CRS="EPSG:3412" minx="-22730542.445111" miny="23540323.467699" maxx="28030213.239617" maxy="57270128.565974" />
 <BoundingBox CRS="EPSG:3575" minx="-2218769.469677" miny="-5518468.599995" maxx="1133233.008108" maxy="-2440685.041382" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>32.676474</eastBoundLongitude>
   <southBoundLatitude>37.353267</southBoundLatitude>
   <northBoundLatitude>65.888228</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-27.243262" miny="37.353267" maxx="32.676474" maxy="65.888228" />
 <BoundingBox CRS="EPSG:25831" minx="-1027208.918278" miny="4257313.340443" maxx="2043762.674535" maxy="7377735.559200" />
 <BoundingBox CRS="EPSG:25832" minx="-1466672.497489" miny="4259561.094168" maxx="1661151.953190" maxy="7434111.038690" />
 <BoundingBox CRS="EPSG:28992" minx="-1500000.013502" miny="-999999.971392" maxx="1500000.013695" maxy="1999999.970643" />
 <BoundingBox CRS="EPSG:3035" minx="2295838.493287" miny="1712442.289194" maxx="5435712.495466" maxy="4854629.220149" />
 <BoundingBox CRS="EPSG:3067" minx="-3107150.509005" miny="4216726.250381" maxx="783036.427152" maxy="8092286.994278" />
-<BoundingBox CRS="EPSG:32661" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
+<BoundingBox CRS="EPSG:32661" minx="-4115048.787613" miny="563088.214526" maxx="-526949.004322" maxy="4171081.663734" />
 <BoundingBox CRS="EPSG:3411" minx="933738.467048" miny="-5198602.302407" maxx="5505159.473396" maxy="-624860.474641" />
 <BoundingBox CRS="EPSG:3412" minx="-22730542.445111" miny="23540323.467699" maxx="28030213.239617" maxy="57270128.565974" />
 <BoundingBox CRS="EPSG:3575" minx="-2218769.469677" miny="-5518468.599995" maxx="1133233.008108" maxy="-2440685.041382" />

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_403_default_time_referenced_to_forecast_time.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_403_default_time_referenced_to_forecast_time.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.403_default_time_referenced_to_forecast_time&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -78,13 +78,13 @@
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
 <CRS>PROJ4:%2Bproj%3Dob_tran%20%2Bo_proj%3Dlonglat%20%2Blon_0%3D%2D8%2E0%20%2Bo_lat_p%3D35%2E0%20%2Bo_lon_p%3D0%2E0%20%2Ba%3D6367470%20%2Be%3D0%20%2Bno_defs</CRS>
-<BoundingBox CRS="CRS:84" minx="41.926322" miny="-5.197559" maxx="59.916479" maxy="19.363445" />
+<BoundingBox CRS="CRS:84" minx="-5.197559" miny="41.926322" maxx="19.363445" maxy="59.916479" />
 <BoundingBox CRS="EPSG:25831" minx="-158524.476447" miny="4674976.849864" maxx="1485166.051976" maxy="6662272.916747" />
 <BoundingBox CRS="EPSG:25832" minx="-640734.840652" miny="4644137.389623" maxx="1126111.574266" maxy="6712613.598713" />
 <BoundingBox CRS="EPSG:28992" minx="-698179.856206" miny="-658358.645806" maxx="998796.634577" maxy="1363404.615714" />
 <BoundingBox CRS="EPSG:3035" minx="3106481.008370" miny="2092364.523226" maxx="4886938.084047" maxy="4166894.308911" />
 <BoundingBox CRS="EPSG:3067" minx="-2084795.387794" miny="4762634.602513" maxx="38153.856845" maxy="7049843.481081" />
-<BoundingBox CRS="EPSG:32661" minx="1510492.846031" miny="-3551923.560319" maxx="3243352.395372" maxy="-1407852.277061" />
+<BoundingBox CRS="EPSG:32661" minx="-3551923.560319" miny="1510492.846031" maxx="-1407852.277061" maxy="3243352.395372" />
 <BoundingBox CRS="EPSG:3411" minx="2190610.404942" miny="-4050561.169232" maxx="4595428.366256" maxy="-1583112.869331" />
 <BoundingBox CRS="EPSG:3412" minx="-3109314.573816" miny="26990899.047875" maxx="13777467.671867" maxy="45513687.683791" />
 <BoundingBox CRS="EPSG:3575" minx="-1311533.636248" miny="-5201751.869726" maxx="588736.834504" maxy="-3221506.782067" />
@@ -106,13 +106,13 @@
   <eastBoundLongitude>19.363445</eastBoundLongitude>
   <southBoundLatitude>41.926322</southBoundLatitude>
   <northBoundLatitude>59.916479</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="41.926322" miny="-5.197559" maxx="59.916479" maxy="19.363445" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-5.197559" miny="41.926322" maxx="19.363445" maxy="59.916479" />
 <BoundingBox CRS="EPSG:25831" minx="-158524.476447" miny="4674976.849864" maxx="1485166.051976" maxy="6662272.916747" />
 <BoundingBox CRS="EPSG:25832" minx="-640734.840652" miny="4644137.389623" maxx="1126111.574266" maxy="6712613.598713" />
 <BoundingBox CRS="EPSG:28992" minx="-698179.856206" miny="-658358.645806" maxx="998796.634577" maxy="1363404.615714" />
 <BoundingBox CRS="EPSG:3035" minx="3106481.008370" miny="2092364.523226" maxx="4886938.084047" maxy="4166894.308911" />
 <BoundingBox CRS="EPSG:3067" minx="-2084795.387794" miny="4762634.602513" maxx="38153.856845" maxy="7049843.481081" />
-<BoundingBox CRS="EPSG:32661" minx="1510492.846031" miny="-3551923.560319" maxx="3243352.395372" maxy="-1407852.277061" />
+<BoundingBox CRS="EPSG:32661" minx="-3551923.560319" miny="1510492.846031" maxx="-1407852.277061" maxy="3243352.395372" />
 <BoundingBox CRS="EPSG:3411" minx="2190610.404942" miny="-4050561.169232" maxx="4595428.366256" maxy="-1583112.869331" />
 <BoundingBox CRS="EPSG:3412" minx="-3109314.573816" miny="26990899.047875" maxx="13777467.671867" maxy="45513687.683791" />
 <BoundingBox CRS="EPSG:3575" minx="-1311533.636248" miny="-5201751.869726" maxx="588736.834504" maxy="-3221506.782067" />
@@ -147,13 +147,13 @@
   <eastBoundLongitude>19.363445</eastBoundLongitude>
   <southBoundLatitude>41.926322</southBoundLatitude>
   <northBoundLatitude>59.916479</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="41.926322" miny="-5.197559" maxx="59.916479" maxy="19.363445" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-5.197559" miny="41.926322" maxx="19.363445" maxy="59.916479" />
 <BoundingBox CRS="EPSG:25831" minx="-158524.476447" miny="4674976.849864" maxx="1485166.051976" maxy="6662272.916747" />
 <BoundingBox CRS="EPSG:25832" minx="-640734.840652" miny="4644137.389623" maxx="1126111.574266" maxy="6712613.598713" />
 <BoundingBox CRS="EPSG:28992" minx="-698179.856206" miny="-658358.645806" maxx="998796.634577" maxy="1363404.615714" />
 <BoundingBox CRS="EPSG:3035" minx="3106481.008370" miny="2092364.523226" maxx="4886938.084047" maxy="4166894.308911" />
 <BoundingBox CRS="EPSG:3067" minx="-2084795.387794" miny="4762634.602513" maxx="38153.856845" maxy="7049843.481081" />
-<BoundingBox CRS="EPSG:32661" minx="1510492.846031" miny="-3551923.560319" maxx="3243352.395372" maxy="-1407852.277061" />
+<BoundingBox CRS="EPSG:32661" minx="-3551923.560319" miny="1510492.846031" maxx="-1407852.277061" maxy="3243352.395372" />
 <BoundingBox CRS="EPSG:3411" minx="2190610.404942" miny="-4050561.169232" maxx="4595428.366256" maxy="-1583112.869331" />
 <BoundingBox CRS="EPSG:3412" minx="-3109314.573816" miny="26990899.047875" maxx="13777467.671867" maxy="45513687.683791" />
 <BoundingBox CRS="EPSG:3575" minx="-1311533.636248" miny="-5201751.869726" maxx="588736.834504" maxy="-3221506.782067" />
@@ -188,13 +188,13 @@
   <eastBoundLongitude>19.363445</eastBoundLongitude>
   <southBoundLatitude>41.926322</southBoundLatitude>
   <northBoundLatitude>59.916479</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="41.926322" miny="-5.197559" maxx="59.916479" maxy="19.363445" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-5.197559" miny="41.926322" maxx="19.363445" maxy="59.916479" />
 <BoundingBox CRS="EPSG:25831" minx="-158524.476447" miny="4674976.849864" maxx="1485166.051976" maxy="6662272.916747" />
 <BoundingBox CRS="EPSG:25832" minx="-640734.840652" miny="4644137.389623" maxx="1126111.574266" maxy="6712613.598713" />
 <BoundingBox CRS="EPSG:28992" minx="-698179.856206" miny="-658358.645806" maxx="998796.634577" maxy="1363404.615714" />
 <BoundingBox CRS="EPSG:3035" minx="3106481.008370" miny="2092364.523226" maxx="4886938.084047" maxy="4166894.308911" />
 <BoundingBox CRS="EPSG:3067" minx="-2084795.387794" miny="4762634.602513" maxx="38153.856845" maxy="7049843.481081" />
-<BoundingBox CRS="EPSG:32661" minx="1510492.846031" miny="-3551923.560319" maxx="3243352.395372" maxy="-1407852.277061" />
+<BoundingBox CRS="EPSG:32661" minx="-3551923.560319" miny="1510492.846031" maxx="-1407852.277061" maxy="3243352.395372" />
 <BoundingBox CRS="EPSG:3411" minx="2190610.404942" miny="-4050561.169232" maxx="4595428.366256" maxy="-1583112.869331" />
 <BoundingBox CRS="EPSG:3412" minx="-3109314.573816" miny="26990899.047875" maxx="13777467.671867" maxy="45513687.683791" />
 <BoundingBox CRS="EPSG:3575" minx="-1311533.636248" miny="-5201751.869726" maxx="588736.834504" maxy="-3221506.782067" />
@@ -229,13 +229,13 @@
   <eastBoundLongitude>19.363445</eastBoundLongitude>
   <southBoundLatitude>41.926322</southBoundLatitude>
   <northBoundLatitude>59.916479</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="41.926322" miny="-5.197559" maxx="59.916479" maxy="19.363445" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-5.197559" miny="41.926322" maxx="19.363445" maxy="59.916479" />
 <BoundingBox CRS="EPSG:25831" minx="-158524.476447" miny="4674976.849864" maxx="1485166.051976" maxy="6662272.916747" />
 <BoundingBox CRS="EPSG:25832" minx="-640734.840652" miny="4644137.389623" maxx="1126111.574266" maxy="6712613.598713" />
 <BoundingBox CRS="EPSG:28992" minx="-698179.856206" miny="-658358.645806" maxx="998796.634577" maxy="1363404.615714" />
 <BoundingBox CRS="EPSG:3035" minx="3106481.008370" miny="2092364.523226" maxx="4886938.084047" maxy="4166894.308911" />
 <BoundingBox CRS="EPSG:3067" minx="-2084795.387794" miny="4762634.602513" maxx="38153.856845" maxy="7049843.481081" />
-<BoundingBox CRS="EPSG:32661" minx="1510492.846031" miny="-3551923.560319" maxx="3243352.395372" maxy="-1407852.277061" />
+<BoundingBox CRS="EPSG:32661" minx="-3551923.560319" miny="1510492.846031" maxx="-1407852.277061" maxy="3243352.395372" />
 <BoundingBox CRS="EPSG:3411" minx="2190610.404942" miny="-4050561.169232" maxx="4595428.366256" maxy="-1583112.869331" />
 <BoundingBox CRS="EPSG:3412" minx="-3109314.573816" miny="26990899.047875" maxx="13777467.671867" maxy="45513687.683791" />
 <BoundingBox CRS="EPSG:3575" minx="-1311533.636248" miny="-5201751.869726" maxx="588736.834504" maxy="-3221506.782067" />

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_DimensionUnits.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_DimensionUnits.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.311-getcapabilities-dimension-units&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -78,13 +78,13 @@
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
 <CRS>PROJ4:%2Bproj%3Dlonglat%20%2Bellps%3DWGS84%20%2Bdatum%3DWGS84%20%2Bno_defs</CRS>
-<BoundingBox CRS="CRS:84" minx="48.950000" miny="-0.050000" maxx="49.650000" maxy="1.050000" />
+<BoundingBox CRS="CRS:84" minx="-0.050000" miny="48.950000" maxx="1.050000" maxy="49.650000" />
 <BoundingBox CRS="EPSG:25831" minx="276706.492867" miny="5423730.017406" maxx="359241.642834" maxy="5504184.844720" />
 <BoundingBox CRS="EPSG:25832" minx="-162215.924111" miny="5452428.998738" maxx="-73577.697170" maxy="5539161.628146" />
 <BoundingBox CRS="EPSG:28992" minx="-243286.563797" miny="115692.137850" maxx="-158210.857658" maxy="198758.393647" />
 <BoundingBox CRS="EPSG:3035" minx="3587293.727943" miny="2910556.450437" maxx="3676408.111280" maxy="2998171.006307" />
 <BoundingBox CRS="EPSG:3067" minx="-1467755.480414" miny="5755116.469362" maxx="-1360791.221574" maxy="5860768.051867" />
-<BoundingBox CRS="EPSG:32661" minx="1995850.338946" miny="-2755161.899057" maxx="2087138.015594" maxy="-2666365.726464" />
+<BoundingBox CRS="EPSG:32661" minx="-2755161.899057" miny="1995850.338946" maxx="-2666365.726464" maxy="2087138.015594" />
 <BoundingBox CRS="EPSG:3411" minx="3217276.885814" miny="-3283673.977407" maxx="3340381.936649" maxy="-3160539.570626" />
 <BoundingBox CRS="EPSG:3412" minx="-29136.465087" miny="32764459.494720" maxx="611831.596821" maxy="33387933.819837" />
 <BoundingBox CRS="EPSG:3575" minx="-781931.373100" miny="-4426233.086688" maxx="-685731.226910" maxy="-4340158.599536" />
@@ -106,13 +106,13 @@
   <eastBoundLongitude>1.050000</eastBoundLongitude>
   <southBoundLatitude>48.950000</southBoundLatitude>
   <northBoundLatitude>49.650000</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.950000" miny="-0.050000" maxx="49.650000" maxy="1.050000" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-0.050000" miny="48.950000" maxx="1.050000" maxy="49.650000" />
 <BoundingBox CRS="EPSG:25831" minx="276706.492867" miny="5423730.017406" maxx="359241.642834" maxy="5504184.844720" />
 <BoundingBox CRS="EPSG:25832" minx="-162215.924111" miny="5452428.998738" maxx="-73577.697170" maxy="5539161.628146" />
 <BoundingBox CRS="EPSG:28992" minx="-243286.563797" miny="115692.137850" maxx="-158210.857658" maxy="198758.393647" />
 <BoundingBox CRS="EPSG:3035" minx="3587293.727943" miny="2910556.450437" maxx="3676408.111280" maxy="2998171.006307" />
 <BoundingBox CRS="EPSG:3067" minx="-1467755.480414" miny="5755116.469362" maxx="-1360791.221574" maxy="5860768.051867" />
-<BoundingBox CRS="EPSG:32661" minx="1995850.338946" miny="-2755161.899057" maxx="2087138.015594" maxy="-2666365.726464" />
+<BoundingBox CRS="EPSG:32661" minx="-2755161.899057" miny="1995850.338946" maxx="-2666365.726464" maxy="2087138.015594" />
 <BoundingBox CRS="EPSG:3411" minx="3217276.885814" miny="-3283673.977407" maxx="3340381.936649" maxy="-3160539.570626" />
 <BoundingBox CRS="EPSG:3412" minx="-29136.465087" miny="32764459.494720" maxx="611831.596821" maxy="33387933.819837" />
 <BoundingBox CRS="EPSG:3575" minx="-781931.373100" miny="-4426233.086688" maxx="-685731.226910" maxy="-4340158.599536" />

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_KMDS_PointNetCDF_pointstylepoint.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_KMDS_PointNetCDF_pointstylepoint.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testKMDS_PointNetCDF&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+<BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -105,13 +105,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -143,13 +143,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -181,13 +181,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -220,13 +220,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -259,13 +259,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -325,13 +325,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -364,13 +364,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -421,13 +421,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -460,13 +460,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -499,13 +499,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -538,13 +538,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -577,13 +577,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -616,13 +616,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -655,13 +655,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -694,13 +694,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -733,13 +733,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -772,13 +772,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -811,13 +811,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -850,13 +850,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -889,13 +889,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -928,13 +928,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -967,13 +967,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1006,13 +1006,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1045,13 +1045,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1084,13 +1084,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1123,13 +1123,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1162,13 +1162,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1201,13 +1201,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1240,13 +1240,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1279,13 +1279,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1318,13 +1318,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1357,13 +1357,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1396,13 +1396,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1435,13 +1435,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1474,13 +1474,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1513,13 +1513,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1552,13 +1552,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1591,13 +1591,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1630,13 +1630,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1669,13 +1669,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1708,13 +1708,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1747,13 +1747,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1786,13 +1786,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />
@@ -1825,13 +1825,13 @@
   <eastBoundLongitude>7.149322</eastBoundLongitude>
   <southBoundLatitude>12.130000</southBoundLatitude>
   <northBoundLatitude>55.399166</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="12.130000" miny="-68.275833" maxx="55.399166" maxy="7.149322" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-68.275833" miny="12.130000" maxx="7.149322" maxy="55.399166" />
 <BoundingBox CRS="EPSG:25831" minx="-9906758.676129" miny="1341055.638469" maxx="951836.432640" maxy="8605856.308089" />
 <BoundingBox CRS="EPSG:25832" minx="-11426227.343341" miny="1341612.511753" maxx="382800.244818" maxy="9034799.679759" />
 <BoundingBox CRS="EPSG:28992" minx="-8805606.109966" miny="-4164572.069133" maxx="372143.463211" maxy="3233625.747402" />
 <BoundingBox CRS="EPSG:3035" minx="-3285690.070643" miny="-1119543.780627" maxx="4140352.577818" maxy="6071044.702106" />
 <BoundingBox CRS="EPSG:3067" minx="-13588402.263697" miny="1423498.626368" maxx="-747816.881762" maxy="12453122.100930" />
-<BoundingBox CRS="EPSG:32661" minx="-7498001.230434" miny="-8223848.076474" maxx="3272454.133168" maxy="535002.459267" />
+<BoundingBox CRS="EPSG:32661" minx="-8223848.076474" miny="-7498001.230434" maxx="535002.459267" maxy="3272454.133168" />
 <BoundingBox CRS="EPSG:3411" minx="-3942117.046146" miny="-9975996.132113" maxx="7877215.337643" maxy="-2369697.552660" />
 <BoundingBox CRS="EPSG:3412" minx="-36574088.915720" miny="5641285.215970" maxx="4899857.294031" maxy="39369117.726749" />
 <BoundingBox CRS="EPSG:3575" minx="-7844965.759495" miny="-8002206.437441" maxx="-189084.750364" maxy="-772564.105215" />

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_PASCAL_probabilities_manydims_timewindow.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_PASCAL_probabilities_manydims_timewindow.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=pascal%2FNetCDF4_probabilities_greater_than_or_equal_to_36_1_0_12_2025%2D07%2D02T10_00_00Z_2025%2D07%2D02T00_00_00Z%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -78,13 +78,13 @@
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
 <CRS>PROJ4:%2Bproj%3Dlonglat%20%2Bellps%3DWGS84%20%2Bdatum%3DWGS84%20%2Bno_defs</CRS>
-<BoundingBox CRS="CRS:84" minx="48.991000" miny="-0.014500" maxx="56.011000" maxy="11.295500" />
+<BoundingBox CRS="CRS:84" minx="-0.014500" miny="48.991000" maxx="11.295500" maxy="56.011000" />
 <BoundingBox CRS="EPSG:25831" minx="279486.181295" miny="5426455.295658" maxx="1106564.235337" maxy="6238397.008695" />
 <BoundingBox CRS="EPSG:25832" minx="-159076.876180" miny="5426455.835211" maxx="667922.720949" maxy="6244030.589292" />
 <BoundingBox CRS="EPSG:28992" minx="-240356.718422" miny="110966.965686" maxx="587386.577109" maxy="907716.266185" />
 <BoundingBox CRS="EPSG:3035" minx="3590473.522941" miny="2875312.852130" maxx="4415832.798743" maxy="3699811.756282" />
 <BoundingBox CRS="EPSG:3067" minx="-1463498.983078" miny="5546449.239554" maxx="-474452.673273" maxy="6541622.309508" />
-<BoundingBox CRS="EPSG:32661" minx="1998797.905458" miny="-2749996.025036" maxx="2930377.601350" maxy="-1808590.961851" />
+<BoundingBox CRS="EPSG:32661" minx="-2749996.025036" miny="1998797.905458" maxx="-1808590.961851" maxy="2930377.601350" />
 <BoundingBox CRS="EPSG:3411" minx="2678953.931008" miny="-3278077.377054" maxx="3855679.674073" maxy="-2102870.594756" />
 <BoundingBox CRS="EPSG:3412" minx="-10153.773965" miny="32170157.134147" maxx="7858652.989460" maxy="40121957.372894" />
 <BoundingBox CRS="EPSG:3575" minx="-778454.897448" miny="-4476517.292347" maxx="101208.769638" maxy="-3679953.333308" />
@@ -106,13 +106,13 @@
   <eastBoundLongitude>11.295500</eastBoundLongitude>
   <southBoundLatitude>48.991000</southBoundLatitude>
   <northBoundLatitude>56.011000</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.991000" miny="-0.014500" maxx="56.011000" maxy="11.295500" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-0.014500" miny="48.991000" maxx="11.295500" maxy="56.011000" />
 <BoundingBox CRS="EPSG:25831" minx="279486.181295" miny="5426455.295658" maxx="1106564.235337" maxy="6238397.008695" />
 <BoundingBox CRS="EPSG:25832" minx="-159076.876180" miny="5426455.835211" maxx="667922.720949" maxy="6244030.589292" />
 <BoundingBox CRS="EPSG:28992" minx="-240356.718422" miny="110966.965686" maxx="587386.577109" maxy="907716.266185" />
 <BoundingBox CRS="EPSG:3035" minx="3590473.522941" miny="2875312.852130" maxx="4415832.798743" maxy="3699811.756282" />
 <BoundingBox CRS="EPSG:3067" minx="-1463498.983078" miny="5546449.239554" maxx="-474452.673273" maxy="6541622.309508" />
-<BoundingBox CRS="EPSG:32661" minx="1998797.905458" miny="-2749996.025036" maxx="2930377.601350" maxy="-1808590.961851" />
+<BoundingBox CRS="EPSG:32661" minx="-2749996.025036" miny="1998797.905458" maxx="-1808590.961851" maxy="2930377.601350" />
 <BoundingBox CRS="EPSG:3411" minx="2678953.931008" miny="-3278077.377054" maxx="3855679.674073" maxy="-2102870.594756" />
 <BoundingBox CRS="EPSG:3412" minx="-10153.773965" miny="32170157.134147" maxx="7858652.989460" maxy="40121957.372894" />
 <BoundingBox CRS="EPSG:3575" minx="-778454.897448" miny="-4476517.292347" maxx="101208.769638" maxy="-3679953.333308" />

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_multidimnc_autostyle.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_multidimnc_autostyle.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=netcdf_5dims%2Fnetcdf_5dims_seq1%2Fnc_5D_20170101000000%2D20170101001000%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+<BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />
@@ -108,13 +108,13 @@
   <eastBoundLongitude>179.505554</eastBoundLongitude>
   <southBoundLatitude>-90.488892</southBoundLatitude>
   <northBoundLatitude>89.511108</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_multidimncdataset_autostyle.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_multidimncdataset_autostyle.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testmultidimautostyle&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+<BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>179.505554</eastBoundLongitude>
   <southBoundLatitude>-90.488892</southBoundLatitude>
   <northBoundLatitude>89.511108</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_no_error_on_existing_dataset_misconfigured_layer.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_no_error_on_existing_dataset_misconfigured_layer.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.datasetwithmisconfiguredlayer&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
+<BoundingBox CRS="CRS:84" minx="-27.243262" miny="37.353267" maxx="32.676474" maxy="65.888228" />
 <BoundingBox CRS="EPSG:25831" minx="-1027208.918278" miny="4257313.340443" maxx="2043762.674535" maxy="7377735.559200" />
 <BoundingBox CRS="EPSG:25832" minx="-1466672.497489" miny="4259561.094168" maxx="1661151.953190" maxy="7434111.038690" />
 <BoundingBox CRS="EPSG:28992" minx="-1500000.013502" miny="-999999.971392" maxx="1500000.013695" maxy="1999999.970643" />
 <BoundingBox CRS="EPSG:3035" minx="2295838.493287" miny="1712442.289194" maxx="5435712.495466" maxy="4854629.220149" />
 <BoundingBox CRS="EPSG:3067" minx="-3107150.509005" miny="4216726.250381" maxx="783036.427152" maxy="8092286.994278" />
-<BoundingBox CRS="EPSG:32661" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
+<BoundingBox CRS="EPSG:32661" minx="-4115048.787613" miny="563088.214526" maxx="-526949.004322" maxy="4171081.663734" />
 <BoundingBox CRS="EPSG:3411" minx="933738.467048" miny="-5198602.302407" maxx="5505159.473396" maxy="-624860.474641" />
 <BoundingBox CRS="EPSG:3412" minx="-22730542.445111" miny="23540323.467699" maxx="28030213.239617" maxy="57270128.565974" />
 <BoundingBox CRS="EPSG:3575" minx="-2218769.469677" miny="-5518468.599995" maxx="1133233.008108" maxy="-2440685.041382" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>32.676474</eastBoundLongitude>
   <southBoundLatitude>37.353267</southBoundLatitude>
   <northBoundLatitude>65.888228</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-27.243262" miny="37.353267" maxx="32.676474" maxy="65.888228" />
 <BoundingBox CRS="EPSG:25831" minx="-1027208.918278" miny="4257313.340443" maxx="2043762.674535" maxy="7377735.559200" />
 <BoundingBox CRS="EPSG:25832" minx="-1466672.497489" miny="4259561.094168" maxx="1661151.953190" maxy="7434111.038690" />
 <BoundingBox CRS="EPSG:28992" minx="-1500000.013502" miny="-999999.971392" maxx="1500000.013695" maxy="1999999.970643" />
 <BoundingBox CRS="EPSG:3035" minx="2295838.493287" miny="1712442.289194" maxx="5435712.495466" maxy="4854629.220149" />
 <BoundingBox CRS="EPSG:3067" minx="-3107150.509005" miny="4216726.250381" maxx="783036.427152" maxy="8092286.994278" />
-<BoundingBox CRS="EPSG:32661" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
+<BoundingBox CRS="EPSG:32661" minx="-4115048.787613" miny="563088.214526" maxx="-526949.004322" maxy="4171081.663734" />
 <BoundingBox CRS="EPSG:3411" minx="933738.467048" miny="-5198602.302407" maxx="5505159.473396" maxy="-624860.474641" />
 <BoundingBox CRS="EPSG:3412" minx="-22730542.445111" miny="23540323.467699" maxx="28030213.239617" maxy="57270128.565974" />
 <BoundingBox CRS="EPSG:3575" minx="-2218769.469677" miny="-5518468.599995" maxx="1133233.008108" maxy="-2440685.041382" />

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_testdatanc.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_testdatanc.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
+<BoundingBox CRS="CRS:84" minx="-27.243262" miny="37.353267" maxx="32.676474" maxy="65.888228" />
 <BoundingBox CRS="EPSG:25831" minx="-1027208.918278" miny="4257313.340443" maxx="2043762.674535" maxy="7377735.559200" />
 <BoundingBox CRS="EPSG:25832" minx="-1466672.497489" miny="4259561.094168" maxx="1661151.953190" maxy="7434111.038690" />
 <BoundingBox CRS="EPSG:28992" minx="-1500000.013502" miny="-999999.971392" maxx="1500000.013695" maxy="1999999.970643" />
 <BoundingBox CRS="EPSG:3035" minx="2295838.493287" miny="1712442.289194" maxx="5435712.495466" maxy="4854629.220149" />
 <BoundingBox CRS="EPSG:3067" minx="-3107150.509005" miny="4216726.250381" maxx="783036.427152" maxy="8092286.994278" />
-<BoundingBox CRS="EPSG:32661" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
+<BoundingBox CRS="EPSG:32661" minx="-4115048.787613" miny="563088.214526" maxx="-526949.004322" maxy="4171081.663734" />
 <BoundingBox CRS="EPSG:3411" minx="933738.467048" miny="-5198602.302407" maxx="5505159.473396" maxy="-624860.474641" />
 <BoundingBox CRS="EPSG:3412" minx="-22730542.445111" miny="23540323.467699" maxx="28030213.239617" maxy="57270128.565974" />
 <BoundingBox CRS="EPSG:3575" minx="-2218769.469677" miny="-5518468.599995" maxx="1133233.008108" maxy="-2440685.041382" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>32.676474</eastBoundLongitude>
   <southBoundLatitude>37.353267</southBoundLatitude>
   <northBoundLatitude>65.888228</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-27.243262" miny="37.353267" maxx="32.676474" maxy="65.888228" />
 <BoundingBox CRS="EPSG:25831" minx="-1027208.918278" miny="4257313.340443" maxx="2043762.674535" maxy="7377735.559200" />
 <BoundingBox CRS="EPSG:25832" minx="-1466672.497489" miny="4259561.094168" maxx="1661151.953190" maxy="7434111.038690" />
 <BoundingBox CRS="EPSG:28992" minx="-1500000.013502" miny="-999999.971392" maxx="1500000.013695" maxy="1999999.970643" />
 <BoundingBox CRS="EPSG:3035" minx="2295838.493287" miny="1712442.289194" maxx="5435712.495466" maxy="4854629.220149" />
 <BoundingBox CRS="EPSG:3067" minx="-3107150.509005" miny="4216726.250381" maxx="783036.427152" maxy="8092286.994278" />
-<BoundingBox CRS="EPSG:32661" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
+<BoundingBox CRS="EPSG:32661" minx="-4115048.787613" miny="563088.214526" maxx="-526949.004322" maxy="4171081.663734" />
 <BoundingBox CRS="EPSG:3411" minx="933738.467048" miny="-5198602.302407" maxx="5505159.473396" maxy="-624860.474641" />
 <BoundingBox CRS="EPSG:3412" minx="-22730542.445111" miny="23540323.467699" maxx="28030213.239617" maxy="57270128.565974" />
 <BoundingBox CRS="EPSG:3575" minx="-2218769.469677" miny="-5518468.599995" maxx="1133233.008108" maxy="-2440685.041382" />

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_testdatanc_autostyle.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_testdatanc_autostyle.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
+<BoundingBox CRS="CRS:84" minx="-27.243262" miny="37.353267" maxx="32.676474" maxy="65.888228" />
 <BoundingBox CRS="EPSG:25831" minx="-1027208.918278" miny="4257313.340443" maxx="2043762.674535" maxy="7377735.559200" />
 <BoundingBox CRS="EPSG:25832" minx="-1466672.497489" miny="4259561.094168" maxx="1661151.953190" maxy="7434111.038690" />
 <BoundingBox CRS="EPSG:28992" minx="-1500000.013502" miny="-999999.971392" maxx="1500000.013695" maxy="1999999.970643" />
 <BoundingBox CRS="EPSG:3035" minx="2295838.493287" miny="1712442.289194" maxx="5435712.495466" maxy="4854629.220149" />
 <BoundingBox CRS="EPSG:3067" minx="-3107150.509005" miny="4216726.250381" maxx="783036.427152" maxy="8092286.994278" />
-<BoundingBox CRS="EPSG:32661" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
+<BoundingBox CRS="EPSG:32661" minx="-4115048.787613" miny="563088.214526" maxx="-526949.004322" maxy="4171081.663734" />
 <BoundingBox CRS="EPSG:3411" minx="933738.467048" miny="-5198602.302407" maxx="5505159.473396" maxy="-624860.474641" />
 <BoundingBox CRS="EPSG:3412" minx="-22730542.445111" miny="23540323.467699" maxx="28030213.239617" maxy="57270128.565974" />
 <BoundingBox CRS="EPSG:3575" minx="-2218769.469677" miny="-5518468.599995" maxx="1133233.008108" maxy="-2440685.041382" />
@@ -108,13 +108,13 @@
   <eastBoundLongitude>32.676474</eastBoundLongitude>
   <southBoundLatitude>37.353267</southBoundLatitude>
   <northBoundLatitude>65.888228</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-27.243262" miny="37.353267" maxx="32.676474" maxy="65.888228" />
 <BoundingBox CRS="EPSG:25831" minx="-1027208.918278" miny="4257313.340443" maxx="2043762.674535" maxy="7377735.559200" />
 <BoundingBox CRS="EPSG:25832" minx="-1466672.497489" miny="4259561.094168" maxx="1661151.953190" maxy="7434111.038690" />
 <BoundingBox CRS="EPSG:28992" minx="-1500000.013502" miny="-999999.971392" maxx="1500000.013695" maxy="1999999.970643" />
 <BoundingBox CRS="EPSG:3035" minx="2295838.493287" miny="1712442.289194" maxx="5435712.495466" maxy="4854629.220149" />
 <BoundingBox CRS="EPSG:3067" minx="-3107150.509005" miny="4216726.250381" maxx="783036.427152" maxy="8092286.994278" />
-<BoundingBox CRS="EPSG:32661" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
+<BoundingBox CRS="EPSG:32661" minx="-4115048.787613" miny="563088.214526" maxx="-526949.004322" maxy="4171081.663734" />
 <BoundingBox CRS="EPSG:3411" minx="933738.467048" miny="-5198602.302407" maxx="5505159.473396" maxy="-624860.474641" />
 <BoundingBox CRS="EPSG:3412" minx="-22730542.445111" miny="23540323.467699" maxx="28030213.239617" maxy="57270128.565974" />
 <BoundingBox CRS="EPSG:3575" minx="-2218769.469677" miny="-5518468.599995" maxx="1133233.008108" maxy="-2440685.041382" />

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_timeseries_path_netcdf_5dims_seq1.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_timeseries_path_netcdf_5dims_seq1.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+<BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>179.505554</eastBoundLongitude>
   <southBoundLatitude>-90.488892</southBoundLatitude>
   <northBoundLatitude>89.511108</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />

--- a/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_timeseries_path_netcdf_5dims_seq2.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetCapabilities_timeseries_path_netcdf_5dims_seq2.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+<BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>179.505554</eastBoundLongitude>
   <southBoundLatitude>-90.488892</southBoundLatitude>
   <northBoundLatitude>89.511108</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />

--- a/tests/expectedoutputs/TestWMS/test_WMSGetFeatureInfo_forecastreferencetime_texthtml_TestDataGetCapabilities.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetFeatureInfo_forecastreferencetime_texthtml_TestDataGetCapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
+<BoundingBox CRS="CRS:84" minx="-27.243262" miny="37.353267" maxx="32.676474" maxy="65.888228" />
 <BoundingBox CRS="EPSG:25831" minx="-1027208.918278" miny="4257313.340443" maxx="2043762.674535" maxy="7377735.559200" />
 <BoundingBox CRS="EPSG:25832" minx="-1466672.497489" miny="4259561.094168" maxx="1661151.953190" maxy="7434111.038690" />
 <BoundingBox CRS="EPSG:28992" minx="-1500000.013502" miny="-999999.971392" maxx="1500000.013695" maxy="1999999.970643" />
 <BoundingBox CRS="EPSG:3035" minx="2295838.493287" miny="1712442.289194" maxx="5435712.495466" maxy="4854629.220149" />
 <BoundingBox CRS="EPSG:3067" minx="-3107150.509005" miny="4216726.250381" maxx="783036.427152" maxy="8092286.994278" />
-<BoundingBox CRS="EPSG:32661" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
+<BoundingBox CRS="EPSG:32661" minx="-4115048.787613" miny="563088.214526" maxx="-526949.004322" maxy="4171081.663734" />
 <BoundingBox CRS="EPSG:3411" minx="933738.467048" miny="-5198602.302407" maxx="5505159.473396" maxy="-624860.474641" />
 <BoundingBox CRS="EPSG:3412" minx="-22730542.445111" miny="23540323.467699" maxx="28030213.239617" maxy="57270128.565974" />
 <BoundingBox CRS="EPSG:3575" minx="-2218769.469677" miny="-5518468.599995" maxx="1133233.008108" maxy="-2440685.041382" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>32.676474</eastBoundLongitude>
   <southBoundLatitude>37.353267</southBoundLatitude>
   <northBoundLatitude>65.888228</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-27.243262" miny="37.353267" maxx="32.676474" maxy="65.888228" />
 <BoundingBox CRS="EPSG:25831" minx="-1027208.918278" miny="4257313.340443" maxx="2043762.674535" maxy="7377735.559200" />
 <BoundingBox CRS="EPSG:25832" minx="-1466672.497489" miny="4259561.094168" maxx="1661151.953190" maxy="7434111.038690" />
 <BoundingBox CRS="EPSG:28992" minx="-1500000.013502" miny="-999999.971392" maxx="1500000.013695" maxy="1999999.970643" />
 <BoundingBox CRS="EPSG:3035" minx="2295838.493287" miny="1712442.289194" maxx="5435712.495466" maxy="4854629.220149" />
 <BoundingBox CRS="EPSG:3067" minx="-3107150.509005" miny="4216726.250381" maxx="783036.427152" maxy="8092286.994278" />
-<BoundingBox CRS="EPSG:32661" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
+<BoundingBox CRS="EPSG:32661" minx="-4115048.787613" miny="563088.214526" maxx="-526949.004322" maxy="4171081.663734" />
 <BoundingBox CRS="EPSG:3411" minx="933738.467048" miny="-5198602.302407" maxx="5505159.473396" maxy="-624860.474641" />
 <BoundingBox CRS="EPSG:3412" minx="-22730542.445111" miny="23540323.467699" maxx="28030213.239617" maxy="57270128.565974" />
 <BoundingBox CRS="EPSG:3575" minx="-2218769.469677" miny="-5518468.599995" maxx="1133233.008108" maxy="-2440685.041382" />

--- a/tests/expectedoutputs/TestWMS/test_WMSGetMapGetCapabilities_testdatanc_WMSGetCapabilities_testdatanc.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetMapGetCapabilities_testdatanc_WMSGetCapabilities_testdatanc.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
+<BoundingBox CRS="CRS:84" minx="-27.243262" miny="37.353267" maxx="32.676474" maxy="65.888228" />
 <BoundingBox CRS="EPSG:25831" minx="-1027208.918278" miny="4257313.340443" maxx="2043762.674535" maxy="7377735.559200" />
 <BoundingBox CRS="EPSG:25832" minx="-1466672.497489" miny="4259561.094168" maxx="1661151.953190" maxy="7434111.038690" />
 <BoundingBox CRS="EPSG:28992" minx="-1500000.013502" miny="-999999.971392" maxx="1500000.013695" maxy="1999999.970643" />
 <BoundingBox CRS="EPSG:3035" minx="2295838.493287" miny="1712442.289194" maxx="5435712.495466" maxy="4854629.220149" />
 <BoundingBox CRS="EPSG:3067" minx="-3107150.509005" miny="4216726.250381" maxx="783036.427152" maxy="8092286.994278" />
-<BoundingBox CRS="EPSG:32661" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
+<BoundingBox CRS="EPSG:32661" minx="-4115048.787613" miny="563088.214526" maxx="-526949.004322" maxy="4171081.663734" />
 <BoundingBox CRS="EPSG:3411" minx="933738.467048" miny="-5198602.302407" maxx="5505159.473396" maxy="-624860.474641" />
 <BoundingBox CRS="EPSG:3412" minx="-22730542.445111" miny="23540323.467699" maxx="28030213.239617" maxy="57270128.565974" />
 <BoundingBox CRS="EPSG:3575" minx="-2218769.469677" miny="-5518468.599995" maxx="1133233.008108" maxy="-2440685.041382" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>32.676474</eastBoundLongitude>
   <southBoundLatitude>37.353267</southBoundLatitude>
   <northBoundLatitude>65.888228</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-27.243262" miny="37.353267" maxx="32.676474" maxy="65.888228" />
 <BoundingBox CRS="EPSG:25831" minx="-1027208.918278" miny="4257313.340443" maxx="2043762.674535" maxy="7377735.559200" />
 <BoundingBox CRS="EPSG:25832" minx="-1466672.497489" miny="4259561.094168" maxx="1661151.953190" maxy="7434111.038690" />
 <BoundingBox CRS="EPSG:28992" minx="-1500000.013502" miny="-999999.971392" maxx="1500000.013695" maxy="1999999.970643" />
 <BoundingBox CRS="EPSG:3035" minx="2295838.493287" miny="1712442.289194" maxx="5435712.495466" maxy="4854629.220149" />
 <BoundingBox CRS="EPSG:3067" minx="-3107150.509005" miny="4216726.250381" maxx="783036.427152" maxy="8092286.994278" />
-<BoundingBox CRS="EPSG:32661" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
+<BoundingBox CRS="EPSG:32661" minx="-4115048.787613" miny="563088.214526" maxx="-526949.004322" maxy="4171081.663734" />
 <BoundingBox CRS="EPSG:3411" minx="933738.467048" miny="-5198602.302407" maxx="5505159.473396" maxy="-624860.474641" />
 <BoundingBox CRS="EPSG:3412" minx="-22730542.445111" miny="23540323.467699" maxx="28030213.239617" maxy="57270128.565974" />
 <BoundingBox CRS="EPSG:3575" minx="-2218769.469677" miny="-5518468.599995" maxx="1133233.008108" maxy="-2440685.041382" />

--- a/tests/expectedoutputs/TestWMS/test_WMSGetMap_IrregularGrid_1Dimensional_latlon_nextdimensionstep_getcapabilities.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetMap_IrregularGrid_1Dimensional_latlon_nextdimensionstep_getcapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_1Dlat1Dlon_grid%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="48.000000" miny="-12.000000" maxx="56.000000" maxy="12.000000" />
+<BoundingBox CRS="CRS:84" minx="-12.000000" miny="48.000000" maxx="12.000000" maxy="56.000000" />
 <BoundingBox CRS="EPSG:25831" minx="-617472.866520" miny="5316302.374392" maxx="1171063.799865" maxy="6308105.878760" />
 <BoundingBox CRS="EPSG:25832" minx="-1062120.485288" miny="5316319.574920" maxx="723775.915399" maxy="6406966.575199" />
 <BoundingBox CRS="EPSG:28992" minx="-1136402.742573" miny="679.856932" maxx="648666.695131" maxy="1024615.234950" />
 <BoundingBox CRS="EPSG:3035" minx="2706198.583345" miny="2765166.476941" maxx="4470309.442165" maxy="3863994.473492" />
 <BoundingBox CRS="EPSG:3067" minx="-2368217.657676" miny="5426200.148164" maxx="-431413.447765" maxy="6912956.275031" />
-<BoundingBox CRS="EPSG:32661" minx="986381.559353" miny="-2875182.623640" maxx="3013618.440647" maxy="-1800251.543330" />
+<BoundingBox CRS="EPSG:32661" minx="-2875182.623640" miny="986381.559353" maxx="-1800251.543330" maxy="3013618.440647" />
 <BoundingBox CRS="EPSG:3411" minx="2064656.256257" miny="-3989496.198511" maxx="3989496.198511" maxy="-2064656.256257" />
 <BoundingBox CRS="EPSG:3412" minx="-8338966.390604" miny="31264396.207114" maxx="8338966.390604" maxy="40107778.643636" />
 <BoundingBox CRS="EPSG:3575" minx="-1715538.939396" miny="-4579562.464643" maxx="159824.857893" maxy="-3465869.545704" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>12.000000</eastBoundLongitude>
   <southBoundLatitude>48.000000</southBoundLatitude>
   <northBoundLatitude>56.000000</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.000000" miny="-12.000000" maxx="56.000000" maxy="12.000000" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-12.000000" miny="48.000000" maxx="12.000000" maxy="56.000000" />
 <BoundingBox CRS="EPSG:25831" minx="-617472.866520" miny="5316302.374392" maxx="1171063.799865" maxy="6308105.878760" />
 <BoundingBox CRS="EPSG:25832" minx="-1062120.485288" miny="5316319.574920" maxx="723775.915399" maxy="6406966.575199" />
 <BoundingBox CRS="EPSG:28992" minx="-1136402.742573" miny="679.856932" maxx="648666.695131" maxy="1024615.234950" />
 <BoundingBox CRS="EPSG:3035" minx="2706198.583345" miny="2765166.476941" maxx="4470309.442165" maxy="3863994.473492" />
 <BoundingBox CRS="EPSG:3067" minx="-2368217.657676" miny="5426200.148164" maxx="-431413.447765" maxy="6912956.275031" />
-<BoundingBox CRS="EPSG:32661" minx="986381.559353" miny="-2875182.623640" maxx="3013618.440647" maxy="-1800251.543330" />
+<BoundingBox CRS="EPSG:32661" minx="-2875182.623640" miny="986381.559353" maxx="-1800251.543330" maxy="3013618.440647" />
 <BoundingBox CRS="EPSG:3411" minx="2064656.256257" miny="-3989496.198511" maxx="3989496.198511" maxy="-2064656.256257" />
 <BoundingBox CRS="EPSG:3412" minx="-8338966.390604" miny="31264396.207114" maxx="8338966.390604" maxy="40107778.643636" />
 <BoundingBox CRS="EPSG:3575" minx="-1715538.939396" miny="-4579562.464643" maxx="159824.857893" maxy="-3465869.545704" />

--- a/tests/expectedoutputs/TestWMS/test_WMSGetMap_IrregularGrid_2Dimensional_latlon_nextdimensionstep_getcapabilities.xml
+++ b/tests/expectedoutputs/TestWMS/test_WMSGetMap_IrregularGrid_2Dimensional_latlon_nextdimensionstep_getcapabilities.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=example_file_irregular_2Dlat2Dlon_grid%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="50.047555" miny="0.079045" maxx="68.959048" maxy="14.878220" />
+<BoundingBox CRS="CRS:84" minx="0.079045" miny="50.047555" maxx="14.878220" maxy="68.959048" />
 <BoundingBox CRS="EPSG:25831" minx="290886.069993" miny="5543918.839869" maxx="1349334.387847" maxy="7695802.996601" />
 <BoundingBox CRS="EPSG:25832" minx="-138248.465935" miny="5543918.938737" maxx="920729.364314" maxy="7675755.896326" />
 <BoundingBox CRS="EPSG:28992" minx="-225068.577456" miny="228522.731875" maxx="833690.264302" maxy="2376907.911564" />
 <BoundingBox CRS="EPSG:3035" minx="3612827.147824" miny="2992800.975219" maxx="4670144.064183" maxy="5121240.178485" />
 <BoundingBox CRS="EPSG:3067" minx="-1412515.509982" miny="5614682.838602" maxx="16995.316516" maxy="7885181.710888" />
-<BoundingBox CRS="EPSG:32661" minx="2003258.047754" miny="-2617330.437195" maxx="3185571.966041" maxy="-282422.611583" />
+<BoundingBox CRS="EPSG:32661" minx="-2617330.437195" miny="2003258.047754" maxx="-282422.611583" maxy="3185571.966041" />
 <BoundingBox CRS="EPSG:3411" minx="1631624.970816" miny="-3181320.682034" maxx="3896895.955779" maxy="-1156383.579597" />
 <BoundingBox CRS="EPSG:3412" minx="46558.751805" miny="32616694.389018" maxx="16942279.459156" maxy="65983428.136773" />
 <BoundingBox CRS="EPSG:3575" minx="-752259.884217" miny="-4366256.077022" maxx="371298.644213" maxy="-2301007.081986" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>14.878220</eastBoundLongitude>
   <southBoundLatitude>50.047555</southBoundLatitude>
   <northBoundLatitude>68.959048</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="50.047555" miny="0.079045" maxx="68.959048" maxy="14.878220" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.079045" miny="50.047555" maxx="14.878220" maxy="68.959048" />
 <BoundingBox CRS="EPSG:25831" minx="290886.069993" miny="5543918.839869" maxx="1349334.387847" maxy="7695802.996601" />
 <BoundingBox CRS="EPSG:25832" minx="-138248.465935" miny="5543918.938737" maxx="920729.364314" maxy="7675755.896326" />
 <BoundingBox CRS="EPSG:28992" minx="-225068.577456" miny="228522.731875" maxx="833690.264302" maxy="2376907.911564" />
 <BoundingBox CRS="EPSG:3035" minx="3612827.147824" miny="2992800.975219" maxx="4670144.064183" maxy="5121240.178485" />
 <BoundingBox CRS="EPSG:3067" minx="-1412515.509982" miny="5614682.838602" maxx="16995.316516" maxy="7885181.710888" />
-<BoundingBox CRS="EPSG:32661" minx="2003258.047754" miny="-2617330.437195" maxx="3185571.966041" maxy="-282422.611583" />
+<BoundingBox CRS="EPSG:32661" minx="-2617330.437195" miny="2003258.047754" maxx="-282422.611583" maxy="3185571.966041" />
 <BoundingBox CRS="EPSG:3411" minx="1631624.970816" miny="-3181320.682034" maxx="3896895.955779" maxy="-1156383.579597" />
 <BoundingBox CRS="EPSG:3412" minx="46558.751805" miny="32616694.389018" maxx="16942279.459156" maxy="65983428.136773" />
 <BoundingBox CRS="EPSG:3575" minx="-752259.884217" miny="-4366256.077022" maxx="371298.644213" maxy="-2301007.081986" />

--- a/tests/expectedoutputs/TestWMSDocumentCache/test_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1.xml
+++ b/tests/expectedoutputs/TestWMSDocumentCache/test_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testtimeseriescached&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+<BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>179.505554</eastBoundLongitude>
   <southBoundLatitude>-90.488892</southBoundLatitude>
   <northBoundLatitude>89.511108</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />

--- a/tests/expectedoutputs/TestWMSDocumentCache/test_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1_and_seq2.xml
+++ b/tests/expectedoutputs/TestWMSDocumentCache/test_WMSGetCapabilities_timeseries_tailpath_netcdf_5dims_seq1_and_seq2.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testtimeseriescached&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+<BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>179.505554</eastBoundLongitude>
   <southBoundLatitude>-90.488892</southBoundLatitude>
   <northBoundLatitude>89.511108</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />

--- a/tests/expectedoutputs/TestWMSDocumentCache/test_WMSGetCapabilities_timeseries_twofiles.xml
+++ b/tests/expectedoutputs/TestWMSDocumentCache/test_WMSGetCapabilities_timeseries_twofiles.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.testtimeseriescached&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+<BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>179.505554</eastBoundLongitude>
   <southBoundLatitude>-90.488892</southBoundLatitude>
   <northBoundLatitude>89.511108</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-90.488892" miny="-180.494446" maxx="89.511108" maxy="179.505554" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-180.494446" miny="-90.488892" maxx="179.505554" maxy="89.511108" />
 <BoundingBox CRS="EPSG:25831" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
 <BoundingBox CRS="EPSG:25832" minx="-14709787.414601" miny="-19720736.728277" maxx="17177711.901099" maxy="47405035.658741" />
 <BoundingBox CRS="EPSG:28992" minx="-352494887.244074" miny="-527708138.497395" maxx="319428390.883462" maxy="521690003.576207" />
 <BoundingBox CRS="EPSG:3035" minx="-8345923.543753" miny="-9395610.119493" maxx="17002297.072989" maxy="15723257.709322" />
 <BoundingBox CRS="EPSG:3067" minx="-15931605.907041" miny="-19720315.591565" maxx="17051580.684528" maxy="19828593.536145" />
-<BoundingBox CRS="EPSG:32661" minx="-407173329.856895" miny="-406795071.401436" maxx="411420024.012517" maxy="411546161.390658" />
+<BoundingBox CRS="EPSG:32661" minx="-406795071.401436" miny="-407173329.856895" maxx="411546161.390658" maxy="411420024.012517" />
 <BoundingBox CRS="EPSG:3411" minx="-399240949.703125" miny="-399607437.540235" maxx="399487065.269510" maxy="398879979.546019" />
 <BoundingBox CRS="EPSG:3412" minx="-2868126705.493384" miny="-2870740092.047709" maxx="2869855924.003487" maxy="2865475278.583282" />
 <BoundingBox CRS="EPSG:3575" minx="-12712149.336113" miny="-12731583.256617" maxx="12735505.704073" maxy="12723911.899582" />

--- a/tests/expectedoutputs/TestWMSTimeHeightProfiles/test_WMSGetCapabilities_TimeHeightProfiles.xml
+++ b/tests/expectedoutputs/TestWMSTimeHeightProfiles/test_WMSGetCapabilities_TimeHeightProfiles.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=test%2Fceilonet%2Fceilonet_chm15k_backsct_la1_t12s_v1%2E0_06310_A20231202_extracted_small%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="50.941341" miny="3.095820" maxx="51.941341" maxy="4.095820" />
+<BoundingBox CRS="CRS:84" minx="3.095820" miny="50.941341" maxx="4.095820" maxy="51.941341" />
 <BoundingBox CRS="EPSG:25831" minx="506586.685443" miny="5643306.234342" maxx="576989.198618" maxy="5755081.271384" />
 <BoundingBox CRS="EPSG:25832" minx="85335.519937" miny="5654761.926157" maxx="162984.338772" maxy="5770997.834634" />
 <BoundingBox CRS="EPSG:28992" minx="-6037.898649" miny="328758.635711" maxx="66205.391192" maxy="441693.548928" />
 <BoundingBox CRS="EPSG:3035" minx="3836551.614229" miny="3108956.081895" maxx="3915496.144901" maxy="3225941.386920" />
 <BoundingBox CRS="EPSG:3067" minx="-1168100.884114" miny="5897608.814895" maxx="-1063341.469832" maxy="6029339.633032" />
-<BoundingBox CRS="EPSG:32661" minx="2236636.957682" miny="-2499207.579300" maxx="2321824.106000" maxy="-2370491.121972" />
+<BoundingBox CRS="EPSG:32661" minx="-2499207.579300" miny="2236636.957682" maxx="-2370491.121972" maxy="2321824.106000" />
 <BoundingBox CRS="EPSG:3411" minx="3181985.726484" miny="-2936325.838930" maxx="3322855.942587" maxy="-2799483.358645" />
 <BoundingBox CRS="EPSG:3412" minx="1867723.902828" miny="34495333.339115" maxx="2540087.501323" maxy="35511264.460837" />
 <BoundingBox CRS="EPSG:3575" minx="-513615.657195" miny="-4250014.213132" maxx="-428706.448090" maxy="-4137435.259796" />
@@ -106,13 +106,13 @@ with P_raw = sum(P_raw_hr) * range_gate_hr / range_gate (beta_raw)</Title>
   <eastBoundLongitude>4.095820</eastBoundLongitude>
   <southBoundLatitude>50.941341</southBoundLatitude>
   <northBoundLatitude>51.941341</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="50.941341" miny="3.095820" maxx="51.941341" maxy="4.095820" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="3.095820" miny="50.941341" maxx="4.095820" maxy="51.941341" />
 <BoundingBox CRS="EPSG:25831" minx="506586.685443" miny="5643306.234342" maxx="576989.198618" maxy="5755081.271384" />
 <BoundingBox CRS="EPSG:25832" minx="85335.519937" miny="5654761.926157" maxx="162984.338772" maxy="5770997.834634" />
 <BoundingBox CRS="EPSG:28992" minx="-6037.898649" miny="328758.635711" maxx="66205.391192" maxy="441693.548928" />
 <BoundingBox CRS="EPSG:3035" minx="3836551.614229" miny="3108956.081895" maxx="3915496.144901" maxy="3225941.386920" />
 <BoundingBox CRS="EPSG:3067" minx="-1168100.884114" miny="5897608.814895" maxx="-1063341.469832" maxy="6029339.633032" />
-<BoundingBox CRS="EPSG:32661" minx="2236636.957682" miny="-2499207.579300" maxx="2321824.106000" maxy="-2370491.121972" />
+<BoundingBox CRS="EPSG:32661" minx="-2499207.579300" miny="2236636.957682" maxx="-2370491.121972" maxy="2321824.106000" />
 <BoundingBox CRS="EPSG:3411" minx="3181985.726484" miny="-2936325.838930" maxx="3322855.942587" maxy="-2799483.358645" />
 <BoundingBox CRS="EPSG:3412" minx="1867723.902828" miny="34495333.339115" maxx="2540087.501323" maxy="35511264.460837" />
 <BoundingBox CRS="EPSG:3575" minx="-513615.657195" miny="-4250014.213132" maxx="-428706.448090" maxy="-4137435.259796" />

--- a/tests/expectedoutputs/TestWMSTimeHeightProfiles/test_wmsgetcapabilities_timeheightprofiles_as_dataset.xml
+++ b/tests/expectedoutputs/TestWMSTimeHeightProfiles/test_wmsgetcapabilities_timeheightprofiles_as_dataset.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.timeheightprofiles&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -78,13 +78,13 @@
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
 <CRS>GFI:TIME_ELEVATION</CRS>
-<BoundingBox CRS="CRS:84" minx="50.941341" miny="3.095820" maxx="51.941341" maxy="4.095820" />
+<BoundingBox CRS="CRS:84" minx="3.095820" miny="50.941341" maxx="4.095820" maxy="51.941341" />
 <BoundingBox CRS="EPSG:25831" minx="506586.685443" miny="5643306.234342" maxx="576989.198618" maxy="5755081.271384" />
 <BoundingBox CRS="EPSG:25832" minx="85335.519937" miny="5654761.926157" maxx="162984.338772" maxy="5770997.834634" />
 <BoundingBox CRS="EPSG:28992" minx="-6037.898649" miny="328758.635711" maxx="66205.391192" maxy="441693.548928" />
 <BoundingBox CRS="EPSG:3035" minx="3836551.614229" miny="3108956.081895" maxx="3915496.144901" maxy="3225941.386920" />
 <BoundingBox CRS="EPSG:3067" minx="-1168100.884114" miny="5897608.814895" maxx="-1063341.469832" maxy="6029339.633032" />
-<BoundingBox CRS="EPSG:32661" minx="2236636.957682" miny="-2499207.579300" maxx="2321824.106000" maxy="-2370491.121972" />
+<BoundingBox CRS="EPSG:32661" minx="-2499207.579300" miny="2236636.957682" maxx="-2370491.121972" maxy="2321824.106000" />
 <BoundingBox CRS="EPSG:3411" minx="3181985.726484" miny="-2936325.838930" maxx="3322855.942587" maxy="-2799483.358645" />
 <BoundingBox CRS="EPSG:3412" minx="1867723.902828" miny="34495333.339115" maxx="2540087.501323" maxy="35511264.460837" />
 <BoundingBox CRS="EPSG:3575" minx="-513615.657195" miny="-4250014.213132" maxx="-428706.448090" maxy="-4137435.259796" />
@@ -106,13 +106,13 @@
   <eastBoundLongitude>4.095820</eastBoundLongitude>
   <southBoundLatitude>50.941341</southBoundLatitude>
   <northBoundLatitude>51.941341</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="50.941341" miny="3.095820" maxx="51.941341" maxy="4.095820" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="3.095820" miny="50.941341" maxx="4.095820" maxy="51.941341" />
 <BoundingBox CRS="EPSG:25831" minx="506586.685443" miny="5643306.234342" maxx="576989.198618" maxy="5755081.271384" />
 <BoundingBox CRS="EPSG:25832" minx="85335.519937" miny="5654761.926157" maxx="162984.338772" maxy="5770997.834634" />
 <BoundingBox CRS="EPSG:28992" minx="-6037.898649" miny="328758.635711" maxx="66205.391192" maxy="441693.548928" />
 <BoundingBox CRS="EPSG:3035" minx="3836551.614229" miny="3108956.081895" maxx="3915496.144901" maxy="3225941.386920" />
 <BoundingBox CRS="EPSG:3067" minx="-1168100.884114" miny="5897608.814895" maxx="-1063341.469832" maxy="6029339.633032" />
-<BoundingBox CRS="EPSG:32661" minx="2236636.957682" miny="-2499207.579300" maxx="2321824.106000" maxy="-2370491.121972" />
+<BoundingBox CRS="EPSG:32661" minx="-2499207.579300" miny="2236636.957682" maxx="-2370491.121972" maxy="2321824.106000" />
 <BoundingBox CRS="EPSG:3411" minx="3181985.726484" miny="-2936325.838930" maxx="3322855.942587" maxy="-2799483.358645" />
 <BoundingBox CRS="EPSG:3412" minx="1867723.902828" miny="34495333.339115" maxx="2540087.501323" maxy="35511264.460837" />
 <BoundingBox CRS="EPSG:3575" minx="-513615.657195" miny="-4250014.213132" maxx="-428706.448090" maxy="-4137435.259796" />

--- a/tests/expectedoutputs/TestWMSTimeSeries/test_WMSGetCapabilities_adaguc_arcus_harmonie_sorted_model_levels.xml
+++ b/tests/expectedoutputs/TestWMSTimeSeries/test_WMSGetCapabilities_adaguc_arcus_harmonie_sorted_model_levels.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="DATASET=adaguc.tests.arcus_harmonie_sorted_model_levels&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -78,13 +78,13 @@
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
 <CRS>PROJ4:%2Bproj%3Dlonglat%20%2Bellps%3DWGS84%20%2Bdatum%3DWGS84%20%2Bno_defs</CRS>
-<BoundingBox CRS="CRS:84" minx="48.991000" miny="-0.014500" maxx="56.011000" maxy="11.295500" />
+<BoundingBox CRS="CRS:84" minx="-0.014500" miny="48.991000" maxx="11.295500" maxy="56.011000" />
 <BoundingBox CRS="EPSG:25831" minx="279486.181295" miny="5426455.295658" maxx="1106564.235337" maxy="6238397.008695" />
 <BoundingBox CRS="EPSG:25832" minx="-159076.876180" miny="5426455.835211" maxx="667922.720949" maxy="6244030.589292" />
 <BoundingBox CRS="EPSG:28992" minx="-240356.718422" miny="110966.965686" maxx="587386.577109" maxy="907716.266185" />
 <BoundingBox CRS="EPSG:3035" minx="3590473.522941" miny="2875312.852130" maxx="4415832.798743" maxy="3699811.756282" />
 <BoundingBox CRS="EPSG:3067" minx="-1463498.983078" miny="5546449.239554" maxx="-474452.673273" maxy="6541622.309508" />
-<BoundingBox CRS="EPSG:32661" minx="1998797.905458" miny="-2749996.025036" maxx="2930377.601350" maxy="-1808590.961851" />
+<BoundingBox CRS="EPSG:32661" minx="-2749996.025036" miny="1998797.905458" maxx="-1808590.961851" maxy="2930377.601350" />
 <BoundingBox CRS="EPSG:3411" minx="2678953.931008" miny="-3278077.377054" maxx="3855679.674073" maxy="-2102870.594756" />
 <BoundingBox CRS="EPSG:3412" minx="-10153.773965" miny="32170157.134147" maxx="7858652.989460" maxy="40121957.372894" />
 <BoundingBox CRS="EPSG:3575" minx="-778454.897448" miny="-4476517.292347" maxx="101208.769638" maxy="-3679953.333308" />
@@ -106,13 +106,13 @@
   <eastBoundLongitude>11.295500</eastBoundLongitude>
   <southBoundLatitude>48.991000</southBoundLatitude>
   <northBoundLatitude>56.011000</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.991000" miny="-0.014500" maxx="56.011000" maxy="11.295500" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-0.014500" miny="48.991000" maxx="11.295500" maxy="56.011000" />
 <BoundingBox CRS="EPSG:25831" minx="279486.181295" miny="5426455.295658" maxx="1106564.235337" maxy="6238397.008695" />
 <BoundingBox CRS="EPSG:25832" minx="-159076.876180" miny="5426455.835211" maxx="667922.720949" maxy="6244030.589292" />
 <BoundingBox CRS="EPSG:28992" minx="-240356.718422" miny="110966.965686" maxx="587386.577109" maxy="907716.266185" />
 <BoundingBox CRS="EPSG:3035" minx="3590473.522941" miny="2875312.852130" maxx="4415832.798743" maxy="3699811.756282" />
 <BoundingBox CRS="EPSG:3067" minx="-1463498.983078" miny="5546449.239554" maxx="-474452.673273" maxy="6541622.309508" />
-<BoundingBox CRS="EPSG:32661" minx="1998797.905458" miny="-2749996.025036" maxx="2930377.601350" maxy="-1808590.961851" />
+<BoundingBox CRS="EPSG:32661" minx="-2749996.025036" miny="1998797.905458" maxx="-1808590.961851" maxy="2930377.601350" />
 <BoundingBox CRS="EPSG:3411" minx="2678953.931008" miny="-3278077.377054" maxx="3855679.674073" maxy="-2102870.594756" />
 <BoundingBox CRS="EPSG:3412" minx="-10153.773965" miny="32170157.134147" maxx="7858652.989460" maxy="40121957.372894" />
 <BoundingBox CRS="EPSG:3575" minx="-778454.897448" miny="-4476517.292347" maxx="101208.769638" maxy="-3679953.333308" />

--- a/tests/expectedoutputs/TestWMSTimeSeries/test_WMSGetFeatureInfo_timeseries_forecastreferencetime_json_WMSGetCapabilities_testdatanc.xml
+++ b/tests/expectedoutputs/TestWMSTimeSeries/test_WMSGetFeatureInfo_timeseries_forecastreferencetime_json_WMSGetCapabilities_testdatanc.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=testdata%2Enc&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
+<BoundingBox CRS="CRS:84" minx="-27.243262" miny="37.353267" maxx="32.676474" maxy="65.888228" />
 <BoundingBox CRS="EPSG:25831" minx="-1027208.918278" miny="4257313.340443" maxx="2043762.674535" maxy="7377735.559200" />
 <BoundingBox CRS="EPSG:25832" minx="-1466672.497489" miny="4259561.094168" maxx="1661151.953190" maxy="7434111.038690" />
 <BoundingBox CRS="EPSG:28992" minx="-1500000.013502" miny="-999999.971392" maxx="1500000.013695" maxy="1999999.970643" />
 <BoundingBox CRS="EPSG:3035" minx="2295838.493287" miny="1712442.289194" maxx="5435712.495466" maxy="4854629.220149" />
 <BoundingBox CRS="EPSG:3067" minx="-3107150.509005" miny="4216726.250381" maxx="783036.427152" maxy="8092286.994278" />
-<BoundingBox CRS="EPSG:32661" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
+<BoundingBox CRS="EPSG:32661" minx="-4115048.787613" miny="563088.214526" maxx="-526949.004322" maxy="4171081.663734" />
 <BoundingBox CRS="EPSG:3411" minx="933738.467048" miny="-5198602.302407" maxx="5505159.473396" maxy="-624860.474641" />
 <BoundingBox CRS="EPSG:3412" minx="-22730542.445111" miny="23540323.467699" maxx="28030213.239617" maxy="57270128.565974" />
 <BoundingBox CRS="EPSG:3575" minx="-2218769.469677" miny="-5518468.599995" maxx="1133233.008108" maxy="-2440685.041382" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>32.676474</eastBoundLongitude>
   <southBoundLatitude>37.353267</southBoundLatitude>
   <northBoundLatitude>65.888228</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="37.353267" miny="-27.243262" maxx="65.888228" maxy="32.676474" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="-27.243262" miny="37.353267" maxx="32.676474" maxy="65.888228" />
 <BoundingBox CRS="EPSG:25831" minx="-1027208.918278" miny="4257313.340443" maxx="2043762.674535" maxy="7377735.559200" />
 <BoundingBox CRS="EPSG:25832" minx="-1466672.497489" miny="4259561.094168" maxx="1661151.953190" maxy="7434111.038690" />
 <BoundingBox CRS="EPSG:28992" minx="-1500000.013502" miny="-999999.971392" maxx="1500000.013695" maxy="1999999.970643" />
 <BoundingBox CRS="EPSG:3035" minx="2295838.493287" miny="1712442.289194" maxx="5435712.495466" maxy="4854629.220149" />
 <BoundingBox CRS="EPSG:3067" minx="-3107150.509005" miny="4216726.250381" maxx="783036.427152" maxy="8092286.994278" />
-<BoundingBox CRS="EPSG:32661" minx="563088.214526" miny="-4115048.787613" maxx="4171081.663734" maxy="-526949.004322" />
+<BoundingBox CRS="EPSG:32661" minx="-4115048.787613" miny="563088.214526" maxx="-526949.004322" maxy="4171081.663734" />
 <BoundingBox CRS="EPSG:3411" minx="933738.467048" miny="-5198602.302407" maxx="5505159.473396" maxy="-624860.474641" />
 <BoundingBox CRS="EPSG:3412" minx="-22730542.445111" miny="23540323.467699" maxx="28030213.239617" maxy="57270128.565974" />
 <BoundingBox CRS="EPSG:3575" minx="-2218769.469677" miny="-5518468.599995" maxx="1133233.008108" maxy="-2440685.041382" />

--- a/tests/expectedoutputs/TestWMSVolScan/test_WMSGetCapabilities_KNMI_VolScan.xml
+++ b/tests/expectedoutputs/TestWMSVolScan/test_WMSGetCapabilities_KNMI_VolScan.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FKNMI_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+<BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -178,13 +178,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -252,13 +252,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -326,13 +326,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -400,13 +400,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -474,13 +474,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -548,13 +548,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -622,13 +622,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -696,13 +696,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />

--- a/tests/expectedoutputs/TestWMSVolScan/test_WMSGetCapabilities_ODIM_VolScan.xml
+++ b/tests/expectedoutputs/TestWMSVolScan/test_WMSGetCapabilities_ODIM_VolScan.xml
@@ -15,7 +15,7 @@
         <KeywordList>
             <Keyword>view</Keyword>
             <Keyword>infoMapAccessService</Keyword>
-            <Keyword>ADAGUCServer version 7.2.0, of Apr 16 2026 13:22:55 </Keyword>
+            <Keyword>ADAGUCServer version 7.3.2, of Jul  3 2026 16:53:34 </Keyword>
         </KeywordList>
         <OnlineResource xlink:type="simple" xlink:href="source=test%2Fvolscan%2FODIM_RAD_NL62_VOL_NA_202106181850%2Eh5&amp;SERVICE=WMS&amp;"/>
         <ContactInformation>
@@ -77,13 +77,13 @@
 <CRS>EPSG:54030</CRS>
 <CRS>EPSG:7399</CRS>
 <CRS>EPSG:900913</CRS>
-<BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+<BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -104,13 +104,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -178,13 +178,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -252,13 +252,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -326,13 +326,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -400,13 +400,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -474,13 +474,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -548,13 +548,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -622,13 +622,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />
@@ -696,13 +696,13 @@
   <eastBoundLongitude>9.789118</eastBoundLongitude>
   <southBoundLatitude>48.963025</southBoundLatitude>
   <northBoundLatitude>54.710773</northBoundLatitude>
-</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="48.963025" miny="0.487083" maxx="54.710773" maxy="9.789118" />
+</EX_GeographicBoundingBox><BoundingBox CRS="CRS:84" minx="0.487083" miny="48.963025" maxx="9.789118" maxy="54.710773" />
 <BoundingBox CRS="EPSG:25831" minx="316070.932906" miny="5423345.956241" maxx="996779.171807" maxy="6083785.024595" />
 <BoundingBox CRS="EPSG:25832" minx="-122795.668672" miny="5423346.137120" maxx="557760.527310" maxy="6095926.973082" />
 <BoundingBox CRS="EPSG:28992" minx="-203888.291639" miny="107848.075459" maxx="477430.777338" maxy="758299.429247" />
 <BoundingBox CRS="EPSG:3035" minx="3626428.370848" miny="2872224.029492" maxx="4307403.392030" maxy="3552004.230734" />
 <BoundingBox CRS="EPSG:3067" minx="-1428745.806714" miny="5567769.286090" maxx="-603098.878292" maxy="6390759.084356" />
-<BoundingBox CRS="EPSG:32661" minx="2034358.725388" miny="-2753348.933214" maxx="2808204.696271" maxy="-1982837.805774" />
+<BoundingBox CRS="EPSG:32661" minx="-2753348.933214" miny="2034358.725388" maxx="-1982837.805774" maxy="2808204.696271" />
 <BoundingBox CRS="EPSG:3411" minx="2812154.650457" miny="-3251680.466992" maxx="3789547.212349" maxy="-2273833.261284" />
 <BoundingBox CRS="EPSG:3412" minx="278676.636155" miny="32303987.692584" maxx="6555184.179091" maxy="38553447.992164" />
 <BoundingBox CRS="EPSG:3575" minx="-740315.616673" miny="-4479402.027538" maxx="-14262.564488" maxy="-3821796.029902" />


### PR DESCRIPTION
MR: Support inverted BBOX axis order for EPSG:32661 in WMS 1.3.0
Related: https://gitlab.com/opengeoweb/opengeoweb/-/work_items/7085

Summary
WMS 1.3.0 requires the BoundingBox axis order in GetCapabilities to follow each CRS's authority-defined axis order (e.g. EPSG:4326 is lat/lon, CRS:84 is lon/lat). This was previously hardcoded in CServerParams::checkBBOXXYOrder to a fixed list of three CRS strings (EPSG:4326, EPSG:4258, CRS:84). This can now be configured in the projection element via invertxyforwms130
