### PR TITLE
Do not mention port 443 icm protocol https

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ USER root
 LABEL maintainer="adaguc@knmi.nl"
 
 # Version should be same as in Definitions.h
-LABEL version="8.0.0"
+LABEL version="8.1.0"
 
 # Try to update image packages
 RUN apt-get -q -y update \

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+**Version 8.1.0**
+
+* When the x-forwarded-for header contains 443 with protocol https, the port is not use in the onlineresource url as this is by default
+
 
 **Version 8.0.0**
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 **Version 8.1.0**
 
-* When the x-forwarded-for header contains 443 with protocol https, the port is not use in the onlineresource url as this is by default
+* When the x-forwarded-for header contains 443 with protocol https, the port is not advertised in the onlineresource url anymore.
 
 
 **Version 8.0.0**

--- a/adagucserverEC/Definitions.h
+++ b/adagucserverEC/Definitions.h
@@ -28,7 +28,7 @@
 #ifndef Definitions_H
 #define Definitions_H
 
-#define ADAGUCSERVER_VERSION "8.0.0" // Please also update in the Dockerfile to the same version
+#define ADAGUCSERVER_VERSION "8.1.0" // Please also update in the Dockerfile to the same version
 
 // CConfigReaderLayerType
 #define CConfigReaderLayerTypeUnknown 0

--- a/python/python_fastapi_server/middleware/x_forwarded_headers.py
+++ b/python/python_fastapi_server/middleware/x_forwarded_headers.py
@@ -65,9 +65,18 @@ class ForwardedHostAndPrefixMiddleware(ProxyHeadersMiddleware):
             # Prevent malicious input
             forwarded_host = urllib.parse.quote(forwarded_host)
 
+            if b"x-forwarded-proto" in headers and len(headers[b"x-forwarded-proto"]) > 0:
+                proto = headers[b"x-forwarded-proto"].decode("ascii")
+            else:
+                proto = ""
+
             if b"x-forwarded-port" in headers and len(headers[b"x-forwarded-port"]) > 0:
                 port = ":" + headers[b"x-forwarded-port"].decode("ascii")
             else:
+                port = ""
+
+            # Port should not be set if it matches the default of the protocol
+            if (port == ":80" and proto == "http") or (port == ":443" and proto == "https"):
                 port = ""
 
             # Replace the Host header with the value of the X-Forwarded-Host header

--- a/python/python_fastapi_server/test_behind_proxy.py
+++ b/python/python_fastapi_server/test_behind_proxy.py
@@ -128,6 +128,31 @@ def test_x_forwarded_for_headers():
     assert get_url_from_capabilities(response) == "https://supertestadagucserver:1234/thepathafterhost/adaguc-server?SERVICE=WMS&"
 
 
+def test_x_forwarded_for_headers_https_port():
+    """
+    Test x-forward- headers
+    """
+    client = get_testclient(
+        environment={
+            "EXTERNALADDRESS": "",
+            "ADAGUC_TRUSTED_HOSTS": "supertestadagucserver",
+            "ADAGUC_TRUSTED_PROXIES": "adaguc-testclient",  # default
+        }
+    )
+    response = client.get(
+        "/adaguc-server?service=WMS&request=getCapabilities",
+        headers={
+            "Host": "my-host-to-be-ignored",
+            "x-forwarded-host": "supertestadagucserver",
+            "x-forwarded-prefix": "/thepathafterhost",
+            "x-forwarded-port": "443",
+            "x-forwarded-proto": "https",
+        },
+    )
+
+    assert get_url_from_capabilities(response) == "https://supertestadagucserver/thepathafterhost/adaguc-server?SERVICE=WMS&"
+
+
 def test_x_forwarded_for_headers_wildcard():
     """
     Test x-forward- headers


### PR DESCRIPTION
When using adaguc-server behind a proxy, the x-forwarded-port and x-forwarded-for headers are used to derive the onlineresource. 
When protocol is https, and the port is 443, the port number is not mention anymore.