### PR TITLE
Reduce CT::string

### DIFF
--- a/CCDFDataModel/CCDFHDF5IO_ODIM.cpp
+++ b/CCDFDataModel/CCDFHDF5IO_ODIM.cpp
@@ -150,7 +150,7 @@ int CDFHDF5Reader::convertODIMHDF5toCF() {
     /* Start collecting projection attributes */
     double xScale;
     double yScale;
-    CT::string projectionString;
+    std::string projectionString;
 
     CDF::Attribute *xScaleAttr = whereVar->getAttributeNE("xscale");
     if (xScaleAttr != nullptr) {
@@ -177,7 +177,7 @@ int CDFHDF5Reader::convertODIMHDF5toCF() {
     cornerX[3] = getAttrValueDouble(whereVar, "UR_lon", -1);
     cornerY[3] = getAttrValueDouble(whereVar, "UR_lat", -1);
 
-    PJ *P = proj_create_crs_to_crs_with_cache(CT::string("+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"), projectionString, nullptr);
+    PJ *P = proj_create_crs_to_crs_with_cache("+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs", projectionString, nullptr);
 
     if (proj_trans_generic(P, PJ_FWD, cornerX, sizeof(double), 4, cornerY, sizeof(double), 4, nullptr, 0, 0, nullptr, 0, 0) != 4) {
       // TODO: No error handling in original code

--- a/CCDFDataModel/CProj4ToCF.cpp
+++ b/CCDFDataModel/CProj4ToCF.cpp
@@ -372,7 +372,7 @@ int CProj4ToCF::convertBackAndFort(const char *projString, CDF::Variable *projec
   CDF::_dump(projectionVariable, &dumpString, CCDFDATAMODEL_DUMP_STANDARD);
   CDBDebug("\n%s", dumpString.c_str());
 
-  CT::string projCTString = convertCFToProj(projectionVariable);
+  std::string projCTString = convertCFToProj(projectionVariable);
   if (projCTString.empty()) {
     CDBError("Could not convert");
     return 1;
@@ -467,16 +467,16 @@ int CProj4ToCF::convertProjToCF(CDF::Variable *projectionVariable, const char *p
     }
     if (projectionVariable->name.empty()) projectionVariable->name = "projection";
     projectionVariable->setAttributeText("proj4_params", proj4String);
-    CT::string kvpProjString = "";
+    std::string kvpProjString = "";
     for (size_t j = 0; j < projKVPList.size(); j++) {
 
       if (projKVPList[j].key.equals("proj") == false && projKVPList[j].key.equals("units") == false) {
         if (projKVPList[j].value.empty() == false) {
-          kvpProjString.printconcat(" +%s=%f", projKVPList[j].key.c_str(), projKVPList[j].value.toDouble());
+          CT::printfconcat(kvpProjString, " +%s=%f", projKVPList[j].key.c_str(), CT::toDouble(projKVPList[j].value.c_str()));
         }
       } else {
-        kvpProjString.printconcat(" +%s=%s", projKVPList[j].key.c_str(), projKVPList[j].value.c_str());
-        kvpProjString.trimSelf();
+        CT::printfconcat(kvpProjString, " +%s=%s", projKVPList[j].key.c_str(), projKVPList[j].value.c_str());
+        kvpProjString = CT::trim(kvpProjString);
       }
     }
     projectionVariable->setAttributeText("proj4_origin", kvpProjString.c_str());
@@ -490,24 +490,20 @@ int CProj4ToCF::convertProjToCF(CDF::Variable *projectionVariable, const char *p
   return 0;
 }
 
-CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
-  CT::string proj4String;
-  proj4String = ("Unsupported projection");
+std::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
+  std::string proj4String = "Unsupported projection";
   try {
-    CT::string grid_mapping_name;
-    grid_mapping_name = projectionVariable->getAttributeThrows("grid_mapping_name")->toString();
-    // CREPORT_INFO_NODOC(CT::string("Unable to obtain projection from proj4 string variable. Trying to use CF conventions to determine projection. grid_mapping_name variable: ") + grid_mapping_name,
-    //                    CReportMessage::Categories::GENERAL);
-    grid_mapping_name.toLowerCaseSelf();
+    std::string grid_mapping_name = projectionVariable->getAttributeThrows("grid_mapping_name")->toString();
+    grid_mapping_name = CT::toLowerCase(grid_mapping_name);
 
-    if (grid_mapping_name.equals("msgnavigation")) {
+    if (grid_mapping_name == "msgnavigation") {
       // Meteosat Second Generation projection
 
-      CT::string longitude_of_projection_origin = "0.000000f";
-      CT::string latitude_of_projection_origin = "0.000000f";
-      CT::string height_from_earth_center = "42163972.000000f";
-      CT::string semi_major_axis = "6378140.000000f";
-      CT::string semi_minor_axis = "6356750.000000f";
+      std::string longitude_of_projection_origin = "0.000000f";
+      std::string latitude_of_projection_origin = "0.000000f";
+      std::string height_from_earth_center = "42163972.000000f";
+      std::string semi_major_axis = "6378140.000000f";
+      std::string semi_minor_axis = "6356750.000000f";
 
       try {
         longitude_of_projection_origin = projectionVariable->getAttributeThrows("longitude_of_projection_origin")->toString();
@@ -530,16 +526,16 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
       } catch (int e) {
       };
 
-      proj4String.print("+proj=geos +lon_0=%f +lat_0=%f +h=%f +a=%f +b=%f", longitude_of_projection_origin.toDouble(), latitude_of_projection_origin.toDouble(), 35807.414063,
-                        semi_major_axis.toDouble(), semi_minor_axis.toDouble());
-    } else if (grid_mapping_name.equals("geostationary")) {
+      proj4String = CT::printf("+proj=geos +lon_0=%f +lat_0=%f +h=%f +a=%f +b=%f", CT::toDouble(longitude_of_projection_origin), CT::toDouble(latitude_of_projection_origin), 35807.414063,
+                               CT::toDouble(semi_major_axis), CT::toDouble(semi_minor_axis));
+    } else if (grid_mapping_name == "geostationary") {
       // Meteosat Second Generation projection
-      CT::string longitude_of_projection_origin = "0.000000f";
-      CT::string latitude_of_projection_origin = "0.000000f";
-      CT::string perspective_point_height = "35807414.063f"; //"35807.414063f" ;
-      CT::string semi_major_axis = "6378140.000000f";
-      CT::string semi_minor_axis = "6356750.000000f";
-      CT::string sweep_angle_axis = "x";
+      std::string longitude_of_projection_origin = "0.000000f";
+      std::string latitude_of_projection_origin = "0.000000f";
+      std::string perspective_point_height = "35807414.063f"; //"35807.414063f" ;
+      std::string semi_major_axis = "6378140.000000f";
+      std::string semi_minor_axis = "6356750.000000f";
+      std::string sweep_angle_axis = "x";
 
       try {
         longitude_of_projection_origin = projectionVariable->getAttributeThrows("longitude_of_projection_origin")->toString();
@@ -566,17 +562,17 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
       } catch (int e) {
       };
 
-      proj4String.print("+proj=geos +lon_0=%f +lat_0=%f +h=%f +a=%f +b=%f +sweep=%s", longitude_of_projection_origin.toDouble(), latitude_of_projection_origin.toDouble(),
-                        perspective_point_height.toDouble(), semi_major_axis.toDouble(), semi_minor_axis.toDouble(), sweep_angle_axis.c_str());
-    } else if (grid_mapping_name.equals("polar_stereographic")) {
+      proj4String = CT::printf("+proj=geos +lon_0=%f +lat_0=%f +h=%f +a=%f +b=%f +sweep=%s", CT::toDouble(longitude_of_projection_origin), CT::toDouble(latitude_of_projection_origin),
+                               CT::toDouble(perspective_point_height), CT::toDouble(semi_major_axis), CT::toDouble(semi_minor_axis), sweep_angle_axis.c_str());
+    } else if (grid_mapping_name == "polar_stereographic") {
       // Polar stereographic projection
-      CT::string straight_vertical_longitude_from_pole = "0.000000f";
-      CT::string latitude_of_projection_origin = "90.000000f";
-      CT::string standard_parallel = "90.000000f";
-      CT::string semi_major_axis = "6378140.000000f";
-      CT::string semi_minor_axis = "6356750.000000f";
-      CT::string false_easting = "0.000000f";
-      CT::string false_northing = "0.000000f";
+      std::string straight_vertical_longitude_from_pole = "0.000000f";
+      std::string latitude_of_projection_origin = "90.000000f";
+      std::string standard_parallel = "90.000000f";
+      std::string semi_major_axis = "6378140.000000f";
+      std::string semi_minor_axis = "6356750.000000f";
+      std::string false_easting = "0.000000f";
+      std::string false_northing = "0.000000f";
       try {
         straight_vertical_longitude_from_pole = projectionVariable->getAttributeThrows("straight_vertical_longitude_from_pole")->toString();
       } catch (int e) {
@@ -606,21 +602,22 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
       } catch (int e) {
       };
 
-      double dfsemi_major_axis = semi_major_axis.toDouble();
-      double dfsemi_minor_axis = semi_minor_axis.toDouble();
+      double dfsemi_major_axis = CT::toDouble(semi_major_axis);
+      double dfsemi_minor_axis = CT::toDouble(semi_minor_axis);
 
-      proj4String.print("+proj=stere +lat_0=%f +lon_0=%f +lat_ts=%f +a=%f +b=%f +x_0=%f +y_0=%f +ellps=WGS84 +datum=WGS84", latitude_of_projection_origin.toDouble(),
-                        straight_vertical_longitude_from_pole.toDouble(), standard_parallel.toDouble(), dfsemi_major_axis, dfsemi_minor_axis, false_easting.toDouble(), false_northing.toDouble());
-    } else if (grid_mapping_name.equals("lambert_conformal_conic")) {
+      proj4String = CT::printf("+proj=stere +lat_0=%f +lon_0=%f +lat_ts=%f +a=%f +b=%f +x_0=%f +y_0=%f +ellps=WGS84 +datum=WGS84", CT::toDouble(latitude_of_projection_origin),
+                               CT::toDouble(straight_vertical_longitude_from_pole), CT::toDouble(standard_parallel), dfsemi_major_axis, dfsemi_minor_axis, CT::toDouble(false_easting),
+                               CT::toDouble(false_northing));
+    } else if (grid_mapping_name == "lambert_conformal_conic") {
       // Lambert conformal conic projection
       //+proj=lcc +lat_0=46.8 +lat_1=45.89892 +lat_2=47.69601 +lon_0=2.337229 +k_0=1.00 +x_0=600000 +y_0=2200000
-      CT::string longitude_of_central_meridian = "0";
-      CT::string latitude_of_projection_origin = "90";
-      CT::string standard_parallel = "";
-      CT::string semi_major_axis = "6378140.000000f";
-      CT::string semi_minor_axis = "6356750.000000f";
-      CT::string false_easting = "0";
-      CT::string false_northing = "0";
+      std::string longitude_of_central_meridian = "0";
+      std::string latitude_of_projection_origin = "90";
+      std::string standard_parallel = "";
+      std::string semi_major_axis = "6378140.000000f";
+      std::string semi_minor_axis = "6356750.000000f";
+      std::string false_easting = "0";
+      std::string false_northing = "0";
 
       try {
         longitude_of_central_meridian = projectionVariable->getAttributeThrows("longitude_of_central_meridian")->toString();
@@ -651,32 +648,32 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
       } catch (int e) {
       };
 
-      double dfsemi_major_axis = semi_major_axis.toDouble();
-      double dfsemi_minor_axis = semi_minor_axis.toDouble();
+      double dfsemi_major_axis = CT::toDouble(semi_major_axis);
+      double dfsemi_minor_axis = CT::toDouble(semi_minor_axis);
 
-      proj4String.print("+proj=lcc +lat_0=%f", latitude_of_projection_origin.toDouble());
+      proj4String = CT::printf("+proj=lcc +lat_0=%f", CT::toDouble(latitude_of_projection_origin));
 
-      auto stpList = standard_parallel.split(" ");
+      auto stpList = CT::split(standard_parallel, " ");
       if (stpList.size() == 1) {
-        proj4String.printconcat(" +lat_1=%f", stpList[0].toDouble());
+        CT::printfconcat(proj4String, " +lat_1=%f", CT::toDouble(stpList[0]));
       }
       if (stpList.size() == 2) {
-        proj4String.printconcat(" +lat_1=%f +lat_2=%f", stpList[0].toDouble(), stpList[1].toDouble());
+        CT::printfconcat(proj4String, " +lat_1=%f +lat_2=%f", CT::toDouble(stpList[0]), CT::toDouble(stpList[1]));
       }
 
-      proj4String.printconcat(" +lon_0=%f +k_0=1.0 +x_0=%f +y_0=%f +a=%f +b=%f", longitude_of_central_meridian.toDouble(), false_easting.toDouble(), false_northing.toDouble(), dfsemi_major_axis,
-                              dfsemi_minor_axis);
-    } else if (grid_mapping_name.equals("lambert_azimuthal_equal_area")) {
+      CT::printfconcat(proj4String, " +lon_0=%f +k_0=1.0 +x_0=%f +y_0=%f +a=%f +b=%f", CT::toDouble(longitude_of_central_meridian), CT::toDouble(false_easting), CT::toDouble(false_northing),
+                       dfsemi_major_axis, dfsemi_minor_axis);
+    } else if (grid_mapping_name == "lambert_azimuthal_equal_area") {
       // Lambert conformal conic projection
       //+proj=lcc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0
-      CT::string longitude_of_projection_origin = "0";
-      CT::string latitude_of_projection_origin = "90";
-      CT::string semi_major_axis = "6378140.000000f";
-      CT::string semi_minor_axis = "-9999";
-      CT::string inverse_flattening = "-9999";
-      CT::string longitude_of_prime_meridian = "0";
-      CT::string false_easting = "0";
-      CT::string false_northing = "0";
+      std::string longitude_of_projection_origin = "0";
+      std::string latitude_of_projection_origin = "90";
+      std::string semi_major_axis = "6378140.000000f";
+      std::string semi_minor_axis = "-9999";
+      std::string inverse_flattening = "-9999";
+      std::string longitude_of_prime_meridian = "0";
+      std::string false_easting = "0";
+      std::string false_northing = "0";
 
       try {
         longitude_of_projection_origin = projectionVariable->getAttributeThrows("longitude_of_projection_origin")->toString();
@@ -711,31 +708,30 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
       } catch (int e) {
       };
 
-      double dfsemi_major_axis = semi_major_axis.toDouble();
-      double inv_flat = inverse_flattening.toDouble();
+      double dfsemi_major_axis = CT::toDouble(semi_major_axis);
+      double inv_flat = CT::toDouble(inverse_flattening);
       double dfsemi_minor_axis;
       if (inv_flat > 0) {
         dfsemi_minor_axis = dfsemi_major_axis * (1 - 1 / inv_flat);
       } else {
-        dfsemi_minor_axis = semi_minor_axis.toDouble();
+        dfsemi_minor_axis = CT::toDouble(semi_minor_axis);
         if (dfsemi_minor_axis <= 0) {
           dfsemi_minor_axis = dfsemi_major_axis;
         }
       }
 
-      proj4String.print("+proj=laea +lat_0=%f +lon_0=%f", latitude_of_projection_origin.toDouble(), longitude_of_projection_origin.toDouble());
-
-      proj4String.printconcat(" +k_0=1.0 +x_0=%f +y_0=%f +a=%f +b=%f +pm=%f", false_easting.toDouble(), false_northing.toDouble(), dfsemi_major_axis, dfsemi_minor_axis,
-                              longitude_of_prime_meridian.toDouble());
-    } else if (grid_mapping_name.equals("rotated_latitude_longitude")) {
+      proj4String = CT::printf("+proj=laea +lat_0=%f +lon_0=%f", CT::toDouble(latitude_of_projection_origin), CT::toDouble(longitude_of_projection_origin));
+      CT::printfconcat(proj4String, " +k_0=1.0 +x_0=%f +y_0=%f +a=%f +b=%f +pm=%f", CT::toDouble(false_easting), CT::toDouble(false_northing), dfsemi_major_axis, dfsemi_minor_axis,
+                       CT::toDouble(longitude_of_prime_meridian));
+    } else if (grid_mapping_name == "rotated_latitude_longitude") {
       //"+proj=ob_tran +o_proj=longlat +lon_0=15 +o_lat_p=47 +o_lon_p=0 +ellps=WGS84 +towgs84=0,0,0 +no_defs"
-      CT::string grid_north_pole_longitude = "-165"; //--> should become 15 in proj4 (-165+180)
-      CT::string grid_north_pole_latitude = "47";
-      CT::string north_pole_grid_longitude = "0";
-      CT::string semi_major_axis = "6378140.000000f";
-      CT::string semi_minor_axis = "6356750.000000f";
-      CT::string false_easting = "0";
-      CT::string false_northing = "0";
+      std::string grid_north_pole_longitude = "-165"; //--> should become 15 in proj4 (-165+180)
+      std::string grid_north_pole_latitude = "47";
+      std::string north_pole_grid_longitude = "0";
+      std::string semi_major_axis = "6378140.000000f";
+      std::string semi_minor_axis = "6356750.000000f";
+      std::string false_easting = "0";
+      std::string false_northing = "0";
       try {
         grid_north_pole_latitude = projectionVariable->getAttributeThrows("grid_north_pole_latitude")->toString();
       } catch (int e) {
@@ -764,14 +760,14 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
         false_northing = projectionVariable->getAttributeThrows("false_northing")->toString();
       } catch (int e) {
       };
-      proj4String.print("+proj=ob_tran +o_proj=longlat +lon_0=%f +o_lat_p=%f +o_lon_p=%f +a=%f +b=%f +x_0=%f +y_0=%f +no_defs", grid_north_pole_longitude.toDouble() + 180.0f,
-                        grid_north_pole_latitude.toDouble(), north_pole_grid_longitude.toDouble(), semi_major_axis.toDouble(), semi_minor_axis.toDouble(), false_easting.toDouble(),
-                        false_northing.toDouble());
-    } else if (grid_mapping_name.equals("oblique_stereographic")) {
+      proj4String = CT::printf("+proj=ob_tran +o_proj=longlat +lon_0=%f +o_lat_p=%f +o_lon_p=%f +a=%f +b=%f +x_0=%f +y_0=%f +no_defs", CT::toDouble(grid_north_pole_longitude) + 180.0f,
+                               CT::toDouble(grid_north_pole_latitude), CT::toDouble(north_pole_grid_longitude), CT::toDouble(semi_major_axis), CT::toDouble(semi_minor_axis),
+                               CT::toDouble(false_easting), CT::toDouble(false_northing));
+    } else if (grid_mapping_name == "oblique_stereographic") {
       // TODO atm we cannot detect +ellps=bessel with cf conventions
-      CT::string latitude_of_projection_origin = "0";
-      CT::string longitude_of_central_meridian = "0";
-      CT::string scale_factor_at_projection_origin = "1";
+      std::string latitude_of_projection_origin = "0";
+      std::string longitude_of_central_meridian = "0";
+      std::string scale_factor_at_projection_origin = "1";
 
       // Get latitude_of_projection_origin
       try {
@@ -798,10 +794,10 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
       };
 
       // Get common stuffs
-      CT::string semi_major_axis = "6377397.155"; // 299.1528128,f=a/(a-b) b=(-(a/f))+a   (-(6377397.155/299.1528128))+6377397.155 = 6356079
-      CT::string semi_minor_axis = "6356079";
-      CT::string false_easting = "0";
-      CT::string false_northing = "0";
+      std::string semi_major_axis = "6377397.155"; // 299.1528128,f=a/(a-b) b=(-(a/f))+a   (-(6377397.155/299.1528128))+6377397.155 = 6356079
+      std::string semi_minor_axis = "6356079";
+      std::string false_easting = "0";
+      std::string false_northing = "0";
       try {
         semi_major_axis = projectionVariable->getAttributeThrows("semi_major_axis")->toString();
       } catch (int e) {
@@ -819,11 +815,12 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
       } catch (int e) {
       };
 
-      proj4String.print("+proj=sterea +lat_0=%f +lon_0=%f +k=%f +a=%f +b=%f +x_0=%f +y_0=%f +no_defs", latitude_of_projection_origin.toDouble(), longitude_of_central_meridian.toDouble(),
-                        scale_factor_at_projection_origin.toDouble(), semi_major_axis.toDouble(), semi_minor_axis.toDouble(), false_easting.toDouble(), false_northing.toDouble());
-    } else if (grid_mapping_name.equals("latitude_longitude")) {
-      CT::string latitude_of_projection_origin = "0";
-      CT::string longitude_of_central_meridian = "0";
+      proj4String =
+          CT::printf("+proj=sterea +lat_0=%f +lon_0=%f +k=%f +a=%f +b=%f +x_0=%f +y_0=%f +no_defs", CT::toDouble(latitude_of_projection_origin), CT::toDouble(longitude_of_central_meridian),
+                     CT::toDouble(scale_factor_at_projection_origin), CT::toDouble(semi_major_axis), CT::toDouble(semi_minor_axis), CT::toDouble(false_easting), CT::toDouble(false_northing));
+    } else if (grid_mapping_name == "latitude_longitude") {
+      std::string latitude_of_projection_origin = "0";
+      std::string longitude_of_central_meridian = "0";
 
       // Get latitude_of_projection_origin
       try {
@@ -841,8 +838,8 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
       };
 
       // Get common stuffs
-      CT::string semi_major_axis = "6377397.155"; // 299.1528128,f=a/(a-b) b=(-(a/f))+a   (-(6377397.155/299.1528128))+6377397.155 = 6356079
-      CT::string semi_minor_axis = "6356079";
+      std::string semi_major_axis = "6377397.155"; // 299.1528128,f=a/(a-b) b=(-(a/f))+a   (-(6377397.155/299.1528128))+6377397.155 = 6356079
+      std::string semi_minor_axis = "6356079";
       try {
         semi_major_axis = projectionVariable->getAttributeThrows("semi_major_axis")->toString();
       } catch (int e) {
@@ -852,18 +849,18 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
       } catch (int e) {
       };
 
-      proj4String.print("+proj=longlat +ellps=WGS84 +datum=WGS84 +lat_0=%f +lon_0=%f +a=%f +b=%f +no_defs", latitude_of_projection_origin.toDouble(), longitude_of_central_meridian.toDouble(),
-                        semi_major_axis.toDouble(), semi_minor_axis.toDouble());
-    } else if (grid_mapping_name.equals("mercator")) {
+      proj4String = CT::printf("+proj=longlat +ellps=WGS84 +datum=WGS84 +lat_0=%f +lon_0=%f +a=%f +b=%f +no_defs", CT::toDouble(latitude_of_projection_origin),
+                               CT::toDouble(longitude_of_central_meridian), CT::toDouble(semi_major_axis), CT::toDouble(semi_minor_axis));
+    } else if (grid_mapping_name == "mercator") {
       // Lambert conformal conic projection
       //+proj=lcc +lat_0=46.8 +lat_1=45.89892 +lat_2=47.69601 +lon_0=2.337229 +k_0=1.00 +x_0=600000 +y_0=2200000
-      CT::string longitude_of_central_meridian = "0";
-      CT::string latitude_of_projection_origin = "90";
-      CT::string standard_parallel = "";
-      CT::string semi_major_axis = "6378140.000000f";
-      CT::string semi_minor_axis = "6356750.000000f";
-      CT::string false_easting = "0";
-      CT::string false_northing = "0";
+      std::string longitude_of_central_meridian = "0";
+      std::string latitude_of_projection_origin = "90";
+      std::string standard_parallel = "";
+      std::string semi_major_axis = "6378140.000000f";
+      std::string semi_minor_axis = "6356750.000000f";
+      std::string false_easting = "0";
+      std::string false_northing = "0";
 
       try {
         longitude_of_central_meridian = projectionVariable->getAttributeThrows("longitude_of_central_meridian")->toString();
@@ -894,29 +891,30 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
       } catch (int e) {
       };
 
-      proj4String.print("+proj=merc +lat_0=%f", latitude_of_projection_origin.toDouble());
+      proj4String = CT::printf("+proj=merc +lat_0=%f", CT::toDouble(latitude_of_projection_origin));
 
-      auto stpList = standard_parallel.split(" ");
+      auto stpList = CT::split(standard_parallel, " ");
       if (stpList.size() == 1) {
-        proj4String.printconcat(" +lat_1=%f", stpList[0].toDouble());
+        CT::printfconcat(proj4String, " +lat_1=%f", CT::toDouble(stpList[0]));
       }
       if (stpList.size() == 2) {
-        proj4String.printconcat(" +lat_1=%f +lat_2=%f", stpList[0].toDouble(), stpList[1].toDouble());
+        CT::printfconcat(proj4String, " +lat_1=%f +lat_2=%f", CT::toDouble(stpList[0]), CT::toDouble(stpList[1]));
       }
 
-      proj4String.printconcat(" +lon_0=%f +k_0=1.0 +x_0=%f +y_0=%f +a=%f ", longitude_of_central_meridian.toDouble(), false_easting.toDouble(), false_northing.toDouble(), semi_major_axis.toDouble());
-    } else if (grid_mapping_name.equals("transverse_mercator")) {
+      CT::printfconcat(proj4String, " +lon_0=%f +k_0=1.0 +x_0=%f +y_0=%f +a=%f ", CT::toDouble(longitude_of_central_meridian), CT::toDouble(false_easting), CT::toDouble(false_northing),
+                       CT::toDouble(semi_major_axis));
+    } else if (grid_mapping_name == "transverse_mercator") {
       // Transverse mercator projection
       //+proj=tmerc +lat_0=46.8 +lon_0=2.337229 +k_0=1.00 +x_0=600000 +y_0=2200000
-      CT::string longitude_of_central_meridian = "0";
-      CT::string latitude_of_projection_origin = "90";
-      CT::string standard_parallel = "";
-      CT::string semi_major_axis = "6378140.000000f";
-      CT::string semi_minor_axis = "6356750.000000f";
-      CT::string inverse_flattening = "297.183263207";
-      CT::string false_easting = "0";
-      CT::string false_northing = "0";
-      CT::string scale_factor_at_projection_origin = "1.0";
+      std::string longitude_of_central_meridian = "0";
+      std::string latitude_of_projection_origin = "90";
+      std::string standard_parallel = "";
+      std::string semi_major_axis = "6378140.000000f";
+      std::string semi_minor_axis = "6356750.000000f";
+      std::string inverse_flattening = "297.183263207";
+      std::string false_easting = "0";
+      std::string false_northing = "0";
+      std::string scale_factor_at_projection_origin = "1.0";
 
       bool found;
 
@@ -975,8 +973,8 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
         } catch (int e) {
         };
         if (found) {
-          float semi_minor_axis_value = semi_major_axis.toDouble() * (1 - 1 / inverse_flattening.toDouble());
-          semi_minor_axis.print("%f", semi_minor_axis_value);
+          float semi_minor_axis_value = CT::toDouble(semi_major_axis) * (1 - 1 / CT::toDouble(inverse_flattening));
+          semi_minor_axis = CT::printf("%f", semi_minor_axis_value);
         } else {
           CREPORT_ERROR_NODOC(CT::string("Projection: ") + grid_mapping_name + CT::string(" needs semi_minor_axis or inverse_flattening"), CReportMessage::Categories::GENERAL);
           return "";
@@ -991,19 +989,19 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
       } catch (int e) {
       };
 
-      proj4String.print("+proj=tmerc +lat_0=%f", latitude_of_projection_origin.toDouble());
-      proj4String.printconcat(" +lon_0=%f +k_0=%f +x_0=%f +y_0=%f +a=%f +b=%f", longitude_of_central_meridian.toDouble(), scale_factor_at_projection_origin.toDouble(), false_easting.toDouble(),
-                              false_northing.toDouble(), semi_major_axis.toDouble(), semi_minor_axis.toDouble());
-    } else if (grid_mapping_name.equals("azimuthal_equidistant")) {
+      proj4String = CT::printf("+proj=tmerc +lat_0=%f", CT::toDouble(latitude_of_projection_origin));
+      CT::printfconcat(proj4String, " +lon_0=%f +k_0=%f +x_0=%f +y_0=%f +a=%f +b=%f", CT::toDouble(longitude_of_central_meridian), CT::toDouble(scale_factor_at_projection_origin),
+                       CT::toDouble(false_easting), CT::toDouble(false_northing), CT::toDouble(semi_major_axis), CT::toDouble(semi_minor_axis));
+    } else if (grid_mapping_name == "azimuthal_equidistant") {
       // azimuthal_equidistant
       //"+proj=aeqd +lat_0=-41.2 +lon_0=174.7 +x_0=25000. +y_0=-100000. +a=6370997.0 +units=m +no_defs"
-      CT::string longitude_of_projection_origin = "0";
-      CT::string latitude_of_projection_origin = "0";
-      CT::string semi_major_axis = "6378140.000000f";
-      CT::string semi_minor_axis = "-9999";
-      CT::string inverse_flattening = "-9999";
-      CT::string false_easting = "0";
-      CT::string false_northing = "0";
+      std::string longitude_of_projection_origin = "0";
+      std::string latitude_of_projection_origin = "0";
+      std::string semi_major_axis = "6378140.000000f";
+      std::string semi_minor_axis = "-9999";
+      std::string inverse_flattening = "-9999";
+      std::string false_easting = "0";
+      std::string false_northing = "0";
 
       try {
         longitude_of_projection_origin = projectionVariable->getAttributeThrows("longitude_of_projection_origin")->toString();
@@ -1034,21 +1032,20 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
       } catch (int e) {
       };
 
-      double dfsemi_major_axis = semi_major_axis.toDouble();
-      double inv_flat = inverse_flattening.toDouble();
+      double dfsemi_major_axis = CT::toDouble(semi_major_axis);
+      double inv_flat = CT::toDouble(inverse_flattening);
       double dfsemi_minor_axis;
       if (inv_flat > 0) {
         dfsemi_minor_axis = dfsemi_major_axis * (1 - 1 / inv_flat);
       } else {
-        dfsemi_minor_axis = semi_minor_axis.toDouble();
+        dfsemi_minor_axis = CT::toDouble(semi_minor_axis);
         if (dfsemi_minor_axis <= 0) {
           dfsemi_minor_axis = dfsemi_major_axis;
         }
       }
 
-      proj4String.print("+proj=aeqd +lat_0=%f +lon_0=%f", latitude_of_projection_origin.toDouble(), longitude_of_projection_origin.toDouble());
-
-      proj4String.printconcat(" +k_0=1.0 +x_0=%f +y_0=%f +a=%f +b=%f ", false_easting.toDouble(), false_northing.toDouble(), dfsemi_major_axis, dfsemi_minor_axis);
+      proj4String = CT::printf("+proj=aeqd +lat_0=%f +lon_0=%f", CT::toDouble(latitude_of_projection_origin), CT::toDouble(longitude_of_projection_origin));
+      CT::printfconcat(proj4String, " +k_0=1.0 +x_0=%f +y_0=%f +a=%f +b=%f ", CT::toDouble(false_easting), CT::toDouble(false_northing), dfsemi_major_axis, dfsemi_minor_axis);
     } else {
       CREPORT_INFO_NODOC(CT::string("Unsupported projection: ") + grid_mapping_name, CReportMessage::Categories::GENERAL);
       return "";
@@ -1068,10 +1065,10 @@ CT::string CProj4ToCF::convertCFToProj(CDF::Variable *projectionVariable) {
 
 int CProj4ToCF::__checkProjString(const char *name, const char *string) {
   CDBDebug("Checking %s", name);
-  CT::string proj4_origin;
-  CT::string proj4_recons;
+  std::string proj4_origin;
+  std::string proj4_recons;
   CDF::Variable *projectionVariable = new CDF::Variable();
-  ;
+
   try {
     if (convertBackAndFort(string, projectionVariable) != 0) {
       CDBError("FAILED: %s: Proj string conversion for %s / [%s]", name, name, string);
@@ -1080,12 +1077,12 @@ int CProj4ToCF::__checkProjString(const char *name, const char *string) {
     }
     proj4_origin = projectionVariable->getAttributeThrows("proj4_origin")->toString();
     proj4_recons = projectionVariable->getAttributeThrows("proj4_params")->toString();
-    if (!proj4_origin.equals(string)) {
+    if (proj4_origin != string) {
       CDBError("FAILED: %s Proj string parsing failed: \nIN:  [%s]\nOUT: [%s]", name, string, proj4_origin.c_str());
       delete projectionVariable;
       return 2;
     }
-    if (!proj4_recons.equals(proj4_origin.c_str())) {
+    if (proj4_recons != proj4_origin) {
       CDBError("FAILED: %s Proj string reconstruction failed: \nIN:  [%s]\nPRS: [%s]\nREC: [%s]", name, string, proj4_origin.c_str(), proj4_recons.c_str());
       delete projectionVariable;
       return 3;

--- a/CCDFDataModel/CProj4ToCF.h
+++ b/CCDFDataModel/CProj4ToCF.h
@@ -84,7 +84,7 @@ public:
    * @param projectionVariable The variable with CF projection attributes to convert to the proj4 string
    * @return The proj4 string which will contain the new proj string after conversion is finished or empty if an error occured
    */
-  CT::string convertCFToProj(CDF::Variable *projectionVariable);
+  std::string convertCFToProj(CDF::Variable *projectionVariable);
 
   int __checkProjString(const char *name, const char *string);
   /**

--- a/CCDFDataModel/ProjCache.cpp
+++ b/CCDFDataModel/ProjCache.cpp
@@ -4,13 +4,13 @@
 // File scope
 static std::map<std::string, PJ *> projections;
 
-PJ *proj_create_crs_to_crs_with_cache(CT::string source_crs, CT::string target_crs, PJ_AREA *area) {
+PJ *proj_create_crs_to_crs_with_cache(std::string source_crs, std::string target_crs, PJ_AREA *area) {
   // NOTE: This will not work when called from multiple threads!!
 
-  source_crs.trimSelf();
-  target_crs.trimSelf();
+  source_crs = CT::trim(source_crs);
+  target_crs = CT::trim(target_crs);
 
-  std::string key = (source_crs + CT::string(":") + target_crs).c_str();
+  std::string key = source_crs + ":" + target_crs;
   PJ *projSourceToDest;
   if (projections.count(key)) {
     projSourceToDest = projections[key];
@@ -23,7 +23,7 @@ PJ *proj_create_crs_to_crs_with_cache(CT::string source_crs, CT::string target_c
 }
 
 void proj_clear_cache() {
-  for (auto const& p : projections) {
+  for (auto const &p: projections) {
     proj_destroy(p.second);
   }
 }

--- a/CCDFDataModel/ProjCache.h
+++ b/CCDFDataModel/ProjCache.h
@@ -3,7 +3,7 @@
 #include <proj.h>
 #include "CTString.h"
 
-PJ *proj_create_crs_to_crs_with_cache(CT::string source_crs, CT::string target_crs, PJ_AREA *area);
+PJ *proj_create_crs_to_crs_with_cache(std::string source_crs, std::string target_crs, PJ_AREA *area);
 void proj_clear_cache();
 
 #endif // ADAGUC_SERVER_PROJCACHE_H

--- a/adagucserverEC/CDataReader.cpp
+++ b/adagucserverEC/CDataReader.cpp
@@ -318,7 +318,7 @@ bool CDataReader::copyCRSFromCFProjectionVariable(CDataSource *dataSource, CDF::
 
   CProj4ToCF proj4ToCF;
   proj4ToCF.debug = true;
-  CT::string projString = proj4ToCF.convertCFToProj(projVar);
+  std::string projString = proj4ToCF.convertCFToProj(projVar);
 
   if (projString.empty()) {
     CREPORT_WARN_NODOC(CT::string("Unknown CF conventions projection."), CReportMessage::Categories::GENERAL);

--- a/adagucserverEC/CImageWarper.cpp
+++ b/adagucserverEC/CImageWarper.cpp
@@ -26,6 +26,7 @@
 #include "Types/ProjectionStore.h"
 #include "CImageWarper.h"
 #include "ProjCache.h"
+#include <algorithm>
 #include <iostream>
 #include <vector>
 #include <cmath>
@@ -228,7 +229,7 @@ int CImageWarper::reprojpoint_inv(double &dfx, double &dfy) {
   return 0;
 }
 
-int CImageWarper::decodeCRS(std::string *outputCRS, std::string *inputCRS, std::vector<CServerConfig::XMLE_Projection *> *prj) {
+int CImageWarper::decodeCRS(std::string *outputCRS, const std::string *inputCRS, std::vector<CServerConfig::XMLE_Projection *> *prj) {
   if (prj == NULL) {
     CDBError("decodeCRS: prj==NULL");
     return 1;
@@ -288,37 +289,23 @@ int CImageWarper::_initreprojSynchronized(const char *projString, GeoParameters 
     return 1;
   }
 
-  CT::string sourceCRS = _GeoDest.crs.c_str();
-
-  CT::string sourceProjectionUndec = projString;
-
+  std::string sourceProjectionUndec = projString;
   std::tie(sourceProjectionUndec, std::ignore) = fixProjection(sourceProjectionUndec);
-  CT::string sourceProjection = sourceProjectionUndec;
-  CT::string latLonProjection = LATLONPROJECTION;
-  {
-    std::string sourceProjectionStd = sourceProjection;
-    std::string sourceProjectionUndecStd = sourceProjectionUndec;
-    if (decodeCRS(&sourceProjectionStd, &sourceProjectionUndecStd, _prj) != 0) {
-      CDBError("decodeCRS failed");
-      return 1;
-    }
-    sourceProjection = sourceProjectionStd;
-    sourceProjectionUndec = sourceProjectionUndecStd;
+
+  std::string sourceProjection;
+  if (decodeCRS(&sourceProjection, &sourceProjectionUndec, _prj) != 0) {
+    CDBError("decodeCRS failed");
+    return 1;
   }
 
-  this->sourceIsLatLonProjection = latLonProjection.equals(sourceProjection);
+  this->sourceIsLatLonProjection = sourceProjection == LATLONPROJECTION;
 
   //    CDBDebug("sourceProjectionUndec %s, sourceProjection %s",sourceProjection.c_str(),sourceProjectionUndec.c_str());
 
   dMaxExtentDefined = 0;
-  {
-    std::string destinationCRSStd = destinationCRS;
-    std::string sourceCRSStd = sourceCRS;
-    if (decodeCRS(&destinationCRSStd, &sourceCRSStd, _prj) != 0) {
-      CDBError("decodeCRS failed");
-      return 1;
-    }
-    destinationCRS = destinationCRSStd;
+  if (decodeCRS(&destinationCRS, &_GeoDest.crs, _prj) != 0) {
+    CDBError("decodeCRS failed");
+    return 1;
   }
   if (destinationCRS.empty()) {
     CDBDebug("Assuming latlon for destination CRS");
@@ -331,13 +318,13 @@ int CImageWarper::_initreprojSynchronized(const char *projString, GeoParameters 
     return 1;
   }
 
-  projSourceToLatlon = proj_create_crs_to_crs_with_cache(sourceProjection, latLonProjection, nullptr);
+  projSourceToLatlon = proj_create_crs_to_crs_with_cache(sourceProjection, LATLONPROJECTION, nullptr);
   if (projSourceToLatlon == nullptr) {
     CDBError("Invalid projection: from %s to %s", destinationCRS.c_str(), LATLONPROJECTION);
     return 1;
   }
 
-  projLatlonToDest = proj_create_crs_to_crs_with_cache(CT::string(LATLONPROJECTION), destinationCRS, nullptr);
+  projLatlonToDest = proj_create_crs_to_crs_with_cache(LATLONPROJECTION, destinationCRS, nullptr);
   if (projLatlonToDest == nullptr) {
     CDBError("Invalid projection: from %s to %s", LATLONPROJECTION, destinationCRS.c_str());
     return 1;
@@ -346,7 +333,7 @@ int CImageWarper::_initreprojSynchronized(const char *projString, GeoParameters 
   initialized = true;
   // CDBDebug("sourceProjection = %s destinationCRS = %s",projString,destinationCRS.c_str());
 
-  if (sourceProjection.equals(destinationCRS.c_str())) {
+  if (sourceProjection == destinationCRS) {
     initialized = true;
     requireReprojection = false;
     return 0;
@@ -572,25 +559,21 @@ void CImageWarper::reprojBBOX(double *df4PixelExtent) {
   df4PixelExtent[3] = ymax;
 }
 
-CT::string CImageWarper::getProj4FromId(CDataSource *dataSource, CT::string projectionId) {
-  CT::string bboxProj4Params;
-  if (projectionId.equals("native")) {
-    bboxProj4Params = dataSource->nativeProj4;
-    return bboxProj4Params;
+std::string CImageWarper::getProj4FromId(CDataSource *dataSource, std::string projectionId) {
+  if (projectionId == "native") {
+    return dataSource->nativeProj4;
   }
   std::vector<CServerConfig::XMLE_Projection *> *prj = &dataSource->srvParams->cfg->Projection;
-  std::string trimmedProjectionId = projectionId.trim();
-  for (size_t j = 0; j < (*prj).size(); j++) { // TODO: use find_if
-    if ((*prj)[j]->attr.id == trimmedProjectionId) {
-      bboxProj4Params = (*prj)[j]->attr.proj4;
-      return bboxProj4Params;
-      break;
-    }
+  std::string trimmedProjectionId = CT::trim(projectionId);
+
+  const auto projection = std::find_if(prj->begin(), prj->end(), [&trimmedProjectionId](const auto *projection) { return projection->attr.id == trimmedProjectionId; });
+  if (projection != prj->end()) {
+    return (*projection)->attr.proj4;
   }
   return projectionId;
 }
 
-std::tuple<CT::string, double> CImageWarper::fixProjection(CT::string projectionString) {
+std::tuple<std::string, double> CImageWarper::fixProjection(std::string projectionString) {
   CProj4ToCF trans;
   CDF::Variable var;
   int status = trans.convertProjToCF(&var, projectionString.c_str());
@@ -606,7 +589,7 @@ std::tuple<CT::string, double> CImageWarper::fixProjection(CT::string projection
         majorAttribute->setData<float>(CDF_FLOAT, semi_major_axis * scaling);
         minorAttribute->setData<float>(CDF_FLOAT, semi_minor_axis * scaling);
 
-        CT::string newProjectionString = trans.convertCFToProj(&var);
+        std::string newProjectionString = trans.convertCFToProj(&var);
         if (!newProjectionString.empty()) return std::make_tuple(newProjectionString, scaling);
       }
     }

--- a/adagucserverEC/CImageWarper.cpp
+++ b/adagucserverEC/CImageWarper.cpp
@@ -559,7 +559,7 @@ void CImageWarper::reprojBBOX(double *df4PixelExtent) {
   df4PixelExtent[3] = ymax;
 }
 
-std::string CImageWarper::getProj4FromId(CDataSource *dataSource, std::string projectionId) {
+std::string CImageWarper::getProj4FromId(CDataSource *dataSource, const std::string &projectionId) {
   if (projectionId == "native") {
     return dataSource->nativeProj4;
   }
@@ -573,7 +573,7 @@ std::string CImageWarper::getProj4FromId(CDataSource *dataSource, std::string pr
   return projectionId;
 }
 
-std::tuple<std::string, double> CImageWarper::fixProjection(std::string projectionString) {
+std::tuple<std::string, double> CImageWarper::fixProjection(const std::string &projectionString) {
   CProj4ToCF trans;
   CDF::Variable var;
   int status = trans.convertProjToCF(&var, projectionString.c_str());

--- a/adagucserverEC/CImageWarper.h
+++ b/adagucserverEC/CImageWarper.h
@@ -115,13 +115,13 @@ public:
    * @param projectionId EPSG code, or projection string, or string "native"
    * @return std::string Will return proj4 parameters for given projection id
    */
-  static std::string getProj4FromId(CDataSource *dataSource, std::string projectionId);
+  static std::string getProj4FromId(CDataSource *dataSource, const std::string &projectionId);
 
   /**
    * Returns the corrected projection string and a factor with which the x and y axis of the data need to be scaled.
    * Needed for a conversion for KM to Meter for example
    */
-  static std::tuple<std::string, double> fixProjection(std::string projectionString);
+  static std::tuple<std::string, double> fixProjection(const std::string &projectionString);
 
   /**
    * Get rotation for given point

--- a/adagucserverEC/CImageWarper.h
+++ b/adagucserverEC/CImageWarper.h
@@ -46,9 +46,8 @@ private:
   int dMaxExtentDefined;
   bool sourceIsLatLonProjection = false;
 
-  CT::string sourceCRSString;
-  CT::string destinationCRS;
-  //     int _decodeCRS(CT::string *CRS);
+  std::string sourceCRSString;
+  std::string destinationCRS;
   std::vector<CServerConfig::XMLE_Projection *> *prj;
   bool initialized;
 
@@ -75,7 +74,7 @@ public:
     }
   }
   PJ *projSourceToDest, *projSourceToLatlon, *projLatlonToDest;
-  CT::string getDestProjString() { return destinationCRS; }
+  std::string getDestProjString() { return destinationCRS; }
   int initreproj(CDataSource *dataSource, GeoParameters &GeoDest, std::vector<CServerConfig::XMLE_Projection *> *prj);
   int initreproj(const char *projString, GeoParameters &GeoDest, std::vector<CServerConfig::XMLE_Projection *> *_prj);
   int init(const char *destString, const char *fromProjString, std::vector<CServerConfig::XMLE_Projection *> *_prj);
@@ -106,8 +105,7 @@ public:
   int reprojfromLatLon(double &dfx, double &dfy);
 
   int reprojToLatLon(double &dfx, double &dfy);
-  // int decodeCRS(CT::string *outputCRS, CT::string *inputCRS);
-  int decodeCRS(std::string *outputCRS, std::string *inputCRS, std::vector<CServerConfig::XMLE_Projection *> *prj);
+  int decodeCRS(std::string *outputCRS, const std::string *inputCRS, std::vector<CServerConfig::XMLE_Projection *> *prj);
   int findExtent(CDataSource *dataSource, double *dfBBOX);
   bool isProjectionRequired() { return requireReprojection; }
   /**
@@ -115,15 +113,15 @@ public:
    *
    * @param dataSource DataSource
    * @param projectionId EPSG code, or projection string, or string "native"
-   * @return CT::string Will return proj4 parameters for given projection id
+   * @return std::string Will return proj4 parameters for given projection id
    */
-  static CT::string getProj4FromId(CDataSource *dataSource, CT::string projectionId);
+  static std::string getProj4FromId(CDataSource *dataSource, std::string projectionId);
 
   /**
-   * Returns the corrected projection string and a factor with witch the x and y axis of the data need to be scaled.
+   * Returns the corrected projection string and a factor with which the x and y axis of the data need to be scaled.
    * Needed for a conversion for KM to Meter for example
    */
-  static std::tuple<CT::string, double> fixProjection(CT::string projectionString);
+  static std::tuple<std::string, double> fixProjection(std::string projectionString);
 
   /**
    * Get rotation for given point

--- a/adagucserverEC/CNetCDFDataWriter.cpp
+++ b/adagucserverEC/CNetCDFDataWriter.cpp
@@ -121,8 +121,8 @@ int CNetCDFDataWriter::init(CServerParams *srvParam, CDataSource *dataSource, in
       if (srvParam->Format.length() == 0) srvParam->Format = ("adagucnetcdf");
     }
 
-    CT::string srvParamBboxProj4Params = CImageWarper::getProj4FromId(dataSource, srvParam->responceCrs);
-    CT::string srvParamGridProj4Params = CImageWarper::getProj4FromId(dataSource, srvParam->geoParams.crs);
+    std::string srvParamBboxProj4Params = CImageWarper::getProj4FromId(dataSource, srvParam->responceCrs);
+    std::string srvParamGridProj4Params = CImageWarper::getProj4FromId(dataSource, srvParam->geoParams.crs);
     GeoParameters serverWCSGeoParams = this->srvParam->geoParams;
     if (!srvParamBboxProj4Params.empty()) {
       serverWCSGeoParams.crs = srvParamBboxProj4Params;
@@ -568,7 +568,7 @@ int CNetCDFDataWriter::addData(std::vector<CDataSource *> &dataSources) {
     CImageWarper warper;
     dataSource->srvParams = this->srvParam;
 
-    CT::string srvParamGridProj4Params = CImageWarper::getProj4FromId(dataSource, srvParam->geoParams.crs);
+    std::string srvParamGridProj4Params = CImageWarper::getProj4FromId(dataSource, srvParam->geoParams.crs);
     GeoParameters clonedSrvGeoParams;
     clonedSrvGeoParams = srvParam->geoParams;
     clonedSrvGeoParams.crs = srvParamGridProj4Params;
@@ -812,7 +812,7 @@ int CNetCDFDataWriter::addData(std::vector<CDataSource *> &dataSources) {
       CDBDebug("DataStep index = %d, timestep = %d", dataStepIndex, dataSource->getCurrentTimeStep());
 #endif
 
-      std::string dataSourceProjectionString = warper.getDestProjString().trim().c_str();
+      std::string dataSourceProjectionString = CT::trim(warper.getDestProjString());
       destCDFObject->getVariableThrows("crs")->setAttributeText("proj4_params", dataSourceProjectionString.c_str());
 
       /* Lookup possible projection EPSG codes based on this */

--- a/adagucserverEC/testadagucserver.cpp
+++ b/adagucserverEC/testadagucserver.cpp
@@ -247,10 +247,10 @@ TEST(CProj4ToCF, azimuthal_equidistant) {
   var.setAttribute("earth_radius", CDF_DOUBLE, &earth_radius, 1);
   var.setAttribute("false_easting", CDF_DOUBLE, &false_easting, 1);
   var.setAttribute("false_northing", CDF_DOUBLE, &false_northing, 1);
-  CT::string projString = proj4ToCF.convertCFToProj(&var);
+  std::string projString = proj4ToCF.convertCFToProj(&var);
   CDBDebug("projString [%s]", projString.c_str());
 
-  CT::string expected = "+proj=aeqd +lat_0=-41.200000 +lon_0=174.700000 +k_0=1.0 +x_0=0.000000 +y_0=0.000000 +a=6378140.000000 +b=6378140.000000 ";
+  std::string expected = "+proj=aeqd +lat_0=-41.200000 +lon_0=174.700000 +k_0=1.0 +x_0=0.000000 +y_0=0.000000 +a=6378140.000000 +b=6378140.000000 ";
   CHECK(projString == expected);
 }
 

--- a/hclasses/CTString.cpp
+++ b/hclasses/CTString.cpp
@@ -592,6 +592,10 @@ namespace CT {
     ltrim(result);
     return result;
   }
+
+  // TODO: When strings like "longlat are passed the function currently silently returns 0. Would be better to throw an exception"
+  double toDouble(const std::string &input) { return atof(trim(input).c_str()); }
+
   std::string randomString(const int length) {
     const char charset[] = "0123456789"
                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/hclasses/CTString.h
+++ b/hclasses/CTString.h
@@ -475,6 +475,11 @@ namespace CT {
   std::string trim(const std::string input);
 
   /**
+   * Converts a string to double after trimming whitespace.
+   */
+  double toDouble(const std::string &input);
+
+  /**
    * Function which returns a std::vector on the stack with a list of strings allocated on the stack
    * Data is automatically freed
    * @param stdstring The string to split


### PR DESCRIPTION
- Removed a couple of CT::strings from projection code.
- CTString has a toDouble(), I used the exact same implementation inside the CT namespace.