### PR TITLE
Add missing forward slash

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 **Version 8.3.0**
 
 - Support showinlegend property in ShadeInterVal to filter out items for the GetLegendGraphic request: https://github.com/KNMI/adaguc-server/issues/754
+- Fix EDR hrefs by adding a missing slash. The Metoffice EDR tool can be used again: https://github.com/KNMI/adaguc-server/pull/757
 
 
 **Version 8.2.0**

--- a/python/python_fastapi_server/routers/utils/edr_utils.py
+++ b/python/python_fastapi_server/routers/utils/edr_utils.py
@@ -222,7 +222,7 @@ def get_collectioninfo_from_md(
     base_url = base_url_ + f"edr/collections/{collection_name}"
 
     if instance is not None:
-        base_url += f"instances/{instance}"
+        base_url += f"/instances/{instance}"
 
     links: list[Link] = []
     links.append(Link(href=f"{base_url}", rel="collection", type="application/json"))
@@ -232,7 +232,7 @@ def get_collectioninfo_from_md(
         ref_times = get_ref_times_for_coll(metadata)
         if ref_times and len(ref_times) > 0:
             has_instances = True
-            instances_link = Link(href=f"{base_url}instances", rel="collection", type="application/json")
+            instances_link = Link(href=f"{base_url}/instances", rel="collection", type="application/json")
             links.append(instances_link)
 
     primary_extent = get_extent_from_md(metadata, first_param)
@@ -268,7 +268,7 @@ def get_collectioninfo_from_md(
         ],
     )
     cube_link = EDRQueryLink(
-        href=f"{base_url}cube",
+        href=f"{base_url}/cube",
         rel="data",
         hreflang="en",
         title="Cube query",
@@ -282,7 +282,7 @@ def get_collectioninfo_from_md(
             output_formats=["GeoJSON"],
         )
         locations_link = EDRQueryLink(
-            href=f"{base_url}locations",
+            href=f"{base_url}/locations",
             rel="data",
             hreflang="en",
             title="Locations query",
@@ -298,7 +298,7 @@ def get_collectioninfo_from_md(
             output_formats=["CoverageJSON", "GeoJSON"],
         )
         instances_query_link = EDRQueryLink(
-            href=f"{base_url}instances",
+            href=f"{base_url}/instances",
             rel="collection",
             hreflang="en",
             title="Instances query",

--- a/python/python_fastapi_server/test_behind_proxy.py
+++ b/python/python_fastapi_server/test_behind_proxy.py
@@ -9,6 +9,15 @@ from xml.etree import ElementTree
 from fastapi.testclient import TestClient
 from fastapi import Response
 import main
+import pytest
+from unittest.mock import patch
+
+
+@pytest.fixture(autouse=True)
+def isolate_environment():
+    """This fixture restores the original env vars after each test"""
+    with patch.dict(os.environ):
+        yield
 
 
 def get_testclient(environment=None):

--- a/python/python_fastapi_server/test_ogc_api_edr.py
+++ b/python/python_fastapi_server/test_ogc_api_edr.py
@@ -145,6 +145,28 @@ def test_collections(client: TestClient):
     }
 
 
+def test_hrefs(client: TestClient):
+    """Test if all hrefs from a collection don't return 404"""
+    resp = client.get("/edr/collections")
+    collection = next((c for c in resp.json()["collections"] if c["id"] == "adaguc.tests.arcus_uwcw.hagl_member"))
+
+    urls = [links["href"] for links in collection["links"]]
+    urls += [query["link"]["href"] for query in collection["data_queries"].values()]
+    urls = sorted(set(urls))
+
+    assert urls == [
+        "http://testserver/edr/collections/adaguc.tests.arcus_uwcw.hagl_member",
+        "http://testserver/edr/collections/adaguc.tests.arcus_uwcw.hagl_member/cube",
+        "http://testserver/edr/collections/adaguc.tests.arcus_uwcw.hagl_member/instances",
+        "http://testserver/edr/collections/adaguc.tests.arcus_uwcw.hagl_member/locations",
+        "http://testserver/edr/collections/adaguc.tests.arcus_uwcw.hagl_member/position",
+    ]
+
+    for url in urls:
+        resp = client.get(url)
+        assert resp.status_code != 404
+
+
 def test_coll_multi_dim_position_single_coverage(client: TestClient):
     # Querying a single datetime and single Z results in a Coverage
     resp = client.get(

--- a/python/python_fastapi_server/test_ogc_api_edr.py
+++ b/python/python_fastapi_server/test_ogc_api_edr.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import pytest
 from adaguc.AdagucTestTools import AdagucTestTools
@@ -156,7 +157,7 @@ def test_hrefs(client: TestClient):
 
     # make unique, and remove base urls.
     urls = sorted(set(urls))
-    urls = [url.replace(str(client.base_url), "") for url in urls]
+    urls = [urlsplit(url).path for url in urls]
 
     assert urls == [
         "/edr/collections/adaguc.tests.arcus_uwcw.hagl_member",

--- a/python/python_fastapi_server/test_ogc_api_edr.py
+++ b/python/python_fastapi_server/test_ogc_api_edr.py
@@ -150,16 +150,20 @@ def test_hrefs(client: TestClient):
     resp = client.get("/edr/collections")
     collection = next((c for c in resp.json()["collections"] if c["id"] == "adaguc.tests.arcus_uwcw.hagl_member"))
 
+    # collect all urls
     urls = [links["href"] for links in collection["links"]]
     urls += [query["link"]["href"] for query in collection["data_queries"].values()]
+
+    # make unique, and remove base urls.
     urls = sorted(set(urls))
+    urls = [url.replace(str(client.base_url), "") for url in urls]
 
     assert urls == [
-        "http://testserver/edr/collections/adaguc.tests.arcus_uwcw.hagl_member",
-        "http://testserver/edr/collections/adaguc.tests.arcus_uwcw.hagl_member/cube",
-        "http://testserver/edr/collections/adaguc.tests.arcus_uwcw.hagl_member/instances",
-        "http://testserver/edr/collections/adaguc.tests.arcus_uwcw.hagl_member/locations",
-        "http://testserver/edr/collections/adaguc.tests.arcus_uwcw.hagl_member/position",
+        "/edr/collections/adaguc.tests.arcus_uwcw.hagl_member",
+        "/edr/collections/adaguc.tests.arcus_uwcw.hagl_member/cube",
+        "/edr/collections/adaguc.tests.arcus_uwcw.hagl_member/instances",
+        "/edr/collections/adaguc.tests.arcus_uwcw.hagl_member/locations",
+        "/edr/collections/adaguc.tests.arcus_uwcw.hagl_member/position",
     ]
 
     for url in urls:


### PR DESCRIPTION
The EDR responses were missing a couple of `/`'s in the href's:

For both `/edr/collections` and for specific instances:
- `collections[].links[1].href` was missing a slash.
- `collections[].data_queries` was missing a slash for `cube`, `locations` and `instances`. `position` included the slash already.

I'm able to use [Metoffice's query tool](https://labs.metoffice.gov.uk/edr/static/html/query.html) with this fix. Even cube works!
Closes https://github.com/KNMI/adaguc-server/issues/658.